### PR TITLE
all makefiles: use -fshort-enums to save some memory

### DIFF
--- a/flight/targets/Bootloaders/BootloaderUpdater/Makefile
+++ b/flight/targets/Bootloaders/BootloaderUpdater/Makefile
@@ -227,6 +227,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 
 CFLAGS += -mcpu=$(MCU) -mthumb
 CFLAGS += $(CDEFS)

--- a/flight/targets/Bootloaders/CopterControl/Makefile
+++ b/flight/targets/Bootloaders/CopterControl/Makefile
@@ -267,6 +267,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)

--- a/flight/targets/Bootloaders/DiscoveryF4/Makefile
+++ b/flight/targets/Bootloaders/DiscoveryF4/Makefile
@@ -186,6 +186,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/FlyingF3/Makefile
+++ b/flight/targets/Bootloaders/FlyingF3/Makefile
@@ -188,6 +188,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/FlyingF4/Makefile
+++ b/flight/targets/Bootloaders/FlyingF4/Makefile
@@ -186,6 +186,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/Freedom/Makefile
+++ b/flight/targets/Bootloaders/Freedom/Makefile
@@ -185,6 +185,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/PipXtreme/Makefile
+++ b/flight/targets/Bootloaders/PipXtreme/Makefile
@@ -269,6 +269,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)

--- a/flight/targets/Bootloaders/Quanton/Makefile
+++ b/flight/targets/Bootloaders/Quanton/Makefile
@@ -186,6 +186,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/RevoMini/Makefile
+++ b/flight/targets/Bootloaders/RevoMini/Makefile
@@ -185,6 +185,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/Revolution/Makefile
+++ b/flight/targets/Bootloaders/Revolution/Makefile
@@ -185,6 +185,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/Bootloaders/Sparky/Makefile
+++ b/flight/targets/Bootloaders/Sparky/Makefile
@@ -187,6 +187,7 @@ CFLAGS += -O$(OPT)
 ifeq ($(DEBUG),NO)
 CFLAGS += -fdata-sections -ffunction-sections
 endif
+CFLAGS += -fshort-enums
 CFLAGS += -mcpu=$(MCU)
 CFLAGS += $(CDEFS)
 CFLAGS += $(BLONLY_CDEFS)

--- a/flight/targets/CopterControl/Makefile
+++ b/flight/targets/CopterControl/Makefile
@@ -574,6 +574,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/DiscoveryF4/Makefile
+++ b/flight/targets/DiscoveryF4/Makefile
@@ -234,6 +234,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/FlyingF3/Makefile
+++ b/flight/targets/FlyingF3/Makefile
@@ -279,6 +279,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/FlyingF4/Makefile
+++ b/flight/targets/FlyingF4/Makefile
@@ -286,6 +286,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/Freedom/Makefile
+++ b/flight/targets/Freedom/Makefile
@@ -365,6 +365,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/PipXtreme/Makefile
+++ b/flight/targets/PipXtreme/Makefile
@@ -401,6 +401,7 @@ CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/Quanton/Makefile
+++ b/flight/targets/Quanton/Makefile
@@ -285,6 +285,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/RevoMini/Makefile
+++ b/flight/targets/RevoMini/Makefile
@@ -359,6 +359,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/Revolution/Makefile
+++ b/flight/targets/Revolution/Makefile
@@ -370,6 +370,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/Revolution/Makefile.osx
+++ b/flight/targets/Revolution/Makefile.osx
@@ -304,6 +304,7 @@ CFLAGS += $(CDEFS)
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 
 CFLAGS += -fomit-frame-pointer
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/flight/targets/Revolution/Makefile.posix
+++ b/flight/targets/Revolution/Makefile.posix
@@ -315,6 +315,8 @@ CFLAGS += -fomit-frame-pointer
 
 CFLAGS += -Wall
 CFLAGS += -Werror
+CFLAGS += -fshort-enums
+
 # Compiler flags to generate dependency files:
 CFLAGS += -MD -MP -MF $(OUTDIR)/dep/$(@F).d
 

--- a/flight/targets/Sparky/Makefile
+++ b/flight/targets/Sparky/Makefile
@@ -281,6 +281,7 @@ CFLAGS += -mapcs-frame
 CFLAGS += -fomit-frame-pointer
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
+CFLAGS += -fshort-enums
 
 CFLAGS += -Wall
 CFLAGS += -Werror


### PR DESCRIPTION
This adds -fshort-enums to all target makefiles which tells gcc to make each individual enum use the smallest possible integer type to hold all its values. This breaks compatibility to code which has not been compiled using -fshort-enums.

The intent of this is to save memory on the flight side.

Todo:
- test and record memory usage on F1
- test on F3
- test on F4
