### PR TITLE
Add GPS groupbox to hardware tab.

### DIFF
--- a/ground/gcs/src/plugins/config/config_cc_hw_widget.cpp
+++ b/ground/gcs/src/plugins/config/config_cc_hw_widget.cpp
@@ -84,7 +84,6 @@ ConfigCCHWWidget::ConfigCCHWWidget(QWidget *parent) : ConfigTaskWidget(parent)
     addUAVObjectToWidgetRelation("ModuleSettings","TelemetrySpeed",m_telemetry->telemetrySpeed);
     addUAVObjectToWidgetRelation("ModuleSettings","GPSSpeed",m_telemetry->gpsSpeed);
     addUAVObjectToWidgetRelation("ModuleSettings","ComUsbBridgeSpeed",m_telemetry->comUsbBridgeSpeed);
-    connect(m_telemetry->groupBoxGPS, SIGNAL(toggled(bool)), this, SLOT(on_groupBoxGPS_toggled(bool)));
 
     // Get required UAVObjects
     UAVObjectManager* objManager = pm->getObject<UAVObjectManager>();
@@ -95,7 +94,9 @@ ConfigCCHWWidget::ConfigCCHWWidget(QWidget *parent) : ConfigTaskWidget(parent)
     moduleSettingsData = moduleSettings->getData();
 
     // Set UI elements
-    m_telemetry->groupBoxGPS->setChecked(moduleSettingsData.State[ModuleSettings::STATE_GPS] == ModuleSettings::STATE_ENABLED);
+    addUAVObjectToWidgetRelation(moduleSettings->getName(),"State",m_telemetry->groupBoxGPS, ModuleSettings::STATE_GPS); // TODO: Set the widget based on the UAVO getName() and getField() methods.
+    m_telemetry->groupBoxGPS->setProperty("TrueString", "Enabled"); // TODO: Get the string automatically
+    m_telemetry->groupBoxGPS->setProperty("FalseString", "Disabled");
 
     // Load UAVObjects to widget relations from UI file
     // using objrelation dynamic property
@@ -106,29 +107,6 @@ ConfigCCHWWidget::ConfigCCHWWidget(QWidget *parent) : ConfigTaskWidget(parent)
     populateWidgets();
     refreshWidgetsValues();
     forceConnectedState();
-}
-
-void ConfigCCHWWidget::on_groupBoxGPS_toggled(bool onState)
-{
-    // Get required UAVObjects
-    ExtensionSystem::PluginManager* pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager* objManager = pm->getObject<UAVObjectManager>();
-
-    ModuleSettings* moduleSettings;
-    moduleSettings = ModuleSettings::GetInstance(objManager);
-    ModuleSettings::DataFields moduleSettingsData;
-    moduleSettingsData = moduleSettings->getData();
-
-    // If state is enabled, then turn on GPS. Otherwise, turn it off.
-    if (onState) {
-        moduleSettingsData.State[ModuleSettings::STATE_GPS] = ModuleSettings::STATE_ENABLED;
-    }
-    else {
-        moduleSettingsData.State[ModuleSettings::STATE_GPS] = ModuleSettings::STATE_DISABLED;
-    }
-
-    moduleSettings->setData(moduleSettingsData);
-
 }
 
 ConfigCCHWWidget::~ConfigCCHWWidget()

--- a/ground/gcs/src/plugins/config/config_cc_hw_widget.h
+++ b/ground/gcs/src/plugins/config/config_cc_hw_widget.h
@@ -47,7 +47,6 @@ private slots:
     void openHelp();
     void refreshValues();
     void widgetsContentsChanged();
-    void on_groupBoxGPS_toggled(bool onState);
 
 private:
     Ui_CC_HW_Widget *m_telemetry;


### PR DESCRIPTION
I propose grouping hardware configurations that are tied to optional module Enable/Disable into groupboxes

For instance:
![Screen Shot 2013-02-27 at 1 32 36 PM](https://f.cloud.github.com/assets/1118185/201062/98642c66-80e3-11e2-9fd0-4e3e312a45bd.png)
![Screen Shot 2013-02-27 at 2 41 39 PM](https://f.cloud.github.com/assets/1118185/201063/9af8fd4e-80e3-11e2-9aba-0e3a3972360f.png)

This cleans up the interface a bit, and is an easy way to allow the user to enable common optional modules without having to go into the UAVO browser.

As a way of extending this, we could create a new tab and put all optional modules there. 
