### PR TITLE
Revert "MPU6000: Remove the chip reset.  Seems to cuase more problems than it solves.

### DIFF
--- a/flight/PiOS/Common/pios_mpu6000.c
+++ b/flight/PiOS/Common/pios_mpu6000.c
@@ -135,13 +135,17 @@ int32_t PIOS_MPU6000_Init(uint32_t spi_id, uint32_t slave_num, const struct pios
 *
 */
 static void PIOS_MPU6000_Config(struct pios_mpu6000_cfg const * cfg)
-{	
-	PIOS_DELAY_WaitmS(50);
+{
+
+	PIOS_MPU6000_Test();
+	
+	// Reset chip
+	while (PIOS_MPU6000_SetReg(PIOS_MPU6000_PWR_MGMT_REG, 0x80) != 0);
+	
+	PIOS_DELAY_WaitmS(100);
 	
 	// Reset chip and fifo
 	while (PIOS_MPU6000_SetReg(PIOS_MPU6000_USER_CTRL_REG, 0x80 | 0x01 | 0x02 | 0x04) != 0);
-
-	PIOS_DELAY_WaitmS(20);
 	
 	// Wait for reset to finish
 	while (PIOS_MPU6000_GetReg(PIOS_MPU6000_USER_CTRL_REG) & 0x07);


### PR DESCRIPTION
This reverts commit 27fe53b37532c8c8f0ae0ef9869293328d3fe0de.

This missing reset often leaves the mpu6000 (on CC3D) fifo in a broken state on warm restart.

Specifically, when we're reading out the accels, temp and gyros, the read from the
FIFO can be out-of-frame with respect to the specific fields.

On CC3D, a single data frame of values coming out of the mpu6000 are:
- acc_y, acc_x, acc_z, temp, g_y, g_x, g_z

When unaligned (by 2 16-bit words), we may actually be reading:
- acc_z, temp, g_y, g_x, g_z, acc_y, acc_x

This is very repeatable by simply hitting the Reset button in the GCS with the CC3D attached via USB.  Untested on an F4 board so far.
