### PR TITLE
GenericI2CSensor: do not fail compilation without PIOS_I2C_INCLUDE

### DIFF
--- a/flight/Modules/GenericI2CSensor/generic_i2c_sensor.c
+++ b/flight/Modules/GenericI2CSensor/generic_i2c_sensor.c
@@ -27,6 +27,9 @@
 
 #include "openpilot.h"
 #include "modulesettings.h"
+
+#if defined(PIOS_INCLUDE_I2C)
+
 #include "i2cvm.h"	   /* UAV Object (VM register file outputs) */
 #include "i2cvmuserprogram.h"	/* UAV Object (bytecode to run) */
 
@@ -76,10 +79,6 @@ static int32_t GenericI2CSensorInitialize(void)
 	} else {
 		module_enabled = false;
 	}
-#endif
-
-#if !defined(PIOS_INCLUDE_I2C)
-	module_enabled = false;
 #endif
 
 	if (!module_enabled)
@@ -148,7 +147,6 @@ MODULE_INITCALL(GenericI2CSensorInitialize, GenericI2CSensorStart)
 
 static void GenericI2CSensorTask(void *parameters)
 {
-#if defined(PIOS_INCLUDE_I2C)
 	// Main task loop
 	while (1) {
 		/* Run the selected program */
@@ -165,12 +163,9 @@ static void GenericI2CSensorTask(void *parameters)
 			vTaskDelay(100 / portTICK_RATE_MS);
 		}
 	}
-#else
-	while (1) {
-		vTaskDelay(100 / portTICK_RATE_MS);
-	}
-#endif
 }
+
+#endif /* PIOS_INCLUDE_I2C */
 
 /**
   * @}

--- a/flight/Modules/GenericI2CSensor/i2c_vm.c
+++ b/flight/Modules/GenericI2CSensor/i2c_vm.c
@@ -26,6 +26,8 @@
  */
 
 #include <pios.h>
+#if defined(PIOS_INCLUDE_I2C)
+
 #include <stdint.h>	      /* uint8_t, uint32_t, etc */
 #include <stdbool.h>	      /* bool */
 #include "uavobjectmanager.h" /* UAVO types */
@@ -589,7 +591,6 @@ static bool i2c_vm_set_dev_addr (struct i2c_vm_regs * vm_state, uint8_t i2c_dev_
  */
 static bool i2c_vm_read (struct i2c_vm_regs * vm_state, uint8_t ram_addr, uint8_t len, uint8_t op3)
 {
-#if defined(PIOS_INCLUDE_I2C)
 	/* Make sure our read fits in our buffer */
 	if ((ram_addr + len) > sizeof(vm_state->uavo.ram)) {
 		return false;
@@ -614,9 +615,6 @@ static bool i2c_vm_read (struct i2c_vm_regs * vm_state, uint8_t ram_addr, uint8_
 	vm_state->uavo.pc++;
 
 	return (true);
-#else
-	return false;
-#endif
 }
 
 /* Write I2C data from virtual machine RAM
@@ -628,7 +626,6 @@ static bool i2c_vm_read (struct i2c_vm_regs * vm_state, uint8_t ram_addr, uint8_
  */
 static bool i2c_vm_write (struct i2c_vm_regs * vm_state, uint8_t ram_addr, uint8_t len, uint8_t op3)
 {
-#if defined(PIOS_INCLUDE_I2C)
 	if ((ram_addr + len) > sizeof(vm_state->uavo.ram)) {
 		return false;
 	}
@@ -652,9 +649,6 @@ static bool i2c_vm_write (struct i2c_vm_regs * vm_state, uint8_t ram_addr, uint8
 	vm_state->uavo.pc++;
 
 	return (true);
-#else
-	return false;
-#endif
 }
 
 /* Send UAVObject from virtual machine registers
@@ -809,7 +803,10 @@ bool i2c_vm_run (const uint32_t * code, uint8_t code_len, uintptr_t i2c_adapter)
 	return (!vm.fault);
 }
 
+#endif /* PIOS_INCLUDE_I2C */
+
 /**
  * @}
  * @}
  */
+


### PR DESCRIPTION
This module makes the code not compile without the I2C include flag.
Now it will fail to start the module and fixes the compilation
errors.

Not sure if we want to add all those hooks in there but I'm not totally sure how else to fix it.
