### PR TITLE
Circular Modulus: remove requirement of -540 being the lower limit

### DIFF
--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -64,12 +64,11 @@ float circular_modulus_deg(float err)
 
 	// fmodf converts negative values into the negative remainder
 	// so we must add 360 to make sure this ends up correct and
-	// behaves like normal modulus
+	// behaves like positive output modulus
 	if (val < 0)
-		val += 360;
-
-	// Must offset by -180 to get symmetrical output (i.e. direction)
-	val -= 180;
+		val += 180;
+	else
+		val -= 180;
 
 	return val;
 


### PR DESCRIPTION
Since fmodf(x,360) will return something between -360 to 360 we can
just add 360 to get a positive output instead of adding a finite value
before the modulus.  This should make it take in any valid angle in
degrees and avoids a while loop.
