### PR TITLE
Replaced loadConfiguration(0) call removed in 9bc1151811f9d059d4a0e591e42165c8e7edb36f

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/uavgadgetdecorator.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetdecorator.cpp
@@ -47,11 +47,11 @@ UAVGadgetDecorator::UAVGadgetDecorator(IUAVGadget *gadget, QList<IUAVGadgetConfi
         m_toolbar->addItem(config->name());
     connect(m_toolbar, SIGNAL(activated(int)), this, SLOT(loadConfiguration(int)));
 
+    // If a gadget configuration exists, use the first configuration when
+    // creating the gadget.
     if (m_configurations->count() > 0){
-        // TODO: better document what this is doing. With this line removed,
-        // all widgets load normally, but in some specific instances-- e.g.
-        // analog dials--, GCS crashes when the user uses Edit Gadgets to
-        // load the new gadget.
+        // Must call loadConfiguration(), or else GCS crashes when
+        // changing widgets using Edit Gadgets mode.
         loadConfiguration(0);
     }
 


### PR DESCRIPTION
This was originally causing a bug by which scopes were loading variables twice, so was removed. However, the scopes bug was fixed during the refactoring, and so this call needs to be put back in order to avoid bugs such as https://github.com/TauLabs/TauLabs/issues/394

It would be nice to understand why some gadgets require this loadConfiguration(0) and others do not.
