### PR TITLE
Two minor UI tweaks.

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
@@ -44,7 +44,7 @@ UAVObjectTreeModel::UAVObjectTreeModel(QObject *parent, bool categorize, bool us
     m_recentlyUpdatedTimeout(500), // ms
     m_recentlyUpdatedColor(QColor(255, 230, 230)),
     m_manuallyChangedColor(QColor(230, 230, 255)),
-    m_updatedOnlyColor(QColor(255,255,0)),
+    m_updatedOnlyColor(QColor(174,207,250,255)),
     m_useScientificFloatNotation(useScientificNotation)
 {
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();


### PR DESCRIPTION
1) Change the default color updatedOnly color to something that in my mind is how cornflower blue should look. No idea if that's the real name for the color, or even a real color.
2) Change the manualcontrol setting UAVO so that none appears first, which has the effect of starting the comboboxes at the top of the list, instead of the bottom.
#2 is actually a change that requires redoing the transmitter setup. We don't have many users right now before the officiali release, so it's hopefully not too much of a burden.
