### PR TITLE
flyingf3: increase init stack size

### DIFF
--- a/flight/targets/FlyingF3/System/flyingf3.c
+++ b/flight/targets/FlyingF3/System/flyingf3.c
@@ -68,7 +68,7 @@ static void Stack_Change_Weak () __attribute__ ((weakref ("Stack_Change")));
 
 /* Local Variables */
 #define INIT_TASK_PRIORITY	(tskIDLE_PRIORITY + configMAX_PRIORITIES - 1)	// max priority
-#define INIT_TASK_STACK		(512 / 4)
+#define INIT_TASK_STACK		(640 / 4)
 static xTaskHandle initTaskHandle;
 
 /* Function Prototypes */


### PR DESCRIPTION
FlyingF3 was blowing its init stack.  This leaves us
with at least 64-bytes of margin on the init stack with
a default configuration.
