### PR TITLE
GCS: Remove telemetry scheduler qrc

### DIFF
--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.pro
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.pro
@@ -30,6 +30,3 @@ OTHER_FILES += telemetryscheduler.pluginspec
 FORMS += telemetryscheduler.ui
 FORMS += metadata_dialog.ui
 
-RESOURCES += telemetryscheduler.qrc
-
-

--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.qrc
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.qrc
@@ -1,3 +1,0 @@
-<RCC>
-    <qresource prefix="/telemetryscheduler"/>
-</RCC>


### PR DESCRIPTION
Fixes a warning reported by @jan76

This follows up on #581 
