### PR TITLE
Reduce ManualControl memory allocation on CopterControl.

### DIFF
--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -42,8 +42,10 @@
 // Private constants
 #if defined(PIOS_CONTROL_STACK_SIZE)
 #define STACK_SIZE_BYTES PIOS_MANUAL_STACK_SIZE
-#else
+#elif !defined(COPTERCONTROL)
 #define STACK_SIZE_BYTES 1424
+#else
+#define STACK_SIZE_BYTES 550
 #endif
 
 #define TASK_PRIORITY (tskIDLE_PRIORITY+4)
@@ -100,6 +102,7 @@ static void manualControlTask(void *parameters)
 	FlightStatusData flightStatus;
 	FlightStatusGet(&flightStatus);
 	flightStatus.Armed = FLIGHTSTATUS_ARMED_DISARMED;
+	FlightStatusSet(&flightStatus);
 
 	// Main task loop
 	lastSysTime = xTaskGetTickCount();


### PR DESCRIPTION
CopterControl doesn't need very much memory for ManualControl, because the tablet input object is not available. Tested with PWM and PPM. Most of the time ManualControl has 104  bytes free, but on occasion I see 96 bytes.

Needs to be tested with DSM and S.BUS if possible.
