### PR TITLE
Speed up opening the preferences pane - op 781

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/dialogs/settingsdialog.cpp
+++ b/ground/gcs/src/plugins/coreplugin/dialogs/settingsdialog.cpp
@@ -37,8 +37,8 @@
 #include <QtCore/QDebug>
 #include <QtCore/QSettings>
 #include <QtGui/QHeaderView>
-#include <QtGui/QPushButton>
 #include <QtGui/QLabel>
+#include <QtGui/QPushButton>
 
 namespace {
     struct PageData {


### PR DESCRIPTION
This comes from http://git.openpilot.org/cru/OPReview-376. It works exactly as advertised, solving the slow responsiveness of the preference pane when it's opened it for the first time.
