### PR TITLE
GCS Log Replay: Fix replay of android log files

### DIFF
--- a/ground/gcs/src/plugins/logging/logfile.h
+++ b/ground/gcs/src/plugins/logging/logfile.h
@@ -45,8 +45,8 @@ protected:
     QTimer timer;
     QTime myTime;
     QFile file;
-    qint32 lastTimeStamp;
-    qint32 lastPlayTime;
+    quint32 lastTimeStamp;
+    quint32 lastPlayTime;
     QMutex mutex;
 
 
@@ -54,10 +54,11 @@ protected:
     double playbackSpeed;
 
 private:
-    QList<qint32> timestampBuffer;
-    QList<qint32> timestampPos;
+    QList<quint32> timestampBuffer;
+    QList<quint32> timestampPos;
     quint32 timestampBufferIdx;
-    qint32 lastTimeStampPos;
+    quint32 lastTimeStampPos;
+    quint32 firstTimestamp;
 };
 
 #endif // LOGFILE_H


### PR DESCRIPTION
The android log files use the android system time which means it
can start at very large numbers, whereas GCS logs start at zero.
To fix this the time of the first timestamp is subtracted out.

Also the times were signed which is inappropriate, so they are
all converted to quint32.

As a side note the way this code is written, it is _extremely_
brittle to ill-formatted logfiles because it doesn't use the
UAVTalk parser or try and maintain sync.  I also removed a
redundant set of checks on the order of timestamps as this is
done during loading and also didn't respond well to the large
timestamps from android.
