### PR TITLE
GCS: Disable setup wizard

### DIFF
--- a/ground/gcs/src/plugins/plugins.pro
+++ b/ground/gcs/src/plugins/plugins.pro
@@ -258,12 +258,15 @@ plugin_uavobjectwidgetutils.depends += plugin_uavtalk
 SUBDIRS += plugin_uavobjectwidgetutils
 
 # Setup Wizard plugin
-plugin_setupwizard.subdir = setupwizard
-plugin_setupwizard.depends = plugin_coreplugin
-plugin_setupwizard.depends += plugin_uavobjectutil
-plugin_setupwizard.depends += plugin_config
-plugin_setupwizard.depends += plugin_uploader
-SUBDIRS += plugin_setupwizard
+### This is disabled until it supports the new calibration systems
+### and also provides at a minimum an informative message when the
+### connected board is not supported.
+#plugin_setupwizard.subdir = setupwizard
+#plugin_setupwizard.depends = plugin_coreplugin
+#plugin_setupwizard.depends += plugin_uavobjectutil
+#plugin_setupwizard.depends += plugin_config
+#plugin_setupwizard.depends += plugin_uploader
+#SUBDIRS += plugin_setupwizard
 
 ############################
 #  Board plugins

--- a/ground/gcs/src/plugins/welcome/qml/main.qml
+++ b/ground/gcs/src/plugins/welcome/qml/main.qml
@@ -108,6 +108,7 @@ Rectangle {
 
             WelcomePageButton {
                 id: wizard
+                visible: false
                 anchors.verticalCenter: parent.verticalCenter
                 baseIconName: "wizard"
                 onClicked: welcomePlugin.triggerAction("SetupWizardPlugin.ShowSetupWizard")


### PR DESCRIPTION
Currently the wizard is quite broken.  The way it deals with calibration
is outdated and it can't handle any of our reference platforms.  Disable
it until someone fixes it and at least adds informative messages when it
won't work for other boards.

This addresses https://github.com/PhoenixPilot/PhoenixPilot/issues/109
although hopefully eventually someone will fix it properly.
