### PR TITLE
Changed file associations for GCS on OSX. Previously, it was associating

### DIFF
--- a/ground/gcs/src/app/Info.plist
+++ b/ground/gcs/src/app/Info.plist
@@ -8,27 +8,13 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleTypeIconFile</key>
-			<string>profile.icns</string>
+			<string></string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
-				<string>pro</string>
+				<string>uav</string>
 			</array>
 			<key>CFBundleTypeName</key>
-			<string>Qt Project File</string>
-			<key>LSHandlerRank</key>
-			<string>Default</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleTypeIconFile</key>
-			<string>prifile.icns</string>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>pri</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Qt Project Include File</string>
+			<string>Tau Labs UAV settings file</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>
 		</dict>
@@ -37,142 +23,17 @@
 			<string>Editor</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
-				<string>qrc</string>
+				<string>tllf</string>
+				<string>oplf</string>
 			</array>
 			<key>CFBundleTypeName</key>
-			<string>Qt Resource File</string>
+			<string>Tau Labs log file</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>ui</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Qt UI File</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>h</string>
-				<string>hpp</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Header File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>TEXT</string>
-				<string>utxt</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>cc</string>
-				<string>CC</string>
-				<string>cp</string>
-				<string>CP</string>
-				<string>cpp</string>
-				<string>CPP</string>
-				<string>cxx</string>
-				<string>CXX</string>
-				<string>c++</string>
-				<string>C++</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>C++ Source File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>TEXT</string>
-				<string>utxt</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>mm</string>
-				<string>MM</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Objective-C++ Source File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>TEXT</string>
-				<string>utxt</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>m</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Objective-C Source File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>TEXT</string>
-				<string>utxt</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>c</string>
-				<string>C</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>C Source File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>TEXT</string>
-				<string>utxt</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>txt</string>
-				<string>text</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Text File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>TEXT</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>*</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>NSStringPboardType</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>****</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
 		</dict>
 	</array>
 	<key>CFBundleGetInfoString</key>
-	<string>OpenPilot GCS; Copyright OpenPilot</string>
+	<string>Tau Labs GCS; Copyright Tau Labs</string>
 	<key>CFBundleIconFile</key>
 	<string>@ICON@</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
with .pro files, which had the unfortunate side effect of opening GCS
instead of Qt Creator when double-clicking on a .pro file.
