### PR TITLE
Fix bug introduced by which the hardware configuration tab was no longer correctly updated on autopilot connect.

### DIFF
--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -3,7 +3,7 @@
  *
  * @file       configgadgetwidget.cpp
  * @author     E. Lafargue & The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     PhoenixPilot, http://github.com/PhoenixPilot, Copyright (C) 2012
+ * @author     Tau Labs, http://www.taulabs.org, Copyright (C) 2013
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup ConfigPlugin Config Plugin
@@ -217,7 +217,7 @@ void ConfigGadgetWidget::onAutopilotConnect() {
             QIcon *icon = new QIcon();
             icon->addFile(":/configgadget/images/hardware_normal.png", QSize(), QIcon::Normal, QIcon::Off);
             icon->addFile(":/configgadget/images/hardware_selected.png", QSize(), QIcon::Normal, QIcon::On);
-            QWidget *qwd = new DefaultHwSettingsWidget(this);
+            QWidget *qwd = new DefaultHwSettingsWidget(this, true);
             ftw->insertTab(ConfigGadgetWidget::hardware, qwd, *icon, QString("Hardware"));
             ftw->setCurrentIndex(ConfigGadgetWidget::hardware);
         } else {


### PR DESCRIPTION
https://github.com/TauLabs/TauLabs/issues/355

This slipped in during the merge from c94cd50. The hardware configuration tab was no longer correctly updated on autopilot connect.
