### PR TITLE
Androidgcs fixes

### DIFF
--- a/flight/targets/UAVObjects/inc/uavobjecttemplate.h
+++ b/flight/targets/UAVObjects/inc/uavobjecttemplate.h
@@ -55,7 +55,11 @@ void $(NAME)SetDefaults(UAVObjHandle obj, uint16_t instId);
 // Object data
 typedef struct {
 $(DATAFIELDS)
+#if !defined(SIM_OSX) && !defined(SIM_POSIX)
 } __attribute__((packed)) __attribute__((aligned(4))) $(NAME)Data;
+#else
+} __attribute__((packed)) $(NAME)Data;
+#endif
 
 // Typesafe Object access functions
 /**


### PR DESCRIPTION
The forcing alignment of the UAVO objects broke simulation for reasons I can't tell.  This change should be "safe" but it would be really nice to know the underlying reason.

The symptoms of simulation without this: most things seemed to work but the FirwmareIAPObj and FlightTelemetryStats were not transmitted (and probably weren't being said).  So it seemed to influence the ability to set objects (since the local copy of FirmwareIAPObj seemed ok before going into the set command).
