### PR TITLE
astyle: bump version to svn revision 376

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -442,23 +442,20 @@ ASTYLE_BUILD_DIR := $(DL_DIR)/astyle
 
 .PHONY: astyle_install
 astyle_install: | $(DL_DIR) $(TOOLS_DIR)
-astyle_install: ASTYLE_URL := http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.02.1/astyle_2.02.1_linux.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fastyle%2Ffiles%2F&ts=1362308618&use_mirror=ignum
-astyle_install: ASTYLE_FILE := astyle_2.02.1_linux.tar.gz
-astyle_install: ASTYLE_OPTIONS := 
+astyle_install: ASTYLE_URL := https://astyle.svn.sourceforge.net/svnroot/astyle/trunk/AStyle
+astyle_install: ASTYLE_REV := 376
+astyle_install: ASTYLE_OPTIONS := prefix=$(ASTYLE_DIR)
 astyle_install: astyle_clean
-        # download the source only if it's newer than what we already have
-	$(V1) wget -P "$(DL_DIR)" --trust-server-name -N "$(ASTYLE_URL)"
-
-        # extract the source
-	$(V0) @echo " EXTRACT      $(ASTYLE_FILE) -> $(ASTYLE_BUILD_DIR)"
-	$(V1) tar -C $(DL_DIR) -xzf "$(DL_DIR)/$(ASTYLE_FILE)"
+        # download the source
+	$(V0) @echo " DOWNLOAD     $(ASTYLE_URL) @ $(ASTYLE_REV)"
+	$(V1) svn export -q "$(ASTYLE_URL)" -r $(ASTYLE_REV) "$(ASTYLE_BUILD_DIR)"
 
         # build and install
 	$(V0) @echo " BUILD        $(ASTYLE_DIR)"
 	$(V1) mkdir -p "$(ASTYLE_DIR)"
 	$(V1) ( \
-	  $(MAKE) -C $(ASTYLE_BUILD_DIR)/build/gcc prefix=$(ASTYLE_DIR) ; \
-	  $(MAKE) -C $(ASTYLE_BUILD_DIR)/build/gcc prefix=$(ASTYLE_DIR) install ; \
+	  $(MAKE) -C $(ASTYLE_BUILD_DIR)/build/gcc $(ASTYLE_OPTIONS) ; \
+	  $(MAKE) -C $(ASTYLE_BUILD_DIR)/build/gcc $(ASTYLE_OPTIONS) install ; \
 	)
 
         # delete the extracted source when we're done


### PR DESCRIPTION
This udpates astyle to a newer version which is better at formatting code linux kernel style.
