### PR TITLE
valgrind: added memcheck startup and suppressions files for gcs

### DIFF
--- a/ground/gcs/projects/valgrind/memcheck.sh
+++ b/ground/gcs/projects/valgrind/memcheck.sh
@@ -1,0 +1,11 @@
+valgrind \
+	--tool=memcheck \
+	--leak-check=full \
+	--show-reachable=yes \
+	--track-fds=yes \
+	--track-origins=yes \
+	--num-callers=50 \
+	--db-attach=no \
+	--gen-suppressions=no \
+	--suppressions=./ground/gcs/projects/valgrind/memcheck.sup \
+	./build/ground/gcs/bin/taulabsgcs.bin

--- a/ground/gcs/projects/valgrind/memcheck.sup
+++ b/ground/gcs/projects/valgrind/memcheck.sup
@@ -1,0 +1,23 @@
+{
+   Libssl and libcrypto are known for this kind of behavior. Can be safely ignored.
+   Memcheck:Cond
+   fun:ASN1_STRING_set
+   fun:ASN1_mbstring_ncopy
+   fun:ASN1_mbstring_copy
+   fun:ASN1_STRING_to_UTF8
+   ...
+}
+{
+   Pixmap overrun Point. This might still be a bug.
+   Memcheck:Addr8
+   ...
+   fun:_ZN8QPainter10drawPixmapERK7QPointFRK7QPixmap
+   ...
+}
+{
+   Pixmap overrun Rect. This might still be a bug.
+   Memcheck:Addr8
+   ...
+   fun:_ZN8QPainter10drawPixmapERK6QRectFRK7QPixmapS2_
+   ...
+}


### PR DESCRIPTION
Current state is that gcs is memcheck "error" free.
This means things like accessing buffers out of bounds and using uninitialized memory have been fixed. There is still lots to check.
See #174
