### PR TITLE
entireflash: branch code path for windows to finally fix that one on all...

### DIFF
--- a/flight/targets/EntireFlash/Makefile
+++ b/flight/targets/EntireFlash/Makefile
@@ -20,10 +20,13 @@
 #####
 
 ###############################################################################
-# This needs SHELL pointing to bash https://wiki.ubuntu.com/DashAsBinSh
+# This makefile requires bash
 ###############################################################################
 
+# Set bash shell for all OSs except MS Windows
+ifndef COMSPEC
 SHELL := /bin/bash
+endif
 
 WHEREAMI := $(dir $(lastword $(MAKEFILE_LIST)))
 TOP      := $(realpath $(WHEREAMI)/../../../)


### PR DESCRIPTION
Note that COMSPEC has to be all uppercase to work.
Ive seen it as ComSpec in other makefiles so there could be another problem lurking.
