### PR TITLE
all pios_spi: check device in non freertos env and remove redundancy

### DIFF
--- a/flight/PiOS/STM32F10x/pios_spi.c
+++ b/flight/PiOS/STM32F10x/pios_spi.c
@@ -238,16 +238,15 @@ int32_t PIOS_SPI_SetClockSpeed(uint32_t spi_id, SPIPrescalerTypeDef spi_prescale
  */
 int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
 
+#if defined(PIOS_INCLUDE_FREERTOS)
 	if (xSemaphoreTake(spi_dev->busy, 0xffff) != pdTRUE)
 		return -1;
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	uint32_t timeout = 0xffff;
 	while ((PIOS_SPI_Busy(spi_id) || spi_dev->busy) && --timeout);
 	if (timeout == 0) //timed out
@@ -273,19 +272,19 @@ int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
  */
 int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
-	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
+
+#if defined(PIOS_INCLUDE_FREERTOS)
+	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 
 	if (xQueueReceiveFromISR((xQueueHandle) spi_dev->busy, NULL, &xHigherPriorityTaskWoken) != pdTRUE)
 		return -1;
 
 	*woken = *woken || (xHigherPriorityTaskWoken == pdTRUE);
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	uint32_t timeout = 0xffff;
 	while ((PIOS_SPI_Busy(spi_id) || spi_dev->busy) && --timeout);
 	if (timeout == 0) //timed out
@@ -309,15 +308,14 @@ int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
  */
 int32_t PIOS_SPI_ReleaseBus(uint32_t spi_id)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
 
+#if defined(PIOS_INCLUDE_FREERTOS)
 	xSemaphoreGive(spi_dev->busy);
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	PIOS_IRQ_Disable();
 	spi_dev->busy = 0;
 	PIOS_IRQ_Enable();
@@ -333,18 +331,18 @@ int32_t PIOS_SPI_ReleaseBus(uint32_t spi_id)
  */
 int32_t PIOS_SPI_ReleaseBusISR(uint32_t spi_id, bool *woken)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
-	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
 
+#if defined(PIOS_INCLUDE_FREERTOS)
+	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+
 	xSemaphoreGiveFromISR(spi_dev->busy, &xHigherPriorityTaskWoken);
 
 	*woken = *woken || (xHigherPriorityTaskWoken == pdTRUE);
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	PIOS_IRQ_Disable();
 	spi_dev->busy = 0;
 	PIOS_IRQ_Enable();

--- a/flight/PiOS/STM32F30x/pios_spi.c
+++ b/flight/PiOS/STM32F30x/pios_spi.c
@@ -263,16 +263,15 @@ int32_t PIOS_SPI_SetClockSpeed(uint32_t spi_id, SPIPrescalerTypeDef spi_prescale
  */
 int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
 
+#if defined(PIOS_INCLUDE_FREERTOS)
 	if (xSemaphoreTake(spi_dev->busy, 0xffff) != pdTRUE)
 		return -1;
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	uint32_t timeout = 0xffff;
 	while ((PIOS_SPI_Busy(spi_id) || spi_dev->busy) && --timeout);
 	if (timeout == 0) //timed out
@@ -298,19 +297,19 @@ int32_t PIOS_SPI_ClaimBus(uint32_t spi_id)
  */
 int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
-	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
+
+#if defined(PIOS_INCLUDE_FREERTOS)
+	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 
 	if (xQueueReceiveFromISR((xQueueHandle) spi_dev->busy, NULL, &xHigherPriorityTaskWoken) != pdTRUE)
 		return -1;
 
 	*woken = *woken || (xHigherPriorityTaskWoken == pdTRUE);
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	uint32_t timeout = 0xffff;
 	while ((PIOS_SPI_Busy(spi_id) || spi_dev->busy) && --timeout);
 	if (timeout == 0) //timed out
@@ -335,15 +334,14 @@ int32_t PIOS_SPI_ClaimBusISR(uint32_t spi_id, bool *woken)
  */
 int32_t PIOS_SPI_ReleaseBus(uint32_t spi_id)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
 
+#if defined(PIOS_INCLUDE_FREERTOS)
 	xSemaphoreGive(spi_dev->busy);
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	PIOS_IRQ_Disable();
 	spi_dev->busy = 0;
 	PIOS_IRQ_Enable();
@@ -359,18 +357,18 @@ int32_t PIOS_SPI_ReleaseBus(uint32_t spi_id)
  */
 int32_t PIOS_SPI_ReleaseBusISR(uint32_t spi_id, bool *woken)
 {
-#if defined(PIOS_INCLUDE_FREERTOS)
-	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
 	PIOS_Assert(valid)
 
+#if defined(PIOS_INCLUDE_FREERTOS)
+	portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+
 	xSemaphoreGiveFromISR(spi_dev->busy, &xHigherPriorityTaskWoken);
 
 	*woken = *woken || (xHigherPriorityTaskWoken == pdTRUE);
 #else
-	struct pios_spi_dev *spi_dev = (struct pios_spi_dev *)spi_id;
 	PIOS_IRQ_Disable();
 	spi_dev->busy = 0;
 	PIOS_IRQ_Enable();


### PR DESCRIPTION
Remove some code redundancy and check the device when not building using FreeRTOS as well.
