### PR TITLE
pios_sbus: fixed gpio init when there is no gpio_clk_func defined in config

### DIFF
--- a/flight/PiOS/Common/pios_sbus.c
+++ b/flight/PiOS/Common/pios_sbus.c
@@ -144,9 +144,13 @@ int32_t PIOS_SBus_Init(uint32_t *sbus_id,
 	*sbus_id = (uint32_t)sbus_dev;
 
 	/* Enable inverter clock and enable the inverter */
-	(*cfg->gpio_clk_func)(cfg->gpio_clk_periph, ENABLE);
-	GPIO_Init(cfg->inv.gpio, &cfg->inv.init);
-	GPIO_WriteBit(cfg->inv.gpio, cfg->inv.init.GPIO_Pin, cfg->gpio_inv_enable);
+	if (cfg->gpio_clk_func != NULL)
+		(*cfg->gpio_clk_func)(cfg->gpio_clk_periph, ENABLE);
+	if (cfg->inv.gpio != NULL)
+	{
+		GPIO_Init(cfg->inv.gpio, &cfg->inv.init);
+		GPIO_WriteBit(cfg->inv.gpio, cfg->inv.init.GPIO_Pin, cfg->gpio_inv_enable);
+	}
 
 	/* Set comm driver callback */
 	(driver->bind_rx_cb)(lower_id, PIOS_SBus_RxInCallback, *sbus_id);


### PR DESCRIPTION
This has slipped in when the pios_sbus driver was moved from F1 only to Common. As the PiOS F4 enabled all GPIOs on startup, the gpio_clk_func is usually NULL. This is now being checked.
