### PR TITLE
Remove keyboard shortcuts from wizard. 

### DIFF
--- a/ground/gcs/src/plugins/config/configgadgetfactory.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetfactory.cpp
@@ -56,7 +56,6 @@ Core::IUAVGadget* ConfigGadgetFactory::createGadget(QWidget *parent)
                                             "ConfigPlugin.ShowInputWizard",
                                             QList<int>() <<
                                             Core::Constants::C_GLOBAL_ID);
-    cmd->setDefaultKeySequence(QKeySequence("Ctrl+R"));
     cmd->action()->setText(tr("Radio Setup Wizard"));
 
     Core::ModeManager::instance()->addAction(cmd, 1);

--- a/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
+++ b/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
@@ -58,7 +58,6 @@ bool SetupWizardPlugin::initialize(const QStringList & args, QString *errMsg)
                                             "SetupWizardPlugin.ShowSetupWizard",
                                             QList<int>() <<
                                             Core::Constants::C_GLOBAL_ID);
-    cmd->setDefaultKeySequence(QKeySequence("Ctrl+V"));
     cmd->action()->setText(tr("Vehicle Setup Wizard"));
 
     Core::ModeManager::instance()->addAction(cmd, 1);


### PR DESCRIPTION
From #595: remove wizard hotkeys.

There's not much need for hotkeys to access the wizard, and using CTRL-V is overloading the commonly used paste function. 
