### PR TITLE
F4 USB HID and CDC: fixed interface deinit to reset device state

### DIFF
--- a/flight/PiOS/STM32F4xx/pios_usb_cdc.c
+++ b/flight/PiOS/STM32F4xx/pios_usb_cdc.c
@@ -341,8 +341,8 @@ static void PIOS_USB_CDC_CTRL_IF_DeInit(uint32_t usb_cdc_id)
 		return;
 	}
 
-	/* DeRegister endpoint specific callbacks with the USBHOOK layer */
-	usb_cdc_dev->usb_data_if_enabled = false;
+	/* reset state of the usb hid device structure */
+	usb_cdc_dev->usb_ctrl_if_enabled = false;
 }
 
 static uint8_t cdc_altset;
@@ -556,8 +556,14 @@ static void PIOS_USB_CDC_DATA_IF_DeInit(uint32_t usb_cdc_id)
 		return;
 	}
 
-	/* DeRegister endpoint specific callbacks with the USBHOOK layer */
+	/* reset state of the usb hid device structure */
+	usb_cdc_dev->rx_active = false;
+	usb_cdc_dev->rx_dropped = 0;
+	usb_cdc_dev->rx_oversize = 0;
+	usb_cdc_dev->tx_active = false;
 	usb_cdc_dev->usb_data_if_enabled = false;
+
+	/* DeRegister endpoint specific callbacks with the USBHOOK layer */
 	PIOS_USBHOOK_DeRegisterEpInCallback(usb_cdc_dev->cfg->data_tx_ep);
 	PIOS_USBHOOK_DeRegisterEpOutCallback(usb_cdc_dev->cfg->data_rx_ep);
 }

--- a/flight/PiOS/STM32F4xx/pios_usb_hid.c
+++ b/flight/PiOS/STM32F4xx/pios_usb_hid.c
@@ -346,8 +346,14 @@ static void PIOS_USB_HID_IF_DeInit(uint32_t usb_hid_id)
 		return;
 	}
 
-	/* DeRegister endpoint specific callbacks with the USBHOOK layer */
+	/* reset state of the usb hid device structure */
+	usb_hid_dev->rx_active = false;
+	usb_hid_dev->rx_dropped = 0;
+	usb_hid_dev->rx_oversize = 0;
+	usb_hid_dev->tx_active = false;
 	usb_hid_dev->usb_if_enabled = false;
+
+	/* DeRegister endpoint specific callbacks with the USBHOOK layer */
 	PIOS_USBHOOK_DeRegisterEpInCallback(usb_hid_dev->cfg->data_tx_ep);
 	PIOS_USBHOOK_DeRegisterEpOutCallback(usb_hid_dev->cfg->data_rx_ep);
 }


### PR DESCRIPTION
Fixes a very nasty bug which renders usb unusable after replugging
This isn't ready yet. I am occasionally seeing the following problems:
- fc hang on plugging in usb
- fc reset on plugging in usb

Will need more time to debug those
