### PR TITLE
ModuleSettings: Remove ALTITUDE module no longer started as module

### DIFF
--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -4,7 +4,6 @@
 		<field name="AdminState" units="" type="enum" options="Disabled,Enabled" defaultvalue="Disabled">
 			<elementnames>
 				<elementname>Airspeed</elementname>
-				<elementname>Altitude</elementname>
 				<elementname>AltitudeHold</elementname>
 				<elementname>Autotune</elementname>
 				<elementname>Battery</elementname>


### PR DESCRIPTION
The baro sensor now runs its own task and uses the sensor api

I should have included this when removing the RADIO module
