### PR TITLE
Revert "Path to turn on compiling SDL by default."

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -138,7 +138,3 @@ linux-g++-* {
     QMAKE_LFLAGS += -Wl,--allow-shlib-undefined -Wl,--no-undefined
 }
 
-#Turn on SDL by default
-isEmpty(GCS_NO_SDL) {
-    CONFIG   += SDL
-}


### PR DESCRIPTION
This makes not using SDL the default.  This does not remove the functionality but simply makes GCS by default not require SDL.  This simplifies setting up a build environment for the people that do not want it - which is the majority.

This PR is for people to vote on whether the pros of maintaining SDL as a default requirement exceed the cons.
