### PR TITLE
cdc: added revolution usb ids to windows usb cdc driver

### DIFF
--- a/flight/Project/Windows USB/OpenPilot-CDC.inf
+++ b/flight/Project/Windows USB/OpenPilot-CDC.inf
@@ -11,10 +11,12 @@ DriverVer=10/15/2009,1.0.0.0
 [DeviceList.NTx86]
 %CopterControl%= DriverInstall,USB\VID_20A0&PID_415b&MI_00
 %PipXtreme%= DriverInstall,USB\VID_20A0&PID_415c&MI_00
+%Revolution%= DriverInstall,USB\VID_20A0&PID_415e&MI_00
 
 [DeviceList.NTamd64]
 %CopterControl%= DriverInstall,USB\VID_20A0&PID_415b&MI_00
 %PipXtreme%= DriverInstall,USB\VID_20A0&PID_415c&MI_00
+%Revolution%= DriverInstall,USB\VID_20A0&PID_415e&MI_00
 
 [DriverInstall]
 include=mdmcpq.inf
@@ -33,3 +35,4 @@ HKR,,EnumPropPages32,,"MsPorts.dll,SerialPortPropPageProvider"
 ProviderName = "CDC Driver"
 CopterControl = "OpenPilot CDC Driver"
 PipXtreme = "OpenPilot CDC Driver"
+Revolution = "OpenPilot CDC Driver"


### PR DESCRIPTION
This has to be properly replaced when the usb vendor id thing has been resolved.
