### PR TITLE
Libkml

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -479,7 +479,7 @@ libkml_install: LIBKML_INSTALL_DIR := $(TOOLS_DIR)/libkml
 libkml_install: LIBKML_BUILD_DIR := $(DL_DIR)/libkml-build
 libkml_install: libkml_clean
         # download the source
-	$(V0) @echo " DOWNLOAD     $(LIBKML_URL) @ $(OPENOCD_REV)"
+	$(V0) @echo " DOWNLOAD     $(LIBKML_URL) @ $(LIBKML_REV)"
 	$(V1) [ ! -d "$(LIBKML_BUILD_DIR)" ] || $(RM) -rf "$(LIBKML_BUILD_DIR)"
 	$(V1) mkdir -p "$(LIBKML_BUILD_DIR)"
 	$(V1) git clone --no-checkout $(LIBKML_URL) "$(LIBKML_BUILD_DIR)"


### PR DESCRIPTION
This PR adds libkml as a tool target. It compiles on Linux and OSX, but is having difficulties on Windows. @jan76 and I have been making progress on this latter part.

I forked libkml from google and made some fixes targeted towards Linux and Windows builds. I'd appreciate some reports on whether this compiles on a variety of platforms. So far it compiles on Mint, OSX 10.7.4, OSX 10.8.2, and whatever @solidgoldbomb uses.
