### PR TITLE
FlyingF3: PWM6 and PWM7 used wrong AF

### DIFF
--- a/flight/targets/board_hw_defs/flyingf3/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/flyingf3/board_hw_defs.c
@@ -1469,7 +1469,7 @@ static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 	{
 		.timer = TIM2,
 		.timer_chan = TIM_Channel_3,
-		.remap = GPIO_AF_2,
+		.remap = GPIO_AF_1,
 		.pin = {
 			.gpio = GPIOA,
 			.init = {
@@ -1485,7 +1485,7 @@ static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 	{
 		.timer = TIM2,
 		.timer_chan = TIM_Channel_4,
-		.remap = GPIO_AF_2,
+		.remap = GPIO_AF_1,
 		.pin = {
 			.gpio = GPIOA,
 			.init = {


### PR DESCRIPTION
They bothed used AF2 which is unused for these pins
instead of AF1 so the PWM functionality wasn't
working.

Fixes #449
