### PR TITLE
Configure the doxygen preprocessor to ignore __attribute__() strings.

### DIFF
--- a/Doxygen/flight_doxygen.cfg
+++ b/Doxygen/flight_doxygen.cfg
@@ -1547,20 +1547,20 @@ PERLMOD_MAKEVAR_PREFIX =
 # evaluate all C-preprocessor directives found in the sources and include 
 # files.
 
-ENABLE_PREPROCESSING   = NO
+ENABLE_PREPROCESSING   = YES
 
 # If the MACRO_EXPANSION tag is set to YES Doxygen will expand all macro 
 # names in the source code. If set to NO (the default) only conditional 
 # compilation will be performed. Macro expansion can be done in a controlled 
 # way by setting EXPAND_ONLY_PREDEF to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES 
 # then the macro expansion is limited to the macros specified with the 
 # PREDEFINED and EXPAND_AS_DEFINED tags.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES	
 
 # If the SEARCH_INCLUDES tag is set to YES (the default) the includes files 
 # pointed to by INCLUDE_PATH will be searched when a #include is found.
@@ -1589,6 +1589,7 @@ INCLUDE_FILE_PATTERNS  =
 # instead of the = operator.
 
 PREDEFINED             = 
+PREDEFINED            := __attribute__(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then 
 # this tag can be used to specify a list of macro names that should be expanded. 


### PR DESCRIPTION
http://taulabs.org/TauLabs/doxygen/flight/html/group___actuator_module.html shows a data structure `__attribute__` http://taulabs.org/TauLabs/doxygen/flight/html/actuator_8c_source.html shows that it's actually a `Mixer_t` data structure. 

http://www.rtems.org/wiki/index.php/Doxygen_Recommendations#GCC_Attributes details how to fix this behavior.
