### PR TITLE
Issue #384 : support all board channel banks update rates in GCS

### DIFF
--- a/ground/gcs/src/plugins/boards_openpilot/coptercontrol.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/coptercontrol.cpp
@@ -67,6 +67,12 @@ bool CopterControl::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList CopterControl::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-3" <<  "4" << "5,7-8" << "6,9-10");
+}
+
+
 QString CopterControl::shortName()
 {
     return QString("CopterControl");

--- a/ground/gcs/src/plugins/boards_openpilot/coptercontrol.h
+++ b/ground/gcs/src/plugins/boards_openpilot/coptercontrol.h
@@ -41,6 +41,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_openpilot/revolution.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revolution.cpp
@@ -78,6 +78,11 @@ bool Revolution::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList Revolution::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-2" << "3" << "4" << "5-6");
+}
+
 /**
  * @brief Revolution::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_openpilot/revolution.h
+++ b/ground/gcs/src/plugins/boards_openpilot/revolution.h
@@ -41,6 +41,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
@@ -78,6 +78,11 @@ bool RevoMini::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList RevoMini::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-2" << "3" << "4" << "5-6");
+}
+
 /**
  * @brief RevoMini::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_openpilot/revomini.h
+++ b/ground/gcs/src/plugins/boards_openpilot/revomini.h
@@ -41,6 +41,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_quantec/quanton.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.cpp
@@ -77,6 +77,12 @@ bool Quanton::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList Quanton::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-4" <<  "5-6" << "7" << "8");
+}
+
+
 /**
  * @brief Quanton::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_quantec/quanton.h
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.h
@@ -41,6 +41,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_stm/flyingf3.cpp
+++ b/ground/gcs/src/plugins/boards_stm/flyingf3.cpp
@@ -77,6 +77,12 @@ bool FlyingF3::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList FlyingF3::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-4" << "5-7" << "8-10" << "11");
+}
+
+
 /**
  * @brief FlyingF3::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_stm/flyingf3.h
+++ b/ground/gcs/src/plugins/boards_stm/flyingf3.h
@@ -41,6 +41,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_stm/flyingf4.cpp
+++ b/ground/gcs/src/plugins/boards_stm/flyingf4.cpp
@@ -77,6 +77,12 @@ bool FlyingF4::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList FlyingF4::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-4" << "5-8");
+}
+
+
 /**
  * @brief FlyingF4::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_stm/flyingf4.h
+++ b/ground/gcs/src/plugins/boards_stm/flyingf4.h
@@ -41,6 +41,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_taulabs/freedom.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/freedom.cpp
@@ -76,6 +76,12 @@ bool Freedom::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList Freedom::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-2" << "3-4" << "6-7");
+}
+
+
 /**
  * @brief Freedom::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_taulabs/freedom.h
+++ b/ground/gcs/src/plugins/boards_taulabs/freedom.h
@@ -40,6 +40,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
@@ -83,6 +83,11 @@ bool Sparky::queryCapabilities(BoardCapabilities capability)
     return false;
 }
 
+QStringList Sparky::queryChannelBanks()
+{
+    return QStringList(QStringList() << "1-2" << "3" << "4,7,9" << "5" << "6,10" << "8");
+}
+
 /**
  * @brief Sparky::getSupportedProtocols
  *  TODO: this is just a stub, we'll need to extend this a lot with multi protocol support

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.h
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.h
@@ -40,6 +40,7 @@ public:
     virtual QString shortName();
     virtual QString boardDescription();
     virtual bool queryCapabilities(BoardCapabilities capability);
+    virtual QStringList queryChannelBanks();
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -263,143 +263,38 @@ void ConfigOutputWidget::refreshWidgetsValues(UAVObject * obj)
     // Get the SpinWhileArmed setting
     m_config->spinningArmed->setChecked(actuatorSettingsData.MotorsSpinWhileArmed == ActuatorSettings::MOTORSSPINWHILEARMED_TRUE);
 
-    // Get Output rates for both banks
-    if(m_config->cb_outputRate1->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[0]))==-1)
-    {
-        m_config->cb_outputRate1->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[0]));
-    }
-    if(m_config->cb_outputRate2->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[1]))==-1)
-    {
-        m_config->cb_outputRate2->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[1]));
-    }
-    m_config->cb_outputRate1->setCurrentIndex(m_config->cb_outputRate1->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[0])));
-    m_config->cb_outputRate2->setCurrentIndex(m_config->cb_outputRate2->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[1])));
-
+    // Get Output rates for all channel banks
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     Q_ASSERT(pm);
     UAVObjectUtilManager* utilMngr = pm->getObject<UAVObjectUtilManager>();
     if (utilMngr) {
-        int board = utilMngr->getBoardModel();
-        if ((board & 0xff00) == 1024) {
-            // CopterControl family
-            m_config->chBank1->setText("1-3");
-            m_config->chBank2->setText("4");
-            m_config->chBank3->setText("5,7-8");
-            m_config->chBank4->setText("6,9-10");
-            m_config->cb_outputRate1->setEnabled(true);
-            m_config->cb_outputRate2->setEnabled(true);
-            m_config->cb_outputRate3->setEnabled(true);
-            m_config->cb_outputRate4->setEnabled(true);
-            if(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]))==-1)
-            {
-                m_config->cb_outputRate3->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]));
+        Core::IBoardType *board = utilMngr->getBoardType();
+        if (board != NULL) {
+            QStringList banks = board->queryChannelBanks();
+            QList<QLabel*> lblList;
+            lblList << m_config->chBank1 << m_config->chBank2 << m_config->chBank3 << m_config->chBank4
+                       << m_config->chBank5 << m_config->chBank6;
+            QList<QComboBox*> cmbList;
+            cmbList << m_config->cb_outputRate1 << m_config->cb_outputRate2 << m_config->cb_outputRate3
+                       << m_config->cb_outputRate4 << m_config->cb_outputRate5 << m_config->cb_outputRate6;
+
+            // First reset & disable all channel fields/outputs, then repopulate (because
+            // we might be for instance connecting various board types one after another)
+            for (int i=0; i < 6; i++) {
+                lblList.at(i)->setText("-");
+                cmbList.at(i)->setEnabled(false);
             }
-            if(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]))==-1)
-            {
-                m_config->cb_outputRate4->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]));
+
+            // Now repopulate based on board capabilities:
+            for (int i=0; i < banks.length(); i++) {
+                lblList.at(i)->setText(banks.at(i));
+                QComboBox* ccmb = cmbList.at(i);
+                ccmb->setEnabled(true);
+                if (ccmb->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[i]))==-1) {
+                    ccmb->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[i]));
+                }
+                ccmb->setCurrentIndex(ccmb->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[i])));
             }
-            m_config->cb_outputRate3->setCurrentIndex(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2])));
-            m_config->cb_outputRate4->setCurrentIndex(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3])));
-        } else if ((board & 0xff00) == 0x0900 ) {
-            // Revolution/RevoMini family
-            m_config->cb_outputRate1->setEnabled(true);
-            m_config->cb_outputRate2->setEnabled(true);
-            m_config->cb_outputRate3->setEnabled(true);
-            m_config->cb_outputRate4->setEnabled(true);
-            m_config->chBank1->setText("1-2");
-            m_config->chBank2->setText("3");
-            m_config->chBank3->setText("4");
-            m_config->chBank4->setText("5-6");
-            if(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]))==-1)
-            {
-                m_config->cb_outputRate3->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]));
-            }
-            if(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]))==-1)
-            {
-                m_config->cb_outputRate4->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]));
-            }
-            m_config->cb_outputRate3->setCurrentIndex(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2])));
-            m_config->cb_outputRate4->setCurrentIndex(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3])));
-        } else if ((board & 0xff00) == 0x8100 ) {
-            // Freedom
-            m_config->cb_outputRate1->setEnabled(true);
-            m_config->cb_outputRate2->setEnabled(true);
-            m_config->cb_outputRate3->setEnabled(true);
-            m_config->cb_outputRate4->setEnabled(true);
-            m_config->chBank1->setText("1-2");
-            m_config->chBank2->setText("3");
-            m_config->chBank3->setText("4-5");
-            m_config->chBank4->setText("6");
-            if(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]))==-1)
-            {
-                m_config->cb_outputRate3->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]));
-            }
-            if(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]))==-1)
-            {
-                m_config->cb_outputRate4->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]));
-            }
-            m_config->cb_outputRate3->setCurrentIndex(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2])));
-            m_config->cb_outputRate4->setCurrentIndex(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3])));
-        } else if ((board & 0xff00) == 0x8200 ) {
-            // FlyingF3
-            m_config->cb_outputRate1->setEnabled(true);
-            m_config->cb_outputRate2->setEnabled(true);
-            m_config->cb_outputRate3->setEnabled(true);
-            m_config->cb_outputRate4->setEnabled(true);
-            m_config->chBank1->setText("1-4");
-            m_config->chBank2->setText("5-7");
-            m_config->chBank3->setText("8-10");
-            m_config->chBank4->setText("11");
-            if(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]))==-1)
-            {
-                m_config->cb_outputRate3->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]));
-            }
-            if(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]))==-1)
-            {
-                m_config->cb_outputRate4->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]));
-            }
-            m_config->cb_outputRate3->setCurrentIndex(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2])));
-            m_config->cb_outputRate4->setCurrentIndex(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3])));
-        } else if ((board & 0xff00) == 0x8600 ) {
-            // Quanton
-            m_config->cb_outputRate1->setEnabled(true);
-            m_config->cb_outputRate2->setEnabled(true);
-            m_config->cb_outputRate3->setEnabled(true);
-            m_config->cb_outputRate4->setEnabled(true);
-            m_config->chBank1->setText("1-4");
-            m_config->chBank2->setText("5-6");
-            m_config->chBank3->setText("7");
-            m_config->chBank4->setText("8");
-            if(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]))==-1)
-            {
-                m_config->cb_outputRate3->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]));
-            }
-            if(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]))==-1)
-            {
-                m_config->cb_outputRate4->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]));
-            }
-            m_config->cb_outputRate3->setCurrentIndex(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2])));
-            m_config->cb_outputRate4->setCurrentIndex(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3])));
-        } else {
-            // Unknown
-            m_config->cb_outputRate1->setEnabled(true);
-            m_config->cb_outputRate2->setEnabled(true);
-            m_config->cb_outputRate3->setEnabled(true);
-            m_config->cb_outputRate4->setEnabled(true);
-            m_config->chBank1->setText("?");
-            m_config->chBank2->setText("?");
-            m_config->chBank3->setText("?");
-            m_config->chBank4->setText("?");
-            if(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]))==-1)
-            {
-                m_config->cb_outputRate3->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[2]));
-            }
-            if(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]))==-1)
-            {
-                m_config->cb_outputRate4->addItem(QString::number(actuatorSettingsData.ChannelUpdateFreq[3]));
-            }
-            m_config->cb_outputRate3->setCurrentIndex(m_config->cb_outputRate3->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[2])));
-            m_config->cb_outputRate4->setCurrentIndex(m_config->cb_outputRate4->findText(QString::number(actuatorSettingsData.ChannelUpdateFreq[3])));
         }
     }
 
@@ -441,6 +336,8 @@ void ConfigOutputWidget::updateObjectsFromWidgets()
         actuatorSettingsData.ChannelUpdateFreq[1] = m_config->cb_outputRate2->currentText().toUInt();
         actuatorSettingsData.ChannelUpdateFreq[2] = m_config->cb_outputRate3->currentText().toUInt();
         actuatorSettingsData.ChannelUpdateFreq[3] = m_config->cb_outputRate4->currentText().toUInt();
+        actuatorSettingsData.ChannelUpdateFreq[4] = m_config->cb_outputRate5->currentText().toUInt();
+        actuatorSettingsData.ChannelUpdateFreq[5] = m_config->cb_outputRate6->currentText().toUInt();
 
         if(m_config->spinningArmed->isChecked() == true)
             actuatorSettingsData.MotorsSpinWhileArmed = ActuatorSettings::MOTORSSPINWHILEARMED_TRUE;

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -144,28 +144,22 @@
              <property name="title">
               <string>Output Update Speed</string>
              </property>
-             <layout class="QGridLayout" name="gridLayout">
+             <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0,0,0,0,0">
               <property name="horizontalSpacing">
                <number>6</number>
               </property>
               <property name="margin">
                <number>12</number>
               </property>
-              <item row="0" column="0">
-               <spacer name="horizontalSpacer_3">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+              <item row="0" column="7">
+               <widget class="QLabel" name="chBank6">
+                <property name="text">
+                 <string>-</string>
                 </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Minimum</enum>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>5</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
+               </widget>
               </item>
               <item row="0" column="1">
                <widget class="QLabel" name="label_9">
@@ -222,34 +216,6 @@
                  <set>Qt::AlignCenter</set>
                 </property>
                </widget>
-              </item>
-              <item row="1" column="0">
-               <spacer name="horizontalSpacer_4">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>20</height>
-                 </size>
-                </property>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Minimum</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>5</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
               <item row="1" column="1">
                <widget class="QLabel" name="label_3">
@@ -395,6 +361,16 @@ Leave at 50Hz for fixed wing.</string>
                 </item>
                </widget>
               </item>
+              <item row="0" column="6">
+               <widget class="QLabel" name="chBank5">
+                <property name="text">
+                 <string>-</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="4">
                <widget class="QComboBox" name="cb_outputRate3">
                 <property name="enabled">
@@ -510,6 +486,167 @@ Leave at 50Hz for fixed wing.</string>
                  </property>
                 </item>
                </widget>
+              </item>
+              <item row="1" column="7">
+               <widget class="QComboBox" name="cb_outputRate6">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>50</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>60</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>125</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>165</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>270</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>330</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>400</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="1" column="6">
+               <widget class="QComboBox" name="cb_outputRate5">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="editable">
+                 <bool>false</bool>
+                </property>
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>50</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>60</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>125</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>165</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>270</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>330</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>400</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="0" column="8">
+               <spacer name="horizontalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Minimum</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>5</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="8">
+               <spacer name="horizontalSpacer_4">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Minimum</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>5</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
              </layout>
             </widget>

--- a/ground/gcs/src/plugins/coreplugin/iboardtype.h
+++ b/ground/gcs/src/plugins/coreplugin/iboardtype.h
@@ -90,9 +90,18 @@ public:
                             BOARD_CAPABILITIES_MAGS, BOARD_CAPABILITIES_BAROS,
                             BOARD_CAPABILITIES_RADIO};
     /**
-     * Query capabilities of the board
+     * @brief Query capabilities of the board.
+     * @return true if board supports the capability that is requested (from BoardCapabilities)
+     *
      */
     virtual bool queryCapabilities(BoardCapabilities capability) = 0;
+
+    /**
+     * @brief Query number & names of output PWM channels banks on the board
+     * @return list of channel bank names
+     *
+     */
+    virtual QStringList queryChannelBanks() { return QStringList(); }
 
     /**
      * @brief getBoardPicture
@@ -112,9 +121,8 @@ public:
     virtual QStringList getSupportedProtocols() = 0;
 
     /**
-     * Get supported protocol(s) for this board
+     * Get name of the HW Configuration UAVObject
      *
-     * TODO: extend GCS to support multiple protocol types.
      */
     virtual QString getHwUAVO() = 0;
 

--- a/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
@@ -444,6 +444,9 @@ FirmwareIAPObj::DataFields UAVObjectUtilManager::getFirmwareIap()
 /**
   * Get the UAV Board model, for anyone interested. Return format is:
   * (Board Type << 8) + BoardRevision.
+  *
+  *  NOTE: Should get deprecated as a public method now, in favour
+  *  of getBoardType and subsequent board capability queries.
   */
 int UAVObjectUtilManager::getBoardModel()
 {


### PR DESCRIPTION
Each boards maps output channels by banks (up to 6) for update rate settings.
GCS used hardcoded values in the config widget, all board-specific values are
now moved to board plugins, and the config gadget queries the board for the
mappings.

Please confirm mapping for Sparky is correct.
