### PR TITLE
UAVOBrowser performance fix

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
@@ -120,7 +120,7 @@ public:
     virtual void apply();
 
     inline bool highlighted() { return m_highlight; }
-    void setHighlight(bool highlight);
+    bool setHighlight(bool highlight);
     static void setHighlightTime(int time) { m_highlightTimeMs = time; }
 
     inline bool changed() { return m_changed; }


### PR DESCRIPTION
By removing a recursively called emit to the updatedHighlight() method, the performance requirements roughly halve. The downside is that it seems that at high data rates the values update a little more slowly, but this can probably be fixed without relying on a recursive call that consumes 20% processor.

https://vimeo.com/59216761

Quite honestly, it's not worth the performance hit just to be able to see numbers flash by four times as fast as they can be read, instead of twice as fast.

Edit: This patch makes it possible to handle 256 instances of the VibrationOutput UAVO. Before, that would crash my GCS.
