### PR TITLE
Flight-minimosd

### DIFF
--- a/flight/targets/CopterControl/System/pios_board.c
+++ b/flight/targets/CopterControl/System/pios_board.c
@@ -539,10 +539,31 @@ void PIOS_Board_Init(void) {
 					PIOS_Assert(0);
 				}
 			}
-	#endif	/* PIOS_INCLUDE_MAVLINK */
-			break;
+			#endif	/* PIOS_INCLUDE_MAVLINK */
+	break;
+	case HWCOPTERCONTROL_MAINPORT_MAVLINKTX_GPS_RX:
+#if defined(PIOS_INCLUDE_GPS)
+#if defined(PIOS_INCLUDE_MAVLINK)
+	{
+		uint32_t pios_usart_generic_id;
+		if (PIOS_USART_Init(&pios_usart_generic_id, &pios_usart_generic_main_cfg)) {
+			PIOS_Assert(0);
+		}
+		uint8_t * rx_buffer = (uint8_t *) pvPortMalloc(PIOS_COM_GPS_RX_BUF_LEN);
+		uint8_t * tx_buffer = (uint8_t *) pvPortMalloc(PIOS_COM_MAVLINK_TX_BUF_LEN);
+		PIOS_Assert(rx_buffer);
+		PIOS_Assert(tx_buffer);
+		if (PIOS_COM_Init(&pios_com_gps_id, &pios_usart_com_driver, pios_usart_generic_id,
+				rx_buffer, PIOS_COM_GPS_RX_BUF_LEN,
+				tx_buffer, PIOS_COM_MAVLINK_TX_BUF_LEN)) {
+			PIOS_Assert(0);
+		}
+		pios_com_mavlink_id = pios_com_gps_id;
 	}
-
+#endif	/* PIOS_INCLUDE_MAVLINK */
+#endif	/* PIOS_INCLUDE_GPS */
+	break;
+}
 	/* Configure the flexi port */
 	uint8_t hw_flexiport;
 	HwCopterControlFlexiPortGet(&hw_flexiport);

--- a/shared/uavobjectdefinition/hwcoptercontrol.xml
+++ b/shared/uavobjectdefinition/hwcoptercontrol.xml
@@ -3,7 +3,7 @@
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>
-		<field name="MainPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,S.Bus,DSM2,DSMX (10bit),DSMX (11bit),DebugConsole,ComBridge, MavLinkTX" defaultvalue="Telemetry"/>
+		<field name="MainPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,S.Bus,DSM2,DSMX (10bit),DSMX (11bit),DebugConsole,ComBridge, MavLinkTX, MavLinkTX_GPS_RX" defaultvalue="Telemetry"/>
 		<field name="FlexiPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,I2C,DSM2,DSMX (10bit),DSMX (11bit),DebugConsole,ComBridge, MavLinkTX" defaultvalue="Disabled"/>
 
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" options="USBTelemetry,RCTransmitter,Disabled" defaultvalue="USBTelemetry"/>


### PR DESCRIPTION
Allow Mavlink and GPS connected on mainport. GPS speed must be set to
mavlink default of 57600.
