### PR TITLE
Spi fixes

### DIFF
--- a/flight/PiOS/STM32F10x/pios_spi.c
+++ b/flight/PiOS/STM32F10x/pios_spi.c
@@ -254,8 +254,10 @@ int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
 		return -1;
 
 	PIOS_IRQ_Disable();
-	if (spi_dev->busy)
+	if (spi_dev->busy) {
+		PIOS_IRQ_Enable();
 		return -1;
+	}
 	spi_dev->busy = 1;
 	PIOS_IRQ_Enable();
 #endif
@@ -290,8 +292,10 @@ int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
 		return -1;
 
 	PIOS_IRQ_Disable();
-	if (spi_dev->busy)
+	if (spi_dev->busy) {
+		PIOS_IRQ_Enable();
 		return -1;
+	}
 	spi_dev->busy = 1;
 	PIOS_IRQ_Enable();
 #endif

--- a/flight/PiOS/STM32F30x/pios_spi.c
+++ b/flight/PiOS/STM32F30x/pios_spi.c
@@ -279,8 +279,10 @@ int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
 		return -1;
 
 	PIOS_IRQ_Disable();
-	if (spi_dev->busy)
+	if (spi_dev->busy) {
+		PIOS_IRQ_Enable();
 		return -1;
+	}
 	spi_dev->busy = 1;
 	PIOS_IRQ_Enable();
 #endif
@@ -315,8 +317,10 @@ int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
 		return -1;
 
 	PIOS_IRQ_Disable();
-	if (spi_dev->busy)
+	if (spi_dev->busy) {
+		PIOS_IRQ_Enable();
 		return -1;
+	}
 	spi_dev->busy = 1;
 	PIOS_IRQ_Enable();
 #endif

--- a/flight/PiOS/STM32F4xx/pios_spi.c
+++ b/flight/PiOS/STM32F4xx/pios_spi.c
@@ -273,8 +273,10 @@ int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
 		return -1;
 
 	PIOS_IRQ_Disable();
-	if (spi_dev->busy)
+	if (spi_dev->busy) {
+		PIOS_IRQ_Enable();
 		return -1;
+	}
 	spi_dev->busy = 1;
 	PIOS_IRQ_Enable();
 #endif
@@ -309,8 +311,10 @@ int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
 		return -1;
 
 	PIOS_IRQ_Disable();
-	if (spi_dev->busy)
+	if (spi_dev->busy) {
+		PIOS_IRQ_Enable();
 		return -1;
+	}
 	spi_dev->busy = 1;
 	PIOS_IRQ_Enable();
 #endif


### PR DESCRIPTION
- adds bus claim and release for non freertos builds
- fixes a bus claim deadlock for non freertos builds
- whole code base has been checked for similar deadlocks

This was inspired by http://reviews.openpilot.org/cru/OPReview-468

Best reviewed ignoring whitespace changes i.e. adding ?w=0
