### PR TITLE
Corrected eraseDone() message. Added additional dialog box to better inform the user.

### DIFF
--- a/ground/gcs/src/plugins/config/configplugin.cpp
+++ b/ground/gcs/src/plugins/config/configplugin.cpp
@@ -134,9 +134,10 @@ void ConfigPlugin::eraseAllSettings()
 
     settingsErased = false;
 
-    //TODO: Replace the second and third [in eraseDone()] pop-up dialogs with a progress indicator tied to the original dialog box
+    //TODO: Replace the second and third [in eraseDone()] pop-up dialogs with a progress indicator,
+    // counter, or infinite chain of `......` tied to the original dialog box
     msgBox.setText(tr("Settings will now erase."));
-    msgBox.setInformativeText(tr("Press <OK> and then please wait until a completion box appears."));
+    msgBox.setInformativeText(tr("Press <OK> and then please wait until a completion box appears. This can take up to 90 seconds."));
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();
 


### PR DESCRIPTION
This fixes a dialog error that had always bothered me in the past. Ultimately, this series of three boxes should be replaced by a single dialog box with a progress indicator or a counter that appears when the user first confirms the choice to erase the settings.
