### PR TITLE
HomeLocation: Remove unused "g_e" field

### DIFF
--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -59,7 +59,6 @@ static void updateSettings();
 
 #ifdef PIOS_GPS_SETS_HOMELOCATION
 static void setHomeLocation(GPSPositionData * gpsData);
-static float GravityAccel(float latitude, float longitude, float altitude);
 #endif
 
 // ****************
@@ -278,20 +277,6 @@ static void gpsTask(void *parameters)
 }
 
 #ifdef PIOS_GPS_SETS_HOMELOCATION
-/*
- * Estimate the acceleration due to gravity for a particular location in LLA
- */
-static float GravityAccel(float latitude, float longitude, float altitude)
-{
-	// WGS84 gravity model.  The effect of gravity over latitude is strong
-	// enough to change the estimated accelerometer bias in those apps.
-	double sinsq = sin((double)latitude);
-	sinsq *= sinsq;
-	// Likewise, over the altitude range of a high-altitude balloon, the effect
-	// due to change in altitude can also affect the model.
-	return (float)(9.7803267714 * (1 + 0.00193185138639*sinsq) / sqrt(1 - 0.00669437999013*sinsq)
-		- 3.086e-6*altitude);
-}
 
 // ****************
 
@@ -319,7 +304,6 @@ static void setHomeLocation(GPSPositionData * gpsData)
 			// Compute local acceleration due to gravity.  Vehicles that span a very large
 			// range of altitude (say, weather balloons) may need to update this during the
 			// flight.
-			home.g_e = GravityAccel(LLA[0], LLA[1], LLA[2]);
 			home.Set = HOMELOCATION_SET_TRUE;
 			HomeLocationSet(&home);
 		}

--- a/ground/gcs/src/plugins/hitl/simulator.cpp
+++ b/ground/gcs/src/plugins/hitl/simulator.cpp
@@ -411,7 +411,6 @@ void Simulator::updateUAVOs(Output2Hardware out){
         homeData.Be[1]=0;
         homeData.Be[2]=0;
 
-        homeData.g_e=9.805;
         homeData.GroundTemperature=15;
         homeData.SeaLevelPressure=1013;
 

--- a/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
@@ -331,13 +331,6 @@ int UAVObjectUtilManager::setHomeLocation(double LLA[3], bool save_to_sdcard)
     homeLocationData.Be[1] = Be[1];
     homeLocationData.Be[2] = Be[2];
 
-    //Check that gravity !=0. Do not let user continue until valid gravity data is entered
-    bool ok=true;
-    while(homeLocationData.g_e < 3 || homeLocationData.g_e > 25 || !ok){ // 3 is Mars's gravity and 25 Jupiter's
-        homeLocationData.g_e = QInputDialog::getDouble(0, tr("Gravity setting error"),
-                                          tr("Please set local gravity in [m/s^2]. If unsure, leave the default."), 9.805, 3, 25, 3, &ok);
-    }
-
     homeLocationData.Set = HomeLocation::SET_TRUE;
 
     homeLocation->setData(homeLocationData);

--- a/shared/uavobjectdefinition/homelocation.xml
+++ b/shared/uavobjectdefinition/homelocation.xml
@@ -6,7 +6,6 @@
         <field name="Longitude" units="deg * 10e6" type="int32" elements="1" defaultvalue="0"/>
         <field name="Altitude" units="m over geoid" type="float" elements="1" defaultvalue="0"/>
         <field name="Be" units="" type="float" elements="3" defaultvalue="0,0,0"/>
-        <field name="g_e" units="m/s^2" type="float" elements="1" defaultvalue="9.81"/>
         <field name="GroundTemperature" units="deg C" type="int8" elements="1" defaultvalue="15"/>
         <field name="SeaLevelPressure" units="millibar" type="uint16" elements="1" defaultvalue="1013"/>
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
We can add it back in if we start using it, but then we need
to use it reliably.  As it was this value was simply set and
then wasted memory.
