### PR TITLE
CameraStabilization: POI mode for pitch was inverted

### DIFF
--- a/flight/Modules/CameraStab/camerastab.c
+++ b/flight/Modules/CameraStab/camerastab.c
@@ -262,7 +262,8 @@ static void attitudeUpdated(UAVObjEvent* ev)
 					// Does not make sense to use position to control yaw
 					break;
 				case CAMERASTABSETTINGS_INPUT_PITCH:
-					csd->inputs[CAMERASTABSETTINGS_INPUT_PITCH] = pitch;
+					// Sign for declination is opposite of the sign for pitch used below
+					csd->inputs[CAMERASTABSETTINGS_INPUT_PITCH] = -pitch;
 					break;
 				case CAMERASTABSETTINGS_INPUT_YAW:
 					CameraDesiredBearingSet(&yaw);


### PR DESCRIPTION
The declination calculation uses the standard pitch representation
(position if up) but the code for camera control uses the opposite
where pitch is down.  This makes sure POI mode feeds in appropriate
inputs.
