### PR TITLE
ManualControl: Position hold should set path desired to HOLDPOSITION

### DIFF
--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -206,7 +206,8 @@ static void pathfollowerTask(void *parameters)
 		switch(flightStatus.FlightMode) {
 			case FLIGHTSTATUS_FLIGHTMODE_POSITIONHOLD:
 			case FLIGHTSTATUS_FLIGHTMODE_RETURNTOHOME:
-				if (pathDesired.Mode == PATHDESIRED_MODE_FLYENDPOINT) {
+				pathStatus.Status = PATHSTATUS_STATUS_INPROGRESS;
+				if (pathDesired.Mode == PATHDESIRED_MODE_HOLDPOSITION) {
 					updatePathVelocity();
 					result = updateFixedDesiredAttitude();
 					if (result) {

--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -676,7 +676,7 @@ static void updatePathDesired(ManualControlCommandData * cmd, bool flightModeCha
 		pathDesired.End[PATHDESIRED_END_DOWN] = positionActual.Down - 10;
 		pathDesired.StartingVelocity=10;
 		pathDesired.EndingVelocity=10;
-		pathDesired.Mode = PATHDESIRED_MODE_FLYENDPOINT;
+		pathDesired.Mode = PATHDESIRED_MODE_HOLDPOSITION;
 		PathDesiredSet(&pathDesired);
 	} else if(flightModeChanged) {
 		// Simple position hold - stay at present altitude and position
@@ -693,7 +693,7 @@ static void updatePathDesired(ManualControlCommandData * cmd, bool flightModeCha
 		pathDesired.End[PATHDESIRED_END_DOWN] = positionActual.Down;
 		pathDesired.StartingVelocity=10;
 		pathDesired.EndingVelocity=10;
-		pathDesired.Mode = PATHDESIRED_MODE_FLYENDPOINT;
+		pathDesired.Mode = PATHDESIRED_MODE_HOLDPOSITION;
 		PathDesiredSet(&pathDesired);
 	}
 }


### PR DESCRIPTION
Previously was using FLYENDPOINT mode.  Both should be acceptable but the
vtol code expects for FlightStatus = PositionHold the PathDesired.Mode should
also indicate the same.  I'm conflicted if this is good since it's essentially
redundant modes, but giving more rich information to the follower might
prove useful in the future (e.g. the way you hodl a position might be different
than flying to an endpoint, even if the current code doesn't treat it as such).
