### PR TITLE
UAVO generator: Calculate the size of the object and embed it

### DIFF
--- a/flight/targets/UAVObjects/inc/uavobjecttemplate.h
+++ b/flight/targets/UAVObjects/inc/uavobjecttemplate.h
@@ -45,7 +45,7 @@
 #define $(NAMEUC)_OBJID $(OBJIDHEX)
 #define $(NAMEUC)_ISSINGLEINST $(ISSINGLEINST)
 #define $(NAMEUC)_ISSETTINGS $(ISSETTINGS)
-#define $(NAMEUC)_NUMBYTES sizeof($(NAME)Data)
+#define $(NAMEUC)_NUMBYTES $(NUMBYTES)
 
 // Generic interface functions
 int32_t $(NAME)Initialize();

--- a/ground/gcs/src/libs/juavobjects/templates/uavobjecttemplate.java
+++ b/ground/gcs/src/libs/juavobjects/templates/uavobjecttemplate.java
@@ -52,13 +52,7 @@ public class $(NAME) extends UAVDataObject {
 		
 $(FIELDSINIT)
 
-		// Compute the number of bytes for this object
-		int numBytes = 0;
-		ListIterator<UAVObjectField> li = fields.listIterator();
-		while(li.hasNext()) {
-			numBytes += li.next().getNumBytes();
-		}
-		NUMBYTES = numBytes;
+		NUMBYTES = $(NUMBYTES);
 
 		// Initialize object
 		initializeFields(fields, ByteBuffer.allocate(NUMBYTES), NUMBYTES);

--- a/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.h
@@ -57,7 +57,7 @@ $(DATAFIELDINFO)
     static const QString CATEGORY;
     static const bool ISSINGLEINST = $(ISSINGLEINST);
     static const bool ISSETTINGS = $(ISSETTINGS);
-    static const quint32 NUMBYTES = sizeof(DataFields);
+    static const quint32 NUMBYTES = $(NUMBYTES);
 
     // Functions
     $(NAME)();

--- a/ground/uavobjgenerator/generators/generator_common.cpp
+++ b/ground/uavobjgenerator/generators/generator_common.cpp
@@ -71,7 +71,9 @@ void replaceCommonTags(QString& out, ObjectInfo* info)
     out.replace(QString("$(ISSINGLEINSTTF)"), boolToTRUEFALSEString( info->isSingleInst ));
     // Replace $(ISSETTINGS) tag
     out.replace(QString("$(ISSETTINGS)"), boolTo01String( info->isSettings ));
-    out.replace(QString("$(ISSETTINGSTF)"), boolToTRUEFALSEString( info->isSettings ));
+    out.replace(QString("$(ISSETTINGSTF)"), boolToTRUEFALSEString( info->isSettings ));    
+    // Replace $(NUMBTES) tag
+    out.replace(QString("$(NUMBYTES)"), QString().setNum(info->numBytes));
     // Replace $(GCSACCESS) tag
     value = accessModeStr[info->gcsAccess];
     out.replace(QString("$(GCSACCESS)"), value);

--- a/ground/uavobjgenerator/uavobjectparser.cpp
+++ b/ground/uavobjgenerator/uavobjectparser.cpp
@@ -94,20 +94,20 @@ quint32 UAVObjectParser::getObjectID(int objIndex)
  * Get the number of bytes in the data fields of this object
  */
 int UAVObjectParser::getNumBytes(int objIndex)
-{
+{    
     ObjectInfo* info = objInfo[objIndex];
-    if (info == NULL)
+    return info->numBytes;
+}
+
+/**
+ * Calculate the number of bytes in this object's fields
+ */
+void UAVObjectParser::calculateSize(ObjectInfo *info) {
+    Q_ASSERT(info != NULL);
+    info->numBytes = 0;
+    for (int n = 0; n < info->fields.length(); ++n)
     {
-        return 0;
-    }
-    else
-    {
-        int numBytes = 0;
-        for (int n = 0; n < info->fields.length(); ++n)
-        {
-            numBytes += info->fields[n]->numBytes * info->fields[n]->numElements;
-        }
-        return numBytes;
+        info->numBytes += info->fields[n]->numBytes * info->fields[n]->numElements;
     }
 }
 
@@ -234,6 +234,9 @@ QString UAVObjectParser::parseXML(QString& xml, QString& filename)
 
         // Calculate ID
         calculateID(info);
+
+        // Calculate size
+        calculateSize(info);
 
         // Add object
         objInfo.append(info);

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -97,6 +97,7 @@ typedef struct  {
     QList<FieldInfo*> fields; /** The data fields for the object **/
     QString description; /** Description used for Doxygen **/
     QString category; /** Description used for Doxygen **/
+    int numBytes;
 } ObjectInfo;
 
 class UAVObjectParser
@@ -131,6 +132,7 @@ private:
     QString processObjectCategory(QDomNode& childNode, QString * category);
     QString processObjectMetadata(QDomNode& childNode, UpdateMode* mode, int* period, bool* acked);
     void calculateID(ObjectInfo* info);
+    void calculateSize(ObjectInfo* info);
     quint32 updateHash(quint32 value, quint32 hash);
     quint32 updateHash(QString& value, quint32 hash);
 };


### PR DESCRIPTION
This is a fix for the bug found in https://github.com/PhoenixPilot/PhoenixPilot/pull/119 where aligning the structures pads them at the end and increases the sizeof value.  This changed the data representation in the UAVTalk packets which was bad.

Luckily the code was written to use the NUMBYTES field instead of sizeof, and so this was a fairly simple fix.

The downside is that sizeof still reports a different size than the on-the-wire size.

I tried adding the align attribute after the first field instead of the end of the structure but that doesn't fix the problem.
