### PR TITLE
pios_i2c: fixed a race condition with wrong bus locking when using FreeRTOS

### DIFF
--- a/flight/PiOS/STM32F10x/pios_i2c.c
+++ b/flight/PiOS/STM32F10x/pios_i2c.c
@@ -949,7 +949,8 @@ int32_t PIOS_I2C_Transfer(uint32_t i2c_id, const struct pios_i2c_txn txn_list[],
 	/* Lock the bus */
 	portTickType timeout;
 	timeout = i2c_adapter->cfg->transfer_timeout_ms / portTICK_RATE_MS;
-	semaphore_success &= (xSemaphoreTake(i2c_adapter->sem_busy, timeout) == pdTRUE);
+	if (xSemaphoreTake(i2c_adapter->sem_busy, timeout) == pdFALSE)
+		return -2;
 #else
 	uint32_t timeout = 0xfff;
 	while(i2c_adapter->busy && --timeout);

--- a/flight/PiOS/STM32F4xx/pios_i2c.c
+++ b/flight/PiOS/STM32F4xx/pios_i2c.c
@@ -986,7 +986,8 @@ int32_t PIOS_I2C_Transfer(uint32_t i2c_id, const struct pios_i2c_txn txn_list[],
 	/* Lock the bus */
 	portTickType timeout;
 	timeout = i2c_adapter->cfg->transfer_timeout_ms / portTICK_RATE_MS;
-	semaphore_success &= (xSemaphoreTake(i2c_adapter->sem_busy, timeout) == pdTRUE);
+	if (xSemaphoreTake(i2c_adapter->sem_busy, timeout) == pdFALSE)
+		return -2;
 #else	
 	PIOS_IRQ_Disable();
 	if(i2c_adapter->busy) {
@@ -1062,7 +1063,8 @@ int32_t PIOS_I2C_Transfer_Callback(uint32_t i2c_id, const struct pios_i2c_txn tx
 	/* Lock the bus */
 	portTickType timeout;
 	timeout = i2c_adapter->cfg->transfer_timeout_ms / portTICK_RATE_MS;
-	semaphore_success &= (xSemaphoreTake(i2c_adapter->sem_busy, timeout) == pdTRUE);
+	if (xSemaphoreTake(i2c_adapter->sem_busy, timeout) == pdFALSE)
+		return -2;
 #else
 	if(i2c_adapter->busy) {
 		PIOS_IRQ_Enable();


### PR DESCRIPTION
When more than one task is concurrently trying to access
the same i2c bus and a timeout occurs on bus lock the
transfer would just continue and blow up the pios_i2c
driver. This has been fixed.
