### PR TITLE
Classed hardware settings into subtree. This reduces the number ofelements in the top tree of the UAVO Browser.

### DIFF
--- a/shared/uavobjectdefinition/hwcoptercontrol.xml
+++ b/shared/uavobjectdefinition/hwcoptercontrol.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwCopterControl" singleinstance="true" settings="true">
+	<object name="HwCopterControl" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>

--- a/shared/uavobjectdefinition/hwdiscoveryf4.xml
+++ b/shared/uavobjectdefinition/hwdiscoveryf4.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwDiscoveryF4" singleinstance="true" settings="true">
+	<object name="HwDiscoveryF4" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="MainPort" units="function" type="enum" elements="1" options="Disabled,DebugConsole" defaultvalue="DebugConsole"/>

--- a/shared/uavobjectdefinition/hwflyingf3.xml
+++ b/shared/uavobjectdefinition/hwflyingf3.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwFlyingF3" singleinstance="true" settings="true">
+	<object name="HwFlyingF3" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>
 		<field name="Uart1" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,S.Bus,DSM2,DSMX (10bit),DSMX (11bit),DebugConsole,ComBridge" defaultvalue="Disabled"/>

--- a/shared/uavobjectdefinition/hwflyingf4.xml
+++ b/shared/uavobjectdefinition/hwflyingf4.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwFlyingF4" singleinstance="true" settings="true">
+	<object name="HwFlyingF4" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>

--- a/shared/uavobjectdefinition/hwfreedom.xml
+++ b/shared/uavobjectdefinition/hwfreedom.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwFreedom" singleinstance="true" settings="true">
+	<object name="HwFreedom" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="Output" units="function" type="enum" elements="1" options="Disabled,PWM" defaultvalue="PWM"/>

--- a/shared/uavobjectdefinition/hwosd.xml
+++ b/shared/uavobjectdefinition/hwosd.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwOSD" singleinstance="true" settings="true">
+	<object name="HwOSD" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" options="USBTelemetry,RCTransmitter,Disabled" defaultvalue="USBTelemetry"/>

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwQuanton" singleinstance="true" settings="true">
+	<object name="HwQuanton" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>

--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwRevolution" singleinstance="true" settings="true">
+	<object name="HwRevolution" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+Outputs,Outputs" defaultvalue="PWM"/>

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -1,5 +1,5 @@
 <xml>
-	<object name="HwRevoMini" singleinstance="true" settings="true">
+	<object name="HwRevoMini" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>


### PR DESCRIPTION
This is (finally) using the subtree functionality that Fred wrote sometime last year. It places the HwXXX uavos into a subtree, which reduces clutter in the settings branch of the UAVO Browser.
