### PR TITLE
Revert "SDL: make the default NO_SDL"

### DIFF
--- a/ground/gcs/copydata.pro
+++ b/ground/gcs/copydata.pro
@@ -63,7 +63,7 @@ equals(copydata, 1) {
             data_copy.commands += $(COPY_FILE) $$targetPath(\"$$[QT_INSTALL_PLUGINS]/sqldrivers/$$dll\") $$targetPath(\"$$GCS_APP_PATH/sqldrivers/$$dll\") $$addNewline()
         }
 
-        !NO_SDL {
+        SDL {
             # copy SDL - Simple DirectMedia Layer (www.libsdl.org)
             # Check the wiki for SDL installation, it should be copied first
             # (make sure that the Qt installation path below is correct)

--- a/ground/gcs/src/libs/libs.pro
+++ b/ground/gcs/src/libs/libs.pro
@@ -12,7 +12,7 @@ SUBDIRS   = \
     qextserialport \
     libqxt
 
-!NO_SDL {
+SDL {
 SUBDIRS += sdlgamepad
 }
 

--- a/ground/gcs/src/plugins/gcscontrol/gcscontrol.pro
+++ b/ground/gcs/src/plugins/gcscontrol/gcscontrol.pro
@@ -8,7 +8,7 @@ include(../../taulabsgcsplugin.pri)
 include(../../plugins/coreplugin/coreplugin.pri) 
 include(../../plugins/uavobjects/uavobjects.pri)
 
-!NO_SDL {
+SDL {
     DEFINES += USE_SDL
     include(../../libs/sdlgamepad/sdlgamepad.pri)
 }


### PR DESCRIPTION
Now #397 is merged, this PR proposes making the default behavior to _not_ include SDL where it can be included by running 

```
make GCS_QMAKE_OPTS="CONFIG+=SDL" -j7 gcs
```

previously a few developers expressed a preference for doing this as it greatly simplifies setting up a development environment since SDL is clunky to install.  Ideally we would then replace USB joystick support with something that can be integrated into our source tree.

This is also consistent with how we include other optional features like OSG.  If the issue is that some people want to always have SDL/OSG included we should be able to pick up environmental variables (or they can set add it in Qt Creator under the qmake options).

We should set jenkins to use CONFIG+=SDL if this merges so the distributable keep support for USB joysticks.  This is purely to simplify setting up development.
