### PR TITLE
obj persistence: delete objects directly by object ID

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -297,7 +297,7 @@ static void objectUpdatedCb(UAVObjEvent * ev)
 		} else if (objper.Operation == OBJECTPERSISTENCE_OPERATION_DELETE) {
 			if (objper.Selection == OBJECTPERSISTENCE_SELECTION_SINGLEOBJECT) {
 				// Delete selected instance
-				retval = UAVObjDelete(objper.ObjectID, objper.InstanceID);
+				retval = UAVObjDeleteById(objper.ObjectID, objper.InstanceID);
 			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLSETTINGS
 				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
 				retval = UAVObjDeleteSettings();

--- a/flight/targets/UAVObjects/inc/uavobjectmanager.h
+++ b/flight/targets/UAVObjects/inc/uavobjectmanager.h
@@ -156,7 +156,7 @@ int32_t UAVObjUnpack(UAVObjHandle obj_handle, uint16_t instId, const uint8_t* da
 int32_t UAVObjPack(UAVObjHandle obj_handle, uint16_t instId, uint8_t* dataOut);
 int32_t UAVObjSave(UAVObjHandle obj_handle, uint16_t instId);
 int32_t UAVObjLoad(UAVObjHandle obj_handle, uint16_t instId);
-int32_t UAVObjDelete(uint32_t obj_id, uint16_t inst_id);
+int32_t UAVObjDeleteById(uint32_t obj_id, uint16_t inst_id);
 #if defined(PIOS_INCLUDE_SDCARD)
 int32_t UAVObjSaveToFile(UAVObjHandle obj_handle, uint16_t instId, FILEINFO* file);
 UAVObjHandle UAVObjLoadFromFile(FILEINFO* file);

--- a/flight/targets/UAVObjects/uavobjectmanager.c
+++ b/flight/targets/UAVObjects/uavobjectmanager.c
@@ -985,7 +985,7 @@ int32_t UAVObjLoad(UAVObjHandle obj_handle, uint16_t instId)
  * @param[in] inst_id The object instance
  * @return 0 if success or -1 if failure
  */
-int32_t UAVObjDelete(uint32_t obj_id, uint16_t inst_id)
+int32_t UAVObjDeleteById(uint32_t obj_id, uint16_t inst_id)
 {
 #if defined(PIOS_INCLUDE_FLASH_SECTOR_SETTINGS)
 	PIOS_FLASHFS_ObjDelete(0, obj_id, inst_id);
@@ -1094,7 +1094,7 @@ int32_t UAVObjDeleteSettings()
 		// Check if this is a settings object
 		if (UAVObjIsSettings(obj)) {
 			// Save object
-			if (UAVObjDelete(UAVObjGetID(obj), 0)
+			if (UAVObjDeleteById(UAVObjGetID(obj), 0)
 				== -1) {
 				goto unlock_exit;
 			}
@@ -1182,7 +1182,7 @@ int32_t UAVObjDeleteMetaobjects()
 	// Load all settings objects
 	LL_FOREACH(uavo_list, obj) {
 		// Load object
-		if (UAVObjDelete(UAVObjGetID(MetaObjectPtr(obj)), 0)
+		if (UAVObjDeleteById(UAVObjGetID(MetaObjectPtr(obj)), 0)
 			== -1) {
 			goto unlock_exit;
 		}


### PR DESCRIPTION
Previously, you could only delete objects from flash
if they had been initialized.  This prevented deleting
settings UAVOs for optional modules that were currently
disabled.

Now, you can delete the object from flash directly by
object ID + object instance.  This allows a user to
delete specific settings objects when in BootFault mode
even when the problem module is disabled.
