### PR TITLE
makefile: ensure that the builds are not run as root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,21 @@ $(foreach var, $(SANITIZE_GCC_VARS), $(eval $(call SANITIZE_VAR,$(var),disallowe
 SANITIZE_DEPRECATED_VARS := USE_BOOTLOADER
 $(foreach var, $(SANITIZE_DEPRECATED_VARS), $(eval $(call SANITIZE_VAR,$(var),deprecated)))
 
+# Deal with unreasonable requests
+# See: http://xkcd.com/149/
+ifeq ($(MAKECMDGOALS),me a sandwich)
+ ifeq ($(shell whoami),root)
+ $(error Okay)
+ else
+ $(error What? Make it yourself)
+ endif
+endif
+
+# Make sure this isn't being run as root
+ifeq ($(shell whoami),root)
+$(error You should not be running this as root)
+endif
+
 # Decide on a verbosity level based on the V= parameter
 export AT := @
 


### PR DESCRIPTION
When running the build as root, any bugs in the Makefiles
can have disasterous results.  This will be even more
important once we start automatically running unit tests
as part of our build.

This change ensures that the builds cannot be run as root.
