### PR TITLE
FlyingF4: Add panic codes for sensor errors

### DIFF
--- a/flight/targets/FlyingF4/System/pios_board.c
+++ b/flight/targets/FlyingF4/System/pios_board.c
@@ -263,7 +263,12 @@ static void panic(int32_t code) {
 			PIOS_LED_Toggle(PIOS_LED_ALARM);
 			PIOS_DELAY_WaitmS(200);
 		}
-		PIOS_DELAY_WaitmS(500);
+		PIOS_DELAY_WaitmS(200);
+		PIOS_WDG_Clear();
+		PIOS_DELAY_WaitmS(200);
+		PIOS_WDG_Clear();
+		PIOS_DELAY_WaitmS(100);
+		PIOS_WDG_Clear();
 	}
 }
 


### PR DESCRIPTION
- 1 pulse - flash chip
  - 2 pulses - MPU6050
  - 3 pulses - HMC5883
  - 4 pulses - MS5611
  - 5 pulses - gyro I2C bus locked
  - 6 pulses - mag/baro I2C bus locked
