### PR TITLE
UAVObjectManager: fix crash when sending data from category

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
@@ -283,4 +283,11 @@ public:
     ArrayFieldTreeItem(const QVariant &data, TreeItem *parent = 0) : TreeItem(data, parent) { }
 };
 
+class CategoryTreeItem : public TreeItem
+{
+Q_OBJECT
+public:
+    CategoryTreeItem(const QList<QVariant> &data, TreeItem *parent = 0) : TreeItem(data, parent) { }
+    CategoryTreeItem(const QVariant &data, TreeItem *parent = 0) : TreeItem(data, parent) { }
+};
 #endif // TREEITEM_H

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -488,6 +488,8 @@ void UAVObjectBrowserWidget::toggleUAVOButtons(const QModelIndex &currentIndex, 
     TreeItem *item = static_cast<TreeItem*>(currentIndex.internalPointer());
     TopTreeItem *top = dynamic_cast<TopTreeItem*>(item);
     ObjectTreeItem *data = dynamic_cast<ObjectTreeItem*>(item);
+    CategoryTreeItem *category = dynamic_cast<CategoryTreeItem*>(item);
+
     bool enableState = true;
 
     //Check if current index refers to an empty index
@@ -496,6 +498,10 @@ void UAVObjectBrowserWidget::toggleUAVOButtons(const QModelIndex &currentIndex, 
 
     //Check if current tree index is the top tree item
     if (top || (data && !data->object()))
+        enableState = false;
+
+    // Check if category selected
+    if (category)
         enableState = false;
 
     enableUAVOBrowserButtons(enableState);

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
@@ -141,7 +141,7 @@ TreeItem* UAVObjectTreeModel::createCategoryItems(QStringList categoryPath, Tree
     foreach(QString category, categoryPath) {
         TreeItem* existing = parent->findChildByName(category);
         if(!existing) {
-            TreeItem* categoryItem = new TreeItem(category);
+            TreeItem* categoryItem = new CategoryTreeItem(category);
             connect(categoryItem, SIGNAL(updateHighlight(TreeItem*)), this, SLOT(updateHighlight(TreeItem*)));
             categoryItem->setHighlightManager(m_highlightManager);
             parent->insertChild(categoryItem);


### PR DESCRIPTION
Categories when selected allowed you to click send or save which
resulted in a crash.  This disables the buttons when they are when
categories are selected.  This required creating a new
CategoryTreeItem class to detect this.
