### PR TITLE
all f3 and f4 targets: calibrated idle counts per second

### DIFF
--- a/flight/targets/DiscoveryF4/System/inc/pios_config.h
+++ b/flight/targets/DiscoveryF4/System/inc/pios_config.h
@@ -94,8 +94,18 @@
 #define CPULOAD_LIMIT_WARNING		80
 #define CPULOAD_LIMIT_CRITICAL		95
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (8379692)
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
 //This enables altitude hold in manualcontrol module
 //#define REVOLUTION

--- a/flight/targets/FlyingF3/System/inc/pios_config.h
+++ b/flight/targets/FlyingF3/System/inc/pios_config.h
@@ -105,8 +105,18 @@
 /* Task stack sizes */
 #define PIOS_EVENTDISPATCHER_STACK_SIZE	130
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (1995998) //FIXME: this is wrong for sure
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (1459667)
 
 #define REVOLUTION
 

--- a/flight/targets/FlyingF4/System/inc/pios_config.h
+++ b/flight/targets/FlyingF4/System/inc/pios_config.h
@@ -104,8 +104,18 @@
 #define CPULOAD_LIMIT_WARNING		80
 #define CPULOAD_LIMIT_CRITICAL		95
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (8379692)
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
 #define REVOLUTION
 

--- a/flight/targets/Freedom/System/inc/pios_config.h
+++ b/flight/targets/Freedom/System/inc/pios_config.h
@@ -113,8 +113,18 @@
 #define CPULOAD_LIMIT_WARNING		80
 #define CPULOAD_LIMIT_CRITICAL		95
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (8379692)
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
 #define REVOLUTION
 

--- a/flight/targets/Quanton/System/inc/pios_config.h
+++ b/flight/targets/Quanton/System/inc/pios_config.h
@@ -105,8 +105,18 @@
 #define CPULOAD_LIMIT_WARNING		80
 #define CPULOAD_LIMIT_CRITICAL		95
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (8379692)
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
 #define REVOLUTION
 

--- a/flight/targets/RevoMini/System/inc/pios_config.h
+++ b/flight/targets/RevoMini/System/inc/pios_config.h
@@ -113,8 +113,18 @@
 #define CPULOAD_LIMIT_WARNING		80
 #define CPULOAD_LIMIT_CRITICAL		95
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (8379692)
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
 #define REVOLUTION
 

--- a/flight/targets/Revolution/System/inc/pios_config.h
+++ b/flight/targets/Revolution/System/inc/pios_config.h
@@ -112,8 +112,18 @@
 #define CPULOAD_LIMIT_WARNING		80
 #define CPULOAD_LIMIT_CRITICAL		95
 
-// This actually needs calibrating
-#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (8379692)
+/*
+ * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.
+ * Calibration has been done by disabling the init task, breaking into debugger after
+ * approximately after 60 seconds, then doing the following math:
+ *
+ * IDLE_COUNTS_PER_SEC_AT_NO_LOAD = (uint32_t)((double)idleCounter / xTickCount * 1000 + 0.5)
+ *
+ * This has to be redone every time the toolchain, toolchain flags or FreeRTOS
+ * configuration like number of task priorities or similar changes.
+ * A change in the cpu load calculation or the idle task handler will invalidate this as well.
+ */
+#define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
 #define REVOLUTION
 


### PR DESCRIPTION
The method is documented as a comment.
This gives 25% used cpu on quanton and 44% on flyingf3 with default configuration each.

Intended to address #336
