### PR TITLE
Added flags to makefile to strip out unused sections.

### DIFF
--- a/flight/targets/Freedom/Makefile
+++ b/flight/targets/Freedom/Makefile
@@ -363,6 +363,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
+CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(CODE_SOURCERY), YES)
 CFLAGS += -fpromote-loop-indices
 endif

--- a/flight/targets/PipXtreme/Makefile
+++ b/flight/targets/PipXtreme/Makefile
@@ -406,6 +406,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
+CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(CODE_SOURCERY), YES)
 CFLAGS += -fpromote-loop-indices
 endif

--- a/flight/targets/RevoMini/Makefile
+++ b/flight/targets/RevoMini/Makefile
@@ -359,6 +359,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
+CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(CODE_SOURCERY), YES)
 CFLAGS += -fpromote-loop-indices
 endif

--- a/flight/targets/Revolution/Makefile
+++ b/flight/targets/Revolution/Makefile
@@ -373,6 +373,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
+CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(CODE_SOURCERY), YES)
 CFLAGS += -fpromote-loop-indices
 endif


### PR DESCRIPTION
-ffunction-sections -fdata-sections was not being used in several makefiles. This has a major impact (~80kb) in reducing flash usage when using the ARM DFT library.
