### PR TITLE
flyingf3: raised stack size of eventdispatcher from 130 to 256 words

### DIFF
--- a/flight/targets/FlyingF3/System/inc/pios_config.h
+++ b/flight/targets/FlyingF3/System/inc/pios_config.h
@@ -103,7 +103,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_EVENTDISPATCHER_STACK_SIZE	130
+#define PIOS_EVENTDISPATCHER_STACK_SIZE	256
 
 /*
  * This has been calibrated 2013/03/11 using next @ 6d21c7a590619ebbc074e60cab5e134e65c9d32b.


### PR DESCRIPTION
Rationale behind 130 was that it is the setting which works for CopterControl.
Turns out that it is too tight for FlyingF3.
