### PR TITLE
quanton: fixed dma settings for SPI1 and SPI2

### DIFF
--- a/flight/targets/board_hw_defs/quanton/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/quanton/board_hw_defs.c
@@ -83,7 +83,6 @@ const struct pios_led_cfg * PIOS_BOARD_HW_DEFS_GetLedCfg (uint32_t board_revisio
  */
 void PIOS_SPI_flash_irq_handler(void);
 void DMA1_Stream3_IRQHandler(void) __attribute__((alias("PIOS_SPI_flash_irq_handler")));
-void DMA1_Stream4_IRQHandler(void) __attribute__((alias("PIOS_SPI_flash_irq_handler")));
 
 static const struct pios_spi_cfg pios_spi_flash_cfg = {
 	.regs = SPI2,
@@ -209,7 +208,6 @@ void PIOS_SPI_flash_irq_handler(void)
  */
 void PIOS_SPI_gyro_accel_irq_handler(void);
 void DMA2_Stream0_IRQHandler(void) __attribute__((alias("PIOS_SPI_gyro_accel_irq_handler")));
-void DMA2_Stream3_IRQHandler(void) __attribute__((alias("PIOS_SPI_gyro_accel_irq_handler")));
 
 static const struct pios_spi_cfg pios_spi_gyro_accel_cfg = {
 	.regs = SPI1,


### PR DESCRIPTION
DMA settings were broken, this lead to problems when saving 
bigger settings objects to spi flash. The new settings have been tested
on both SPIs.
