### PR TITLE
Indoor INS: do not perform correction at 500 hz

### DIFF
--- a/flight/Modules/Attitude/revolution/attitude.c
+++ b/flight/Modules/Attitude/revolution/attitude.c
@@ -996,17 +996,15 @@ static int32_t updateAttitudeINSGPS(bool first_run, bool outdoor_mode)
 		gps_vel_updated = false;
 	}
 
-	// When runnning in indoor mode force the position to zero but only do it every
-	// 50 updates to approximately run at the same rate as a 10 hz gps
-	static uint8_t indoor_pos_divisor = 0;
-	indoor_pos_divisor++;
-	if (!outdoor_mode && indoor_pos_divisor > 50) {
+	// Update fake position at 10 hz
+	static uint32_t indoor_pos_time;
+	if (!outdoor_mode && PIOS_DELAY_DiffuS(indoor_pos_time) > 100000) {
+		indoor_pos_time = PIOS_DELAY_GetRaw();
 		vel[0] = vel[1] = vel[2] = 0;
 		NED[0] = NED[1] = 0;
 		NED[2] = -(baroData.Altitude + baro_offset);
 		sensors |= HORIZ_SENSORS | HORIZ_POS_SENSORS;
 		sensors |= VERT_SENSORS;
-		indoor_pos_divisor = 0;
 	}
 
 	/*


### PR DESCRIPTION
Indoor mode right now is a CPU beast because it performs the
correction step every cycle.  This changes it to run as frequently
as it would if the GPS were available.
