### PR TITLE
AltitudeHold: increase queue size

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -61,7 +61,7 @@
 #include "modulesettings.h"
 
 // Private constants
-#define MAX_QUEUE_SIZE 2
+#define MAX_QUEUE_SIZE 3
 #define STACK_SIZE_BYTES 1024
 #define TASK_PRIORITY (tskIDLE_PRIORITY+1)
 #define ACCEL_DOWNSAMPLE 4


### PR DESCRIPTION
On F3 targets because this is responding to changes in AltHoldDesired
and accels and baro it can back up and miss events.  Setting the queue
size to 3 fixes this problem.  This has been flight tested on Sparky
successfully.
