### PR TITLE
Extended UAVO widget checkbox relation to support arbitrary strings and added support for groupboxes

### DIFF
--- a/ground/gcs/src/plugins/config/config_cc_hw_widget.cpp
+++ b/ground/gcs/src/plugins/config/config_cc_hw_widget.cpp
@@ -146,6 +146,98 @@ void ConfigCCHWWidget::openHelp()
     QDesktopServices::openUrl( QUrl("http://wiki.openpilot.org/x/D4AUAQ", QUrl::StrictMode) );
 }
 
+
+/**
+ * Gets a variant from a widget
+ * @param widget pointer to the widget from where to get the value
+ * @param scale scale to be used on the assignement
+ * @return returns the value of the widget times the scale
+ */
+QVariant ConfigCCHWWidget::getVariantFromWidget(QWidget * widget, double scale)
+{
+    if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget))
+    {
+        QString ret;
+        if(groupBox->property("TrueString").isValid() && groupBox->property("FalseString").isValid()){
+            if(groupBox->isChecked())
+                ret = groupBox->property("TrueString").toString();
+            else
+                ret = groupBox->property("FalseString").toString();
+        }
+        else{
+            if(groupBox->isChecked())
+                ret = "TRUE";
+            else
+                ret = "FALSE";
+        }
+
+        return ret;
+    }
+    else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget))
+    {
+        QString ret;
+        if(checkBox->property("TrueString").isValid() && checkBox->property("FalseString").isValid()){
+            if(checkBox->isChecked())
+                ret = checkBox->property("TrueString").toString();
+            else
+                ret = checkBox->property("FalseString").toString();
+        }
+        else{
+            if(checkBox->isChecked())
+                ret = "TRUE";
+            else
+                ret = "FALSE";
+        }
+
+        return ret;
+    }
+    else
+    {
+        return ConfigTaskWidget::getVariantFromWidget(widget, scale);
+    }
+}
+
+
+/**
+ * Sets a widget from a variant
+ * @param widget pointer for the widget to set
+ * @param scale scale to be used on the assignement
+ * @param value value to be used on the assignement
+ * @return returns true if the assignement was successfull
+ */
+bool ConfigCCHWWidget::setWidgetFromVariant(QWidget *widget, QVariant value, double scale)
+{
+
+    if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget))
+        {
+            bool bvalue;
+            if(groupBox->property("TrueString").isValid() && groupBox->property("FalseString").isValid()){
+                bvalue = value.toString()==groupBox->property("TrueString").toString();
+            }
+            else{
+                bvalue = value.toString()=="TRUE";
+            }
+            groupBox->setChecked(bvalue);
+            return true;
+        }
+        else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget))
+        {
+            bool bvalue;
+            if(checkBox->property("TrueString").isValid() && checkBox->property("FalseString").isValid()){
+                bvalue = value.toString()==checkBox->property("TrueString").toString();
+            }
+            else{
+                bvalue = value.toString()=="TRUE";
+            }
+            checkBox->setChecked(bvalue);
+            return true;
+        }
+    else
+    {
+        return ConfigTaskWidget::setWidgetFromVariant(widget, value, scale);
+    }
+}
+
 /**
   * @}
   * @}

--- a/ground/gcs/src/plugins/config/config_cc_hw_widget.h
+++ b/ground/gcs/src/plugins/config/config_cc_hw_widget.h
@@ -49,6 +49,8 @@ private slots:
     void widgetsContentsChanged();
 
 private:
+    QVariant getVariantFromWidget(QWidget * widget, double scale);
+    bool setWidgetFromVariant(QWidget *widget, QVariant value, double scale);
     Ui_CC_HW_Widget *m_telemetry;
     QSvgRenderer *m_renderer;
 };

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -1100,39 +1100,11 @@ QVariant ConfigTaskWidget::getVariantFromWidget(QWidget * widget,double scale)
     }
     else if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget))
     {
-        QString ret;
-        if(groupBox->property("TrueString").isValid() && groupBox->property("FalseString").isValid()){
-            if(groupBox->isChecked())
-                ret = groupBox->property("TrueString").toString();
-            else
-                ret = groupBox->property("FalseString").toString();
-        }
-        else{
-            if(groupBox->isChecked())
-                ret = "TRUE";
-            else
-                ret = "FALSE";
-        }
-
-        return ret;
+        return (QString)(groupBox->isChecked() ? "TRUE":"FALSE");
     }
     else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget))
     {
-        QString ret;
-        if(checkBox->property("TrueString").isValid() && checkBox->property("FalseString").isValid()){
-            if(checkBox->isChecked())
-                ret = checkBox->property("TrueString").toString();
-            else
-                ret = checkBox->property("FalseString").toString();
-        }
-        else{
-            if(checkBox->isChecked())
-                ret = "TRUE";
-            else
-                ret = "FALSE";
-        }
-
-        return ret;
+        return (QString)(checkBox->isChecked() ? "TRUE":"FALSE");
     }
     else if(QLineEdit * lineEdit=qobject_cast<QLineEdit *>(widget))
     {
@@ -1180,25 +1152,13 @@ bool ConfigTaskWidget::setWidgetFromVariant(QWidget *widget, QVariant value, dou
     }
     else if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget))
     {
-        bool bvalue;
-        if(groupBox->property("TrueString").isValid() && groupBox->property("FalseString").isValid()){
-            bvalue = value.toString()==groupBox->property("TrueString").toString();
-        }
-        else{
-            bvalue = value.toString()=="TRUE";
-        }
+        bool bvalue=value.toString()=="TRUE";
         groupBox->setChecked(bvalue);
         return true;
     }
     else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget))
     {
-        bool bvalue;
-        if(checkBox->property("TrueString").isValid() && checkBox->property("FalseString").isValid()){
-            bvalue = value.toString()==checkBox->property("TrueString").toString();
-        }
-        else{
-            bvalue = value.toString()=="TRUE";
-        }
+        bool bvalue=value.toString()=="TRUE";
         checkBox->setChecked(bvalue);
         return true;
     }

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
@@ -189,8 +189,6 @@ private:
     bool dirty;
     bool setFieldFromWidget(QWidget *widget, UAVObjectField *field, int index, double scale);
     bool setWidgetFromField(QWidget *widget, UAVObjectField *field, int index, double scale, bool hasLimits);
-    QVariant getVariantFromWidget(QWidget *widget, double scale);
-    bool setWidgetFromVariant(QWidget *widget,QVariant value,double scale);
     void connectWidgetUpdatesToSlot(QWidget *widget, const char *function);
     void disconnectWidgetUpdatesToSlot(QWidget *widget, const char *function);
     void loadWidgetLimits(QWidget *widget, UAVObjectField *field, int index, bool hasLimits, double sclale);
@@ -208,6 +206,8 @@ protected slots:
 protected:
     virtual void enableControls(bool enable);
     void checkWidgetsLimits(QWidget *widget, UAVObjectField *field, int index, bool hasLimits, QVariant value, double scale);
+    virtual QVariant getVariantFromWidget(QWidget *widget, double scale);
+    virtual bool setWidgetFromVariant(QWidget *widget,QVariant value,double scale);
 };
 
 #endif // CONFIGTASKWIDGET_H


### PR DESCRIPTION
This was a pretty easy fix. It basically involves adding a dynamic property to the widget (setProperty is inherited from QObject, so this method is available for pretty much everything in Qt). When making the checkbox/groupbox, it is enough to define "TrueString" (with the UAVO field name representing the checked state) and "FalseString" (with the UAVO field name representing the unchecked state).

An example of how to use this is in https://github.com/TauLabs/TauLabs/pull/365/files#diff-1.

Thanks to @peabody124 for the hint about where to look.
