### PR TITLE
firmware_defs.mk: add support for build paths containing @

### DIFF
--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -85,14 +85,15 @@ gccversion :
 	@echo $(MSG_LOAD_FILE) $(call toprel, $@)
 	$(V1) $(OBJCOPY) -O binary $< $@
 
+replace_special_chars = $(subst @,_,$(subst :,_,$(subst -,_,$(subst .,_,$(subst /,_,$1)))))
 %.bin.o: %.bin
 	@echo $(MSG_BIN_OBJ) $(call toprel, $@)
 	$(V1) $(OBJCOPY) -I binary -O elf32-littlearm --binary-architecture arm \
 		--rename-section .data=.rodata,alloc,load,readonly,data,contents \
 		--wildcard \
-		--redefine-sym _binary_$(subst :,_,$(subst -,_,$(subst .,_,$(subst /,_,$<))))_start=_binary_start \
-		--redefine-sym _binary_$(subst :,_,$(subst -,_,$(subst .,_,$(subst /,_,$<))))_end=_binary_end \
-		--redefine-sym _binary_$(subst :,_,$(subst -,_,$(subst .,_,$(subst /,_,$<))))_size=_binary_size \
+		--redefine-sym _binary_$(call replace_special_chars,$<)_start=_binary_start \
+		--redefine-sym _binary_$(call replace_special_chars,$<)_end=_binary_end \
+		--redefine-sym _binary_$(call replace_special_chars,$<)_size=_binary_size \
 		$< $@
 
 # Create extended listing file/disassambly from ELF output file.


### PR DESCRIPTION
Enhanced the firmware_defs.mk rule for .bin.o files to support build paths containing the @ character.
