### PR TITLE
ef: explicitly use bash for EF targets

### DIFF
--- a/flight/targets/EntireFlash/Makefile
+++ b/flight/targets/EntireFlash/Makefile
@@ -23,6 +23,8 @@
 # This needs SHELL pointing to bash https://wiki.ubuntu.com/DashAsBinSh
 ###############################################################################
 
+SHELL := /bin/bash
+
 WHEREAMI := $(dir $(lastword $(MAKEFILE_LIST)))
 TOP      := $(realpath $(WHEREAMI)/../../../)
 include $(TOP)/make/firmware-defs.mk


### PR DESCRIPTION
Since the makefile contents depend on bash, then make
the makefile actually use bash.
