### PR TITLE
logfs: always pack enums that are used in packed structs

### DIFF
--- a/flight/PiOS/Common/pios_flashfs_logfs.c
+++ b/flight/PiOS/Common/pios_flashfs_logfs.c
@@ -97,7 +97,7 @@ enum arena_state {
 	ARENA_STATE_RESERVED = 0xE6E6FFFF,
 	ARENA_STATE_ACTIVE   = 0xE6E66666,
 	ARENA_STATE_OBSOLETE = 0x00000000,
-};
+} __attribute__((packed));
 
 struct arena_header {
 	uint32_t magic;
@@ -326,7 +326,7 @@ enum slot_state {
 	SLOT_STATE_RESERVED = 0xFAFAFFFF,
 	SLOT_STATE_ACTIVE   = 0xFAFAAAAA,
 	SLOT_STATE_OBSOLETE = 0x00000000,
-};
+} __attribute__((packed));
 
 struct slot_header {
 	enum slot_state state;


### PR DESCRIPTION
Failing to follow this rule can result in the sizes of the
enum outside of the struct and the ones within the struct
to be different sizes.  This is confusing and can lead to
subtle bugs.
