### PR TITLE
Open and Retrieve buttons no longer stay enabled while uploader is flashing firmware

### DIFF
--- a/ground/gcs/src/plugins/uploader/devicewidget.h
+++ b/ground/gcs/src/plugins/uploader/devicewidget.h
@@ -54,6 +54,7 @@ public:
     void setDfu(DFUObject* dfu);
     void populate();
     void freeze();
+    void unfreeze();
     typedef enum { STATUSICON_OK, STATUSICON_RUNNING, STATUSICON_FAIL, STATUSICON_INFO} StatusIcon;
     QString setOpenFileName();
     QString setSaveFileName();


### PR DESCRIPTION
Currently, the while flashing firmware, the uploader widget leaves Open and Retrieve buttons enabled, while it disables Flash. This patch changes the behavior such that all three buttons are disabled during a flash procedure.
