### PR TITLE
Disables scope updates when scopes are not visible. 

### DIFF
--- a/ground/gcs/src/plugins/scope/scopegadgetwidget.cpp
+++ b/ground/gcs/src/plugins/scope/scopegadgetwidget.cpp
@@ -482,6 +482,10 @@ void ScopeGadgetWidget::uavObjectReceived(UAVObject* obj)
 
 void ScopeGadgetWidget::replotNewData()
 {
+    // If the plot is not visible, do not replot
+    if (!isVisible())
+        return;
+
 	QMutexLocker locker(&mutex);
 
 	foreach(PlotData* plotData, m_curvesData.values())
@@ -735,4 +739,10 @@ void ScopeGadgetWidget::csvLoggingDisconnect()
     m_csvLoggingConnected=0;
     if (m_csvLoggingNewFileOnConnect)csvLoggingStop();
     return;
+}
+
+void ScopeGadgetWidget::showEvent(QShowEvent *event)
+{
+    replotNewData();
+    QwtPlot::showEvent(event);
 }

--- a/ground/gcs/src/plugins/scope/scopegadgetwidget.h
+++ b/ground/gcs/src/plugins/scope/scopegadgetwidget.h
@@ -92,11 +92,12 @@ public:
     void setLoggingPath(QString value){m_csvLoggingPath=value;};
 
 protected:
-	void mousePressEvent(QMouseEvent *e);
-	void mouseReleaseEvent(QMouseEvent *e);
-	void mouseDoubleClickEvent(QMouseEvent *e);
-	void mouseMoveEvent(QMouseEvent *e);
-	void wheelEvent(QWheelEvent *e);
+    void mousePressEvent(QMouseEvent *e);
+    void mouseReleaseEvent(QMouseEvent *e);
+    void mouseDoubleClickEvent(QMouseEvent *e);
+    void mouseMoveEvent(QMouseEvent *e);
+    void wheelEvent(QWheelEvent *e);
+    void showEvent(QShowEvent *event);
 
 private slots:
     void uavObjectReceived(UAVObject*);


### PR DESCRIPTION
Reduces idle CPU load on Mac by approximately one-third. Unknown gains on other platforms.
