### PR TITLE
all_targets: increase baro oversampling from 512 to 1024

### DIFF
--- a/flight/targets/FlyingF4/System/pios_board.c
+++ b/flight/targets/FlyingF4/System/pios_board.c
@@ -104,7 +104,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_cfg = {
 #if defined(PIOS_INCLUDE_MS5611)
 #include "pios_ms5611_priv.h"
 static const struct pios_ms5611_cfg pios_ms5611_cfg = {
-	.oversampling = MS5611_OSR_512,
+	.oversampling = MS5611_OSR_1024,
 	.temperature_interleaving = 1,
 };
 #endif /* PIOS_INCLUDE_MS5611 */

--- a/flight/targets/Freedom/System/pios_board.c
+++ b/flight/targets/Freedom/System/pios_board.c
@@ -99,7 +99,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_cfg = {
 #if defined(PIOS_INCLUDE_MS5611)
 #include "pios_ms5611_priv.h"
 static const struct pios_ms5611_cfg pios_ms5611_cfg = {
-	.oversampling = MS5611_OSR_512,
+	.oversampling = MS5611_OSR_1024,
 	.temperature_interleaving = 1,
 };
 #endif /* PIOS_INCLUDE_MS5611 */

--- a/flight/targets/Quanton/System/pios_board.c
+++ b/flight/targets/Quanton/System/pios_board.c
@@ -98,7 +98,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_cfg = {
 #if defined(PIOS_INCLUDE_MS5611)
 #include "pios_ms5611_priv.h"
 static const struct pios_ms5611_cfg pios_ms5611_cfg = {
-	.oversampling = MS5611_OSR_512,
+	.oversampling = MS5611_OSR_1024,
 	.temperature_interleaving = 1,
 };
 #endif /* PIOS_INCLUDE_MS5611 */

--- a/flight/targets/RevoMini/System/pios_board.c
+++ b/flight/targets/RevoMini/System/pios_board.c
@@ -97,7 +97,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_cfg = {
 #if defined(PIOS_INCLUDE_MS5611)
 #include "pios_ms5611_priv.h"
 static const struct pios_ms5611_cfg pios_ms5611_cfg = {
-	.oversampling = MS5611_OSR_512,
+	.oversampling = MS5611_OSR_1024,
 	.temperature_interleaving = 1,
 };
 #endif /* PIOS_INCLUDE_MS5611 */

--- a/flight/targets/Revolution/System/pios_board.c
+++ b/flight/targets/Revolution/System/pios_board.c
@@ -97,7 +97,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_cfg = {
 #if defined(PIOS_INCLUDE_MS5611)
 #include "pios_ms5611_priv.h"
 static const struct pios_ms5611_cfg pios_ms5611_cfg = {
-	.oversampling = MS5611_OSR_512,
+	.oversampling = MS5611_OSR_1024,
 	.temperature_interleaving = 1,
 };
 #endif /* PIOS_INCLUDE_MS5611 */


### PR DESCRIPTION
- this fixes occasional event system warnings
- has to be flight tested
