### PR TITLE
sim sensors: avoid divide by zero in magOffsetEstimation

### DIFF
--- a/flight/Modules/Sensors/simulated/sensors.c
+++ b/flight/Modules/Sensors/simulated/sensors.c
@@ -1183,15 +1183,17 @@ static void magOffsetEstimation(MagnetometerData *mag)
 	xy[1] = -sy * B_e[0] + cy * B_e[1];
 	
 	float xy_norm = sqrtf(xy[0]*xy[0] + xy[1]*xy[1]);
-	
-	delta[0] = -rate * (xy[0] / xy_norm * Rxy - xy[0]);
-	delta[1] = -rate * (xy[1] / xy_norm * Rxy - xy[1]);
-	delta[2] = -rate * (Rz - B_e[2]);
-	
-	magBias.x += delta[0];
-	magBias.y += delta[1];
-	magBias.z += delta[2];
-	MagBiasSet(&magBias);
+
+	if (xy_norm > 0) {
+		delta[0] = -rate * (xy[0] / xy_norm * Rxy - xy[0]);
+		delta[1] = -rate * (xy[1] / xy_norm * Rxy - xy[1]);
+		delta[2] = -rate * (Rz - B_e[2]);
+
+		magBias.x += delta[0];
+		magBias.y += delta[1];
+		magBias.z += delta[2];
+		MagBiasSet(&magBias);
+	}
 #endif
 
 }


### PR DESCRIPTION
magOffsetEstimation() does a divide by zero when computing delta[0] and delta[1] when:

```
(gdb) p attitude
$28 = {q1 = 1, q2 = 0, q3 = 0, q4 = 0, Roll = 0, Pitch = 0, Yaw = 0}
(gdb) p homeLocation
$29 = {Latitude = 0, Longitude = 0, Altitude = 0, Be = {0, 0, 0}, SeaLevelPressure = 1013, Set = 0 '\000', GroundTemperature = 15 '\017'}
(gdb) p magBias
$30 = {x = 0, y = 0, z = 0}
```

This skips the computation of magBias when `xy_norm == 0` to avoid the nan in magBias.
