### PR TITLE
posix: bump up telemetry rx/tx buffer sizes to work around deadlock

### DIFF
--- a/flight/targets/Revolution/System/pios_board_sim.c
+++ b/flight/targets/Revolution/System/pios_board_sim.c
@@ -83,8 +83,8 @@ const struct pios_tcp_cfg pios_tcp_aux_cfg = {
 };
 #endif
 
-#define PIOS_COM_TELEM_RF_RX_BUF_LEN 192
-#define PIOS_COM_TELEM_RF_TX_BUF_LEN 192
+#define PIOS_COM_TELEM_RF_RX_BUF_LEN 384
+#define PIOS_COM_TELEM_RF_TX_BUF_LEN 384
 #define PIOS_COM_GPS_RX_BUF_LEN 96
 
 /**


### PR DESCRIPTION
pios_tcp.c performs all transmits synchronously in the tx_start
handler.  This can lead to deadlocks on the telemetry connection->lock.

Rx thread takes connection lock, calls tx path in response to a get
request.  Blocks on full tx queue.  Tx thread blocks on connection
lock.  Deadlock.

This change does not actually fix the issue.  It simply works around
this deadlock by making the tx buffers larger.
