### PR TITLE
Fix Q_DECL_EXPORT bug that caused Windows breakage.

### DIFF
--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.pro
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.pro
@@ -2,6 +2,7 @@ TEMPLATE = lib
 QT += xml
 
 TARGET = TelemetryScheduler 
+DEFINES += TELEMETRYSCHEDULER_LIBRARY
 
 include(../../taulabsgcsplugin.pri) 
 include(../../plugins/coreplugin/coreplugin.pri) 
@@ -14,6 +15,7 @@ HEADERS += telemetryschedulergadgetconfiguration.h
 HEADERS += telemetryschedulergadgetwidget.h
 HEADERS += telemetryschedulergadgetfactory.h
 HEADERS += telemetryschedulerplugin.h
+HEADERS += telemetryscheduler_global.h
 HEADERS += metadata_dialog.h
 
 SOURCES += telemetryschedulergadget.cpp

--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler_global.h
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler_global.h
@@ -1,0 +1,41 @@
+/**
+ ******************************************************************************
+ *
+ * @file       telemetryscheduler_global.h
+ * @author     Tau Labs, http://taulabs.org Copyright (C) 2013.
+ * @see        The GNU Public License (GPL) Version 3
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup TelemetrySchedulerPlugin TelemetryScheduler Plugin
+ * @{
+ * @brief The TelemetryScheduler GCS plugin
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef TELEMETRY_SCHEDULER_H
+#define TELEMETRY_SCHEDULER_H
+
+#include <QtCore/qglobal.h>
+
+#if defined(TELEMETRYSCHEDULER_LIBRARY)
+#  define TELEMETRYSCHEDULER_EXPORT Q_DECL_EXPORT
+#else
+#  define TELEMETRYSCHEDULER_EXPORT Q_DECL_IMPORT
+#endif
+
+#endif // TELEMETRY_SCHEDULER_H
+

--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryschedulergadgetfactory.h
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryschedulergadgetfactory.h
@@ -27,6 +27,7 @@
 #ifndef TELEMETRYSCHEDULERGADGETFACTORY_H_
 #define TELEMETRYSCHEDULERGADGETFACTORY_H_
 
+#include "telemetryscheduler_global.h"
 #include <coreplugin/iuavgadgetfactory.h>
 
 namespace Core {
@@ -36,7 +37,7 @@ class IUAVGadgetFactory;
 
 using namespace Core;
 
-class Q_DECL_IMPORT TelemetrySchedulerGadgetFactory : public IUAVGadgetFactory
+class TELEMETRYSCHEDULER_EXPORT TelemetrySchedulerGadgetFactory : public IUAVGadgetFactory
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
Apparently I caused breakage in Windows with an inappropriately placed Q_DECL_EXPORT.

Fixes https://github.com/TauLabs/TauLabs/pull/542.
