### PR TITLE
Misc Math tests did not include sharedapi

### DIFF
--- a/flight/tests/misc_math/Makefile
+++ b/flight/tests/misc_math/Makefile
@@ -27,6 +27,7 @@ WHEREAMI := $(dir $(lastword $(MAKEFILE_LIST)))
 TOP      := $(realpath $(WHEREAMI)/../../../)
 include $(TOP)/make/firmware-defs.mk
 
+EXTRAINCDIRS += $(SHAREDAPIDIR)
 EXTRAINCDIRS += $(FLIGHTLIB)/math
 
 CFLAGS += -O0


### PR DESCRIPTION
This is required since they include physical_constants.h

I'll merge this once it builds cleanly on jenkins
