### PR TITLE
gdb: add config config files for missing targets

### DIFF
--- a/flight/Project/gdb/bl_freedom
+++ b/flight/Project/gdb/bl_freedom
@@ -1,0 +1,4 @@
+define connect
+	target remote localhost:3333
+	file ./build/bl_freedom/bl_freedom.elf
+end

--- a/flight/Project/gdb/bl_pipxtreme
+++ b/flight/Project/gdb/bl_pipxtreme
@@ -1,0 +1,38 @@
+define connect
+	target remote localhost:3333
+	monitor cortex_m3 vector_catch all
+	file ./build/bl_pipxtreme/bl_pipxtreme.elf
+end
+#monitor reset halt
+
+define hook-step
+	monitor cortex_m3 maskisr on
+end
+define hookpost-step
+	monitor cortex_m3 maskisr off
+end
+
+define hook-stepi
+	monitor cortex_m3 maskisr on
+end
+
+define hookpost-stepi
+	monitor cortex_m3 maskisr off
+end
+
+define hook-next
+	monitor cortex_m3 maskisr on
+end
+
+define hookpost-next
+	monitor cortex_m3 maskisr off
+end
+
+define hook-finish
+	monitor cortex_m3 maskisr on
+end
+
+define hookpost-finish
+	monitor cortex_m3 maskisr off
+end
+

--- a/flight/Project/gdb/bl_quanton
+++ b/flight/Project/gdb/bl_quanton
@@ -1,0 +1,4 @@
+define connect
+	target remote localhost:3333
+	file ./build/bl_quanton/bl_quanton.elf
+end

--- a/flight/Project/gdb/bl_sparky
+++ b/flight/Project/gdb/bl_sparky
@@ -1,0 +1,4 @@
+define connect
+	target remote localhost:3333
+	file ./build/bl_sparky/bl_sparky.elf
+end

--- a/flight/Project/gdb/freedom
+++ b/flight/Project/gdb/freedom
@@ -1,0 +1,4 @@
+define connect
+	target remote localhost:3333
+	file ./build/fw_freedom/fw_freedom.elf
+end

--- a/flight/Project/gdb/pipxtreme
+++ b/flight/Project/gdb/pipxtreme
@@ -1,7 +1,7 @@
 define connect
 	target remote localhost:3333
 	monitor cortex_m3 vector_catch all
-	file ./Build/PipXtreme.elf
+	file ./build/fw_pipxtreme/fw_pipxtreme.elf
 end
 #monitor reset halt
 

--- a/flight/Project/gdb/quanton
+++ b/flight/Project/gdb/quanton
@@ -1,0 +1,4 @@
+define connect
+	target remote localhost:3333
+	file ./build/fw_quanton/fw_quanton.elf
+end

--- a/flight/Project/gdb/sparky
+++ b/flight/Project/gdb/sparky
@@ -1,0 +1,4 @@
+define connect
+	target remote localhost:3333
+	file ./build/fw_sparky/fw_sparky.elf
+end


### PR DESCRIPTION
Some targets were missing gdb config files for bl and fw.  pipxtreme config file didn't match the official board name.
