### PR TITLE
Added openocd_git_install_without_ftdi

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -100,6 +100,12 @@ OPENOCD_BUILD_DIR := $(DL_DIR)/openocd-build
 openocd_install: | $(DL_DIR) $(TOOLS_DIR)
 openocd_install: OPENOCD_URL  := http://sourceforge.net/projects/openocd/files/openocd/0.6.1/openocd-0.6.1.tar.bz2/download
 openocd_install: OPENOCD_FILE := openocd-0.6.1.tar.bz2
+openocd_install: OPENOCD_OPTIONS := --prefix="$(OPENOCD_DIR)" --enable-stlink
+
+ifeq ($(OPENOCD_FTDI), yes)
+openocd_install: OPENOCD_OPTIONS := $(OPENOCD_OPTIONS) --enable-ft2232_libftdi
+endif
+
 openocd_install: openocd_clean
         # download the source only if it's newer than what we already have
 	$(V1) wget -N -P "$(DL_DIR)" --trust-server-name "$(OPENOCD_URL)"
@@ -121,7 +127,7 @@ openocd_install: openocd_clean
 	$(V1) mkdir -p "$(OPENOCD_DIR)"
 	$(V1) ( \
 	  cd $(OPENOCD_BUILD_DIR)/openocd-0.6.1 ; \
-	  ./configure --prefix="$(OPENOCD_DIR)" --enable-ft2232_libftdi --enable-stlink ; \
+	  ./configure $(OPENOCD_OPTIONS) ; \
 	  $(MAKE) --silent ; \
 	  $(MAKE) --silent install ; \
 	)
@@ -182,7 +188,14 @@ libusb_win_clean:
 openocd_git_win_install: | $(DL_DIR) $(TOOLS_DIR)
 openocd_git_win_install: OPENOCD_URL  := git://git.code.sf.net/p/openocd/code
 openocd_git_win_install: OPENOCD_REV  := cf1418e9a85013bbf8dbcc2d2e9985695993d9f4
+openocd_git_win_install: OPENOCD_OPTIONS := 
+
+ifeq ($(OPENOCD_FTDI), yes)
+openocd_git_win_install: OPENOCD_OPTIONS := $(OPENOCD_OPTIONS) --enable-ft2232_ftd2xx --with-ftd2xx-win32-zipdir=$(FTD2XX_DIR)
+endif
+
 openocd_git_win_install: openocd_win_clean libusb_win_install ftd2xx_install
+
         # download the source
 	$(V0) @echo " DOWNLOAD     $(OPENOCD_URL) @ $(OPENOCD_REV)"
 	$(V1) [ ! -d "$(OPENOCD_BUILD_DIR)" ] || $(RM) -rf "$(OPENOCD_BUILD_DIR)"
@@ -211,7 +224,7 @@ openocd_git_win_install: openocd_win_clean libusb_win_install ftd2xx_install
 		--build=i686-pc-linux-gnu --host=i586-mingw32msvc \
 		CPPFLAGS=-I$(LIBUSB_WIN_DIR)/include \
 		LDFLAGS=-L$(LIBUSB_WIN_DIR)/lib/gcc \
-		--enable-ft2232_ftd2xx --with-ftd2xx-win32-zipdir=$(FTD2XX_DIR) \
+		$(OPENOCD_OPTIONS) \
 		--disable-werror \
 		--enable-stlink ; \
 	  $(MAKE) ; \


### PR DESCRIPTION
For those who do not wish to install libftdi. Tested on OSX.
