### PR TITLE
By removing the setText updates, OPMap CPU costs drop 8%.

### DIFF
--- a/ground/gcs/src/plugins/opmap/opmapgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/opmap/opmapgadgetwidget.cpp
@@ -272,10 +272,10 @@ OPMapGadgetWidget::OPMapGadgetWidget(QWidget *parent) : QWidget(parent)
     connect(m_updateTimer, SIGNAL(timeout()), this, SLOT(updatePosition()));
     m_updateTimer->start();
 
-    m_statusUpdateTimer = new QTimer();
-	m_statusUpdateTimer->setInterval(200);
-	connect(m_statusUpdateTimer, SIGNAL(timeout()), this, SLOT(updateMousePos()));
-    m_statusUpdateTimer->start();
+//    m_statusUpdateTimer = new QTimer();
+//    m_statusUpdateTimer->setInterval(200);
+//    connect(m_statusUpdateTimer, SIGNAL(timeout()), this, SLOT(updateMousePos()));
+//    m_statusUpdateTimer->start();
     // **************
 
     m_map->setFocus();
@@ -607,15 +607,15 @@ void OPMapGadgetWidget::updatePosition()
     m_map->UAV->SetYawRate(psiRate_dps); //Not correct, but I'm being lazy right now.
 
     // *************
-	// display the UAV position
+    // display the UAV position
 
-    QString str =
-            "lat: " + QString::number(uav_pos.Lat(), 'f', 7) +
-            " lon: " + QString::number(uav_pos.Lng(), 'f', 7) +
-			" " + QString::number(uav_yaw, 'f', 1) + "deg" +
-			" " + QString::number(uav_altitude, 'f', 1) + "m";
-//            " " + QString::number(uav_ground_speed_meters_per_second, 'f', 1) + "m/s";
-    m_widget->labelUAVPos->setText(str);
+//    QString str =
+//            "lat: " + QString::number(uav_pos.Lat(), 'f', 7) +
+//            " lon: " + QString::number(uav_pos.Lng(), 'f', 7) +
+//            " " + QString::number(uav_yaw, 'f', 1) + "deg" +
+//            " " + QString::number(uav_altitude, 'f', 1) + "m";
+////            " " + QString::number(uav_ground_speed_meters_per_second, 'f', 1) + "m/s";
+//    m_widget->labelUAVPos->setText(str);
 
 	// *************
 	// set the UAV icon position on the map


### PR DESCRIPTION
### RFC: seeking feedback.

This is highly odd. I have tracked down a serious performance hit to the setText(). On OSX 10.8 I am able to consistently and repeatedly reduce processor load by 8% when removing the `m_widget->labelUAVPos->setText(str)` line.

This makes no sense to me, but is easy to demonstrate. The `connect(m_statusUpdateTimer, SIGNAL(timeout()), this, SLOT(updateMousePos()))` line is commented out because it also produces the same processor spike. To see this processor spike, in a normal GCS from next, simply go to the map widget and watch the processor load as you move the mouse cursor.

On Linux, the savings are 4-6%. @jan76 reported 5% on Windows.

This is with the default settings. I am completely puzzled about why this should happen. Thoughts?
