### PR TITLE
FlashFS: fix formatting with multiple instances

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -308,7 +308,8 @@ static void objectUpdatedCb(UAVObjEvent * ev)
 		} else if (objper.Operation == OBJECTPERSISTENCE_OPERATION_FULLERASE) {
 			retval = -1;
 #if defined(PIOS_INCLUDE_FLASH_SECTOR_SETTINGS)
-			retval = PIOS_FLASHFS_Format(0);
+			extern uintptr_t pios_uavo_settings_fs_id;
+			retval = PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
 #endif
 		}
 		switch(retval) {


### PR DESCRIPTION
The old format command took a (0) in for no reason which
because the uintptr_t to the file system and obviously
results in an error erasing flash.
