### PR TITLE
"Erase all settings" error message is misleading on FlyingF3

### DIFF
--- a/ground/gcs/src/plugins/config/configplugin.cpp
+++ b/ground/gcs/src/plugins/config/configplugin.cpp
@@ -137,7 +137,7 @@ void ConfigPlugin::eraseAllSettings()
     //TODO: Replace the second and third [in eraseDone()] pop-up dialogs with a progress indicator,
     // counter, or infinite chain of `......` tied to the original dialog box
     msgBox.setText(tr("Settings will now erase."));
-    msgBox.setInformativeText(tr("Press <OK> and then please wait until a completion box appears. This can take up to 90 seconds."));
+    msgBox.setInformativeText(tr("Press <OK> and then please wait until a completion box appears. This can take up to %1 seconds.").arg(FLASH_ERASE_TIMEOUT_MS/1000));
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();
 


### PR DESCRIPTION
GCS returns an error when erasing all settings on FlyingF3. I'm not sure if erase all settings is failing (the erase seems to be successful), or if it's just that GCS isn't being very graceful in handling the way FlyingF3 erases its settings.
