### PR TITLE
Fixed makefile so openocd_git will work on Mac.

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -217,9 +217,17 @@ openocd_win_clean:
 .PHONY: openocd_git_install
 
 openocd_git_install: | $(DL_DIR) $(TOOLS_DIR)
-openocd_git_install: OPENOCD_URL  := git://git.code.sf.net/p/openocd/code
-openocd_git_install: OPENOCD_REV  := cf1418e9a85013bbf8dbcc2d2e9985695993d9f4
+openocd_git_install: OPENOCD_URL     := git://git.code.sf.net/p/openocd/code
+openocd_git_install: OPENOCD_REV     := cf1418e9a85013bbf8dbcc2d2e9985695993d9f4
+openocd_git_install: OPENOCD_OPTIONS := --enable-maintainer-mode --prefix="$(OPENOCD_DIR)" --enable-ft2232_libftdi --enable-buspirate --enable-stlink
+
+ifeq ($(UNAME), Darwin)
+openocd_git_install: OPENOCD_OPTIONS := $(OPENOCD_OPTIONS) --disable-option-checking
+endif
+
 openocd_git_install: openocd_clean
+
+
         # download the source
 	$(V0) @echo " DOWNLOAD     $(OPENOCD_URL) @ $(OPENOCD_REV)"
 	$(V1) [ ! -d "$(OPENOCD_BUILD_DIR)" ] || $(RM) -rf "$(OPENOCD_BUILD_DIR)"
@@ -243,7 +251,7 @@ openocd_git_install: openocd_clean
 	$(V1) ( \
 	  cd $(OPENOCD_BUILD_DIR) ; \
 	  ./bootstrap ; \
-	  ./configure --enable-maintainer-mode --prefix="$(OPENOCD_DIR)" --enable-ft2232_libftdi --enable-buspirate --enable-stlink --disable-option-checking; \
+	  ./configure  $(OPENOCD_OPTIONS) ; \
 	  $(MAKE) ; \
 	  $(MAKE) install ; \
 	)


### PR DESCRIPTION
This was the solution to a very annoying problem for getting openocd to compile from the git repo. The fix comes from esden/summon-arm-toolchain#8.

Please check this on Linux to make sure it doesn't break anything.

(I borked something and somehow the prior pull request got closed, so to be on the safe side I'm opening another pull request here).
