### PR TITLE
Minimal fix for flash slowness

### DIFF
--- a/flight/PiOS.osx/inc/pios_flash_priv.h
+++ b/flight/PiOS.osx/inc/pios_flash_priv.h
@@ -84,7 +84,18 @@ struct pios_flash_partition {
 	const struct pios_flash_chip *chip_desc;
 	uint16_t first_sector;
 	uint16_t last_sector;
+	uint32_t chip_offset;
+	uint32_t size;
 };
+
+#define FLASH_SECTOR_1KB   (  1 * 1024)
+#define FLASH_SECTOR_2KB   (  2 * 1024)
+#define FLASH_SECTOR_4KB   (  4 * 1024)
+#define FLASH_SECTOR_8KB   (  8 * 1024)
+#define FLASH_SECTOR_16KB  ( 16 * 1024)
+#define FLASH_SECTOR_32KB  ( 32 * 1024)
+#define FLASH_SECTOR_64KB  ( 64 * 1024)
+#define FLASH_SECTOR_128KB (128 * 1024)
 
 extern void PIOS_FLASH_register_partition_table(const struct pios_flash_partition partition_table[], uint8_t num_partitions);
 

--- a/flight/PiOS.posix/inc/pios_flash_priv.h
+++ b/flight/PiOS.posix/inc/pios_flash_priv.h
@@ -58,7 +58,18 @@ struct pios_flash_partition {
 	const struct pios_flash_chip *chip_desc;
 	uint16_t first_sector;
 	uint16_t last_sector;
+	uint32_t chip_offset;
+	uint32_t size;
 };
+
+#define FLASH_SECTOR_1KB   (  1 * 1024)
+#define FLASH_SECTOR_2KB   (  2 * 1024)
+#define FLASH_SECTOR_4KB   (  4 * 1024)
+#define FLASH_SECTOR_8KB   (  8 * 1024)
+#define FLASH_SECTOR_16KB  ( 16 * 1024)
+#define FLASH_SECTOR_32KB  ( 32 * 1024)
+#define FLASH_SECTOR_64KB  ( 64 * 1024)
+#define FLASH_SECTOR_128KB (128 * 1024)
 
 extern void PIOS_FLASH_register_partition_table(const struct pios_flash_partition partition_table[], uint8_t num_partitions);
 

--- a/flight/PiOS/inc/pios_flash_priv.h
+++ b/flight/PiOS/inc/pios_flash_priv.h
@@ -84,7 +84,18 @@ struct pios_flash_partition {
 	const struct pios_flash_chip *chip_desc;
 	uint16_t first_sector;
 	uint16_t last_sector;
+	uint32_t chip_offset;
+	uint32_t size;
 };
+
+#define FLASH_SECTOR_1KB   (  1 * 1024)
+#define FLASH_SECTOR_2KB   (  2 * 1024)
+#define FLASH_SECTOR_4KB   (  4 * 1024)
+#define FLASH_SECTOR_8KB   (  8 * 1024)
+#define FLASH_SECTOR_16KB  ( 16 * 1024)
+#define FLASH_SECTOR_32KB  ( 32 * 1024)
+#define FLASH_SECTOR_64KB  ( 64 * 1024)
+#define FLASH_SECTOR_128KB (128 * 1024)
 
 extern void PIOS_FLASH_register_partition_table(const struct pios_flash_partition partition_table[], uint8_t num_partitions);
 

--- a/flight/targets/board_hw_defs/coptercontrol/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/coptercontrol/board_hw_defs.c
@@ -439,7 +439,7 @@ static const struct pios_flash_sector_range stm32f1_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 127,
-		.sector_size = 1 * 1024,
+		.sector_size = FLASH_SECTOR_1KB,
 	},
 };
 
@@ -461,7 +461,7 @@ static const struct pios_flash_sector_range m25p16_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 31,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 };
 
@@ -477,7 +477,7 @@ static const struct pios_flash_sector_range w25x40_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 127,
-		.sector_size = 4 * 1024,
+		.sector_size = FLASH_SECTOR_4KB,
 	},
 };
 
@@ -495,6 +495,8 @@ static const struct pios_flash_partition pios_flash_partition_table_w25x40[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 11,
+		.chip_offset   = 0,
+		.size          = (11 - 0 + 1) * FLASH_SECTOR_1KB,
 	},
 
 	{
@@ -502,6 +504,8 @@ static const struct pios_flash_partition pios_flash_partition_table_w25x40[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 12,
 		.last_sector  = 127,
+		.chip_offset  = (12 * FLASH_SECTOR_1KB),
+		.size         = (127 - 12 + 1) * FLASH_SECTOR_1KB,
 	},
 
 	{
@@ -509,6 +513,8 @@ static const struct pios_flash_partition pios_flash_partition_table_w25x40[] = {
 		.chip_desc    = &pios_flash_chip_w25x40,
 		.first_sector = 0,
 		.last_sector  = 63,
+		.chip_offset  = 0,
+		.size         = (63 - 0 + 1) * FLASH_SECTOR_4KB,
 	},
 
 	{
@@ -516,6 +522,8 @@ static const struct pios_flash_partition pios_flash_partition_table_w25x40[] = {
 		.chip_desc    = &pios_flash_chip_w25x40,
 		.first_sector = 64,
 		.last_sector  = 127,
+		.chip_offset  = (64 * FLASH_SECTOR_4KB),
+		.size         = (127 - 64 + 1) * FLASH_SECTOR_4KB,
 	},
 };
 
@@ -525,6 +533,8 @@ static const struct pios_flash_partition pios_flash_partition_table_m25p16[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 11,
+		.chip_offset  = 0,
+		.size         = (11 - 0 + 1) * FLASH_SECTOR_1KB,
 	},
 
 	{
@@ -532,6 +542,8 @@ static const struct pios_flash_partition pios_flash_partition_table_m25p16[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 12,
 		.last_sector  = 127,
+		.chip_offset  = (12 * FLASH_SECTOR_1KB),
+		.size         = (127 - 12 + 1) * FLASH_SECTOR_1KB,
 	},
 
 	{
@@ -539,6 +551,8 @@ static const struct pios_flash_partition pios_flash_partition_table_m25p16[] = {
 		.chip_desc    = &pios_flash_chip_m25p16,
 		.first_sector = 0,
 		.last_sector  = 15,
+		.chip_offset  = 0,
+		.size         = (15 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
@@ -546,6 +560,8 @@ static const struct pios_flash_partition pios_flash_partition_table_m25p16[] = {
 		.chip_desc    = &pios_flash_chip_m25p16,
 		.first_sector = 16,
 		.last_sector  = 31,
+		.chip_offset  = (16 * FLASH_SECTOR_64KB),
+		.size         = (31 - 16 + 1) * FLASH_SECTOR_64KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/discoveryf4/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/discoveryf4/board_hw_defs.c
@@ -250,17 +250,17 @@ static const struct pios_flash_sector_range stm32f4_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 3,
-		.sector_size = 16 * 1024,
+		.sector_size = FLASH_SECTOR_16KB,
 	},
 	{
 		.base_sector = 4,
 		.last_sector = 4,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 	{
 		.base_sector = 5,
 		.last_sector = 11,
-		.sector_size = 128 * 1024,
+		.sector_size = FLASH_SECTOR_128KB,
 	},
 
 };
@@ -280,6 +280,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 1,
+		.chip_offset  = 0,
+		.size         = (1 - 0 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	{
@@ -287,6 +289,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 2,
 		.last_sector  = 3,
+		.chip_offset  = (2 * FLASH_SECTOR_16KB),
+		.size         = (3 - 2 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	/* NOTE: sector 4 of internal flash is currently unallocated */
@@ -296,6 +300,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 5,
 		.last_sector  = 6,
+		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB),
+		.size         = (6 - 5 + 1) * FLASH_SECTOR_128KB,
 	},
 
 	/* NOTE: sectors 7-11 of the internal flash are currently unallocated */

--- a/flight/targets/board_hw_defs/flyingf3/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/flyingf3/board_hw_defs.c
@@ -608,7 +608,7 @@ static const struct pios_flash_sector_range stm32f3_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 127,
-		.sector_size = 2 * 1024,
+		.sector_size = FLASH_SECTOR_2KB,
 	},
 };
 
@@ -627,6 +627,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 7,
+		.chip_offset  = 0,
+		.size         = (7 - 0 + 1) * FLASH_SECTOR_2KB,
 	},
 
 	{
@@ -634,6 +636,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 8,
 		.last_sector  = 15,
+		.chip_offset  = (8 * FLASH_SECTOR_2KB),
+		.size         = (15 - 8 + 1) * FLASH_SECTOR_2KB,
 	},
 
 	{
@@ -641,6 +645,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 16,
 		.last_sector  = 23,
+		.chip_offset  = (16 * FLASH_SECTOR_2KB),
+		.size         = (23 - 16 + 1) * FLASH_SECTOR_2KB,
 	},
 
 	{
@@ -648,6 +654,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 24,
 		.last_sector  = 127,
+		.chip_offset  = (24 * FLASH_SECTOR_2KB),
+		.size         = (127 - 24 + 1) * FLASH_SECTOR_2KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/flyingf4/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/flyingf4/board_hw_defs.c
@@ -271,17 +271,17 @@ static const struct pios_flash_sector_range stm32f4_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 3,
-		.sector_size = 16 * 1024,
+		.sector_size = FLASH_SECTOR_16KB,
 	},
 	{
 		.base_sector = 4,
 		.last_sector = 4,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 	{
 		.base_sector = 5,
 		.last_sector = 11,
-		.sector_size = 128 * 1024,
+		.sector_size = FLASH_SECTOR_128KB,
 	},
 
 };
@@ -299,7 +299,7 @@ static const struct pios_flash_sector_range m25p16_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 31,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 };
 
@@ -318,6 +318,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 1,
+		.chip_offset  = 0,
+		.size         = (1 - 0 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	/* NOTE: sectors 2-4 of the internal flash are currently unallocated */
@@ -327,6 +329,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 5,
 		.last_sector  = 6,
+		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB),
+		.size         = (6 - 5 + 1) * FLASH_SECTOR_128KB,
 	},
 
 	/* NOTE: sectors 7-11 of the internal flash are currently unallocated */
@@ -336,6 +340,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 0,
 		.last_sector  = 15,
+		.chip_offset  = 0,
+		.size         = (15 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
@@ -343,6 +349,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 16,
 		.last_sector  = 31,
+		.chip_offset  = (16 * FLASH_SECTOR_64KB),
+		.size         = (31 - 16 + 1) * FLASH_SECTOR_64KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/freedom/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/freedom/board_hw_defs.c
@@ -555,17 +555,17 @@ static const struct pios_flash_sector_range stm32f4_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 3,
-		.sector_size = 16 * 1024,
+		.sector_size = FLASH_SECTOR_16KB,
 	},
 	{
 		.base_sector = 4,
 		.last_sector = 4,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 	{
 		.base_sector = 5,
 		.last_sector = 11,
-		.sector_size = 128 * 1024,
+		.sector_size = FLASH_SECTOR_128KB,
 	},
 
 };
@@ -583,7 +583,7 @@ static const struct pios_flash_sector_range m25p16_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 31,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 };
 
@@ -602,6 +602,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 1,
+		.chip_offset  = 0,
+		.size         = (1 - 0 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	/* NOTE: sectors 2-4 of the internal flash are currently unallocated */
@@ -611,6 +613,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 5,
 		.last_sector  = 6,
+		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB),
+		.size         = (6 - 5 + 1) * FLASH_SECTOR_128KB,
 	},
 
 	/* NOTE: sectors 7-11 of the internal flash are currently unallocated */
@@ -620,6 +624,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 0,
 		.last_sector  = 15,
+		.chip_offset  = 0,
+		.size         = (15 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
@@ -627,6 +633,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 16,
 		.last_sector  = 31,
+		.chip_offset  = (16 * FLASH_SECTOR_64KB),
+		.size         = (31 - 16 + 1) * FLASH_SECTOR_64KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/pipxtreme/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/pipxtreme/board_hw_defs.c
@@ -651,7 +651,7 @@ static const struct pios_flash_sector_range stm32f1_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 127,
-		.sector_size = 1 * 1024,
+		.sector_size = FLASH_SECTOR_1KB,
 	},
 };
 
@@ -670,6 +670,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 11,
+		.chip_offset  = 0,
+		.size         = (11 - 0 + 1) * FLASH_SECTOR_1KB,
 	},
 
 	{
@@ -677,6 +679,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 12,
 		.last_sector  = 111,
+		.chip_offset  = (12 * FLASH_SECTOR_1KB),
+		.size         = (111 - 12 + 1) * FLASH_SECTOR_1KB,
 	},
 
 	{
@@ -684,6 +688,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 112,
 		.last_sector  = 127,
+		.chip_offset  = (112 * FLASH_SECTOR_1KB),
+		.size         = (127 - 112 + 1) * FLASH_SECTOR_1KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/quanton/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/quanton/board_hw_defs.c
@@ -601,17 +601,17 @@ static const struct pios_flash_sector_range stm32f4_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 3,
-		.sector_size = 16 * 1024,
+		.sector_size = FLASH_SECTOR_16KB,
 	},
 	{
 		.base_sector = 4,
 		.last_sector = 4,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 	{
 		.base_sector = 5,
 		.last_sector = 11,
-		.sector_size = 128 * 1024,
+		.sector_size = FLASH_SECTOR_128KB,
 	},
 
 };
@@ -629,7 +629,7 @@ static const struct pios_flash_sector_range mx25_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 1023,
-		.sector_size = 4 * 1024,
+		.sector_size = FLASH_SECTOR_4KB,
 	},
 };
 
@@ -648,6 +648,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 1,
+		.chip_offset  = 0,
+		.size         = (1 - 0 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	/* NOTE: sectors 2-4 of the internal flash are currently unallocated */
@@ -657,6 +659,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 5,
 		.last_sector  = 6,
+		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB),
+		.size         = (6 - 5 + 1) * FLASH_SECTOR_128KB,
 	},
 
 	/* NOTE: sectors 7-11 of the internal flash are currently unallocated */
@@ -666,6 +670,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 0,
 		.last_sector  = 511,
+		.chip_offset  = 0,
+		.size         = (511 - 0 + 1) * FLASH_SECTOR_4KB,
 	},
 
 	{
@@ -673,6 +679,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 512,
 		.last_sector  = 1023,
+		.chip_offset  = (512 * FLASH_SECTOR_4KB),
+		.size         = (1023 - 512 + 1) * FLASH_SECTOR_4KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/revolution/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/revolution/board_hw_defs.c
@@ -486,17 +486,17 @@ static const struct pios_flash_sector_range stm32f4_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 3,
-		.sector_size = 16 * 1024,
+		.sector_size = FLASH_SECTOR_16KB,
 	},
 	{
 		.base_sector = 4,
 		.last_sector = 4,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 	{
 		.base_sector = 5,
 		.last_sector = 11,
-		.sector_size = 128 * 1024,
+		.sector_size = FLASH_SECTOR_128KB,
 	},
 
 };
@@ -514,7 +514,7 @@ static const struct pios_flash_sector_range m25p16_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 31,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 };
 
@@ -533,6 +533,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 1,
+		.chip_offset  = 0,
+		.size         = (1 - 0 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	/* NOTE: sectors 2-4 of the internal flash are currently unallocated */
@@ -542,6 +544,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 5,
 		.last_sector  = 6,
+		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB),
+		.size         = (6 - 5 + 1) * FLASH_SECTOR_128KB,
 	},
 
 	/* NOTE: sectors 7-11 of the internal flash are currently unallocated */
@@ -551,6 +555,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 0,
 		.last_sector  = 15,
+		.chip_offset  = 0,
+		.size         = (15 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
@@ -558,6 +564,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 16,
 		.last_sector  = 31,
+		.chip_offset  = (16 * FLASH_SECTOR_64KB),
+		.size         = (31 - 16 + 1) * FLASH_SECTOR_64KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/revomini/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/revomini/board_hw_defs.c
@@ -464,17 +464,17 @@ static const struct pios_flash_sector_range stm32f4_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 3,
-		.sector_size = 16 * 1024,
+		.sector_size = FLASH_SECTOR_16KB,
 	},
 	{
 		.base_sector = 4,
 		.last_sector = 4,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 	{
 		.base_sector = 5,
 		.last_sector = 11,
-		.sector_size = 128 * 1024,
+		.sector_size = FLASH_SECTOR_128KB,
 	},
 
 };
@@ -492,7 +492,7 @@ static const struct pios_flash_sector_range m25p16_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 31,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 };
 
@@ -511,6 +511,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 1,
+		.chip_offset  = 0,
+		.size         = (1 - 0 + 1) * FLASH_SECTOR_16KB,
 	},
 
 	/* NOTE: sectors 2-4 of the internal flash are currently unallocated */
@@ -520,6 +522,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 5,
 		.last_sector  = 6,
+		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB),
+		.size         = (6 - 5 + 1) * FLASH_SECTOR_128KB,
 	},
 
 	/* NOTE: sectors 7-11 of the internal flash are currently unallocated */
@@ -529,6 +533,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 0,
 		.last_sector  = 15,
+		.chip_offset  = 0,
+		.size         = (15 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
@@ -536,6 +542,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_external,
 		.first_sector = 16,
 		.last_sector  = 31,
+		.chip_offset  = (16 * FLASH_SECTOR_64KB),
+		.size         = (31 - 16 + 1) * FLASH_SECTOR_64KB,
 	},
 };
 

--- a/flight/targets/board_hw_defs/sparky/board_hw_defs.c
+++ b/flight/targets/board_hw_defs/sparky/board_hw_defs.c
@@ -333,7 +333,7 @@ static const struct pios_flash_sector_range stm32f3_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 127,
-		.sector_size = 2 * 1024,
+		.sector_size = FLASH_SECTOR_2KB,
 	},
 };
 
@@ -352,6 +352,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 0,
 		.last_sector  = 7,
+		.chip_offset  = 0,
+		.size         = (7 - 0 + 1) * FLASH_SECTOR_2KB,
 	},
 
 	{
@@ -359,6 +361,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 8,
 		.last_sector  = 15,
+		.chip_offset  = (8 * FLASH_SECTOR_2KB),
+		.size         = (15 - 8 + 1) * FLASH_SECTOR_2KB,
 	},
 
 	{
@@ -366,6 +370,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 16,
 		.last_sector  = 23,
+		.chip_offset  = (16 * FLASH_SECTOR_2KB),
+		.size         = (23 - 16 + 1) * FLASH_SECTOR_2KB,
 	},
 
 	{
@@ -373,6 +379,8 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 24,
 		.last_sector  = 127,
+		.chip_offset  = (24 * FLASH_SECTOR_2KB),
+		.size         = (127 - 24 + 1) * FLASH_SECTOR_2KB,
 	},
 };
 

--- a/flight/tests/logfs/unittest_init.c
+++ b/flight/tests/logfs/unittest_init.c
@@ -21,18 +21,18 @@ const struct flashfs_logfs_cfg flashfs_config_waypoints = {
 
 #include "pios_flash_posix_priv.h"
 
+#include "pios_flash_priv.h"
+
 const struct pios_flash_posix_cfg flash_config = {
 	.size_of_flash  = 3 * 1024 * 1024,
-	.size_of_sector = 64 * 1024,
+	.size_of_sector = FLASH_SECTOR_64KB,
 };
-
-#include "pios_flash_priv.h"
 
 static const struct pios_flash_sector_range posix_flash_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 47,
-		.sector_size = 64 * 1024,
+		.sector_size = FLASH_SECTOR_64KB,
 	},
 };
 
@@ -51,6 +51,8 @@ const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_posix,
 		.first_sector = 0,
 		.last_sector  = 31,
+		.chip_offset  = 0,
+		.size         = (31 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
@@ -58,6 +60,8 @@ const struct pios_flash_partition pios_flash_partition_table[] = {
 		.chip_desc    = &pios_flash_chip_posix,
 		.first_sector = 32,
 		.last_sector  = 47,
+		.chip_offset  = (32 * 64 * 1024),
+		.size         = (47 - 32 + 1) * FLASH_SECTOR_64KB,
 	},
 };
 


### PR DESCRIPTION
Computing the partition's extents within the chip's address space is
a relatively expensive operation and it was being done on every read
and write operation.

This per read/write cost slowed the initialization of the board
sufficiently that it was causing watchdog expiry leaving boards in
a reboot loop as the cost of traversing the logfs increased due to
an increase in the number of dirty file slots.

This has an unfortunate side-effect of requiring that all boards
express both the sector numbers as well as the byte offsets of the
start and end of each partition.  Since these values must agree,
they are still compared at runtime as a final precaution against
typos.
