### PR TITLE
watchdog: clear wdg backup register during init

### DIFF
--- a/flight/PiOS/STM32F10x/pios_wdg.c
+++ b/flight/PiOS/STM32F10x/pios_wdg.c
@@ -72,9 +72,13 @@ uint16_t PIOS_WDG_Init()
 
 	// watchdog flags now stored in backup registers
 	PWR_BackupAccessCmd(ENABLE);
-	
-	BKP_WriteBackupRegister(PIOS_WDG_REGISTER, 0x0);
 	wdg_configuration.bootup_flags = BKP_ReadBackupRegister(PIOS_WDG_REGISTER);
+
+	/*
+	 * Start from an empty set of registered flags so previous boots
+	 * can't influence the current one
+	 */
+	BKP_WriteBackupRegister(PIOS_WDG_REGISTER, 0);
 #endif
 	return delay;
 }

--- a/flight/PiOS/STM32F30x/pios_wdg.c
+++ b/flight/PiOS/STM32F30x/pios_wdg.c
@@ -78,8 +78,14 @@ uint16_t PIOS_WDG_Init()
 
 	// watchdog flags now stored in backup registers
 	PWR_BackupAccessCmd(ENABLE);
-	
+
 	wdg_configuration.bootup_flags = RTC_ReadBackupRegister(PIOS_WDG_REGISTER);
+
+	/*
+	 * Start from an empty set of registered flags so previous boots
+	 * can't influence the current one
+	 */
+	RTC_WriteBackupRegister(PIOS_WDG_REGISTER, 0);
 #endif
 	return delay;
 }

--- a/flight/PiOS/STM32F4xx/pios_wdg.c
+++ b/flight/PiOS/STM32F4xx/pios_wdg.c
@@ -77,8 +77,14 @@ uint16_t PIOS_WDG_Init()
 
 	// watchdog flags now stored in backup registers
 	PWR_BackupAccessCmd(ENABLE);
-	
+
 	wdg_configuration.bootup_flags = RTC_ReadBackupRegister(PIOS_WDG_REGISTER);
+
+	/*
+	 * Start from an empty set of registered flags so previous boots
+	 * can't influence the current one
+	 */
+	RTC_WriteBackupRegister(PIOS_WDG_REGISTER, 0);
 #endif
 	return delay;
 }


### PR DESCRIPTION
Using the PIOS_WDG_REGISTER slot in the backup registers is
a useful debug tool but it is important to ensure that this
state cannot influence the watchdog behaviour on future reboots.

Specifically, if a future boot removes one of the modules that
was previously watched by the watchdog, we don't want that
removal to endlessly trigger a watchdog.

F1 variant was actually clearing the flag, but was actually
doing it _before_ caching the value for debug purposes.  F3/F4
variants were carrying state across a reboot which is bad for
the reasons listed above.
