### PR TITLE
Sensors: sanitize baro before setting UAVO

### DIFF
--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -344,8 +344,10 @@ static void update_mags(struct pios_sensor_mag_data *mag)
  */
 static void update_baro(struct pios_sensor_baro_data *baro)
 {
+	if (isnan(baro->altitude) || isnan(baro->temperature) || isnan(baro->pressure))
+		return;
+
 	BaroAltitudeData baroAltitude;
-	BaroAltitudeGet(&baroAltitude);
 	baroAltitude.Temperature = baro->temperature;
 	baroAltitude.Pressure = baro->pressure;
 	baroAltitude.Altitude = baro->altitude;


### PR DESCRIPTION
Sometimes right at startup there seems to be an occasional
NAN in the altitude which can poison everything else.  I
considered fixing this in the MS5611 driver but it seems
reasonable to check before setting the UAVO regardless of
whether the MS5611 should have produced NAN.

I'm pushing this as a standalone PR instead of #672 because 
vinz saw some wobbles with that branch and this is the critical
fix.
