### PR TITLE
Bug in uavtalk.cpp

### DIFF
--- a/ground/gcs/src/plugins/uavtalk/uavtalk.cpp
+++ b/ground/gcs/src/plugins/uavtalk/uavtalk.cpp
@@ -316,12 +316,13 @@ bool UAVTalk::processInputByte(quint8 rxbyte)
                 if (rxType == TYPE_OBJ_REQ || rxType == TYPE_ACK || rxType == TYPE_NACK)
                 {
                     rxLength = 0;
+                    rxInstanceLength = 0;
                 }
                 else
                 {
                     rxLength = rxObj->getNumBytes();
+                    rxInstanceLength = (rxObj->isSingleInstance() ? 0 : 2);
                 }
-                rxInstanceLength = (rxObj->isSingleInstance() ? 0 : 2);
 
                 // Check length and determine next state
                 if (rxLength >= MAX_PAYLOAD_LENGTH)


### PR DESCRIPTION
In https://github.com/TauLabs/TauLabs/blob/next/ground/gcs/src/plugins/uavtalk/uavtalk.cpp, our handling of rxObj seems like a bug. We allow for the possibility that it is NULL, but then don't specifically handle the case where it is NULL and rxType == TYPE_OBJ_REQ. We subsequently use rxObj, which leads to occasional crashes on my computer.

```
UAVObject *rxObj = objMngr->getObject(rxObjId);
if (rxObj == NULL && rxType != TYPE_OBJ_REQ)
{
  stats.rxErrors++;
  rxState = STATE_SYNC;
  UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Sync (badtype)");
  break;
}

// Determine data length
if (rxType == TYPE_OBJ_REQ || rxType == TYPE_ACK || rxType == TYPE_NACK)
{
   rxLength = 0;
}
else
{
  rxLength = rxObj->getNumBytes();
}
rxInstanceLength = (rxObj->isSingleInstance() ? 0 : 2);
```

Here's my suggested fix, but I'd like comments from those familiar with uavtalk.cpp:

```
UAVObject *rxObj = objMngr->getObject(rxObjId);
if (rxObj == NULL)
{
  if (rxType != TYPE_OBJ_REQ)
  {
    stats.rxErrors++;
    rxState = STATE_SYNC;
    UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Sync (badtype)");
  }
  break;
}
```
