### PR TITLE
UBX: Require TIMEUTC_VALIDWKN instead of TIMEUTC_VALID_UTC

### DIFF
--- a/flight/Modules/GPS/UBX.c
+++ b/flight/Modules/GPS/UBX.c
@@ -254,7 +254,7 @@ static void parse_ubx_nav_velned (const struct UBX_NAV_VELNED *velned, GPSPositi
 #if !defined(PIOS_GPS_MINIMAL)
 static void parse_ubx_nav_timeutc (const struct UBX_NAV_TIMEUTC *timeutc)
 {
-	if (!(timeutc->valid & TIMEUTC_VALIDUTC))
+	if (!(timeutc->valid & TIMEUTC_VALIDWKN))
 		return;
 
 	GPSTimeData GpsTime;


### PR DESCRIPTION
This flag was frequently not set and stopped the GPSTime object
updating, and thus the HomeLocation from updating.  This seems
to be related to leap seconds but probably isn't an issue:

http://lists.linuxtogo.org/pipermail/smartphones-standards/2008-September/000440.html
