### PR TITLE
Added support for M25P16 flash chip

### DIFF
--- a/flight/targets/board_hw_defs/flyingf4/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/flyingf4/board_hw_defs.c
@@ -263,8 +263,11 @@ static const struct flashfs_logfs_cfg flashfs_m25p_waypoints_cfg = {
 };
 
 static const struct pios_flash_jedec_cfg flash_m25p_cfg = {
-	.sector_erase = 0xD8,
-	.chip_erase = 0xC7
+	.expect_manufacturer = JEDEC_MANUFACTURER_ST,
+	.expect_memorytype   = 0x20,
+	.expect_capacity     = 0x15,
+	.sector_erase        = 0xD8,
+	.chip_erase          = 0xC7
 };
 
 #include "pios_flash.h"


### PR DESCRIPTION
Current FlyingF4 firmware has incomplete definition of the flash chip that is used.
The three lines of this PR define a M25P16.
