### PR TITLE
android: pick up new SDK (r21.0.1)

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -295,7 +295,7 @@ dfuutil_clean:
 # see http://developer.android.com/sdk/ for latest versions
 ANDROID_SDK_DIR := $(TOOLS_DIR)/android-sdk-linux
 .PHONY: android_sdk_install
-android_sdk_install: ANDROID_SDK_URL  := http://dl.google.com/android/android-sdk_r20.0.3-linux.tgz
+android_sdk_install: ANDROID_SDK_URL  := http://dl.google.com/android/android-sdk_r21.0.1-linux.tgz
 android_sdk_install: ANDROID_SDK_FILE := $(notdir $(ANDROID_SDK_URL))
 # order-only prereq on directory existance:
 android_sdk_install: | $(DL_DIR) $(TOOLS_DIR)


### PR DESCRIPTION
Looks like SDK r21.0.1 is required for new installs or it fails to install API 16 when you run `make android_sdk_update`.

I was getting this error on a new install on Ubuntu 12.04:

```
Skipping 'SDK Platform Android 4.1.2, API 16, revision 4'; it depends on 'Android SDK Tools, revision 21.0.1' which was not installed.
Skipping 'Google APIs, Android API 16, revision 3'; it depends on 'SDK Platform Android 4.1.2, API 16, revision 4' which was not installed.
```

To test this, run (on linux):

```
make android_sdk_install
make android_sdk_update
make androidgcs
```
