### PR TITLE
module init: kick the watchdog between module init calls

### DIFF
--- a/flight/PiOS.osx/inc/pios_initcall.h
+++ b/flight/PiOS.osx/inc/pios_initcall.h
@@ -8,6 +8,7 @@
  *
  * @file       pios_initcall.h  
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
  * @brief      Initcall header
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -58,7 +59,7 @@ extern void StartModules();
 	StartModules(); \
 	}
 
-#define MODULE_INITIALISE_ALL { \
+#define MODULE_INITIALISE_ALL(wdgfn) {		\
 	/* Initialize modules */ \
 	InitModules(); \
 	/* Initialize the system thread */ \

--- a/flight/PiOS.posix/inc/pios_initcall.h
+++ b/flight/PiOS.posix/inc/pios_initcall.h
@@ -8,6 +8,7 @@
  *
  * @file       pios_initcall.h  
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
  * @brief      Initcall header
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -58,7 +59,7 @@ extern void StartModules();
 	StartModules(); \
 	}
 
-#define MODULE_INITIALISE_ALL { \
+#define MODULE_INITIALISE_ALL(wdgfn) {		\
 	/* Initialize modules */ \
 	InitModules(); \
 	/* Initialize the system thread */ \

--- a/flight/PiOS/inc/pios_initcall.h
+++ b/flight/PiOS/inc/pios_initcall.h
@@ -8,6 +8,7 @@
  *
  * @file       pios_initcall.h  
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
  * @brief      Initcall header
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -69,9 +70,13 @@ extern initmodule_t __module_initcall_start[], __module_initcall_end[];
 
 #define MODULE_INITCALL(ifn, sfn)		__define_module_initcall("module", ifn, sfn)
 
-#define MODULE_INITIALISE_ALL  { for (initmodule_t *fn = __module_initcall_start; fn < __module_initcall_end; fn++) \
-									if (fn->fn_minit) \
-										(fn->fn_minit)(); }
+#define MODULE_INITIALISE_ALL(wdgfn)  { \
+		for (initmodule_t *fn = __module_initcall_start; fn < __module_initcall_end; fn++) { \
+			if (fn->fn_minit)				\
+				(fn->fn_minit)();			\
+			(wdgfn)();					\
+		}							\
+	}
 
 #define MODULE_TASKCREATE_ALL  { for (initmodule_t *fn = __module_initcall_start; fn < __module_initcall_end; fn++) \
 									if (fn->fn_tinit) \

--- a/flight/targets/CopterControl/System/coptercontrol.c
+++ b/flight/targets/CopterControl/System/coptercontrol.c
@@ -76,7 +76,7 @@ int main()
 #endif
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* swap the stack to use the IRQ stack */
 	Stack_Change();

--- a/flight/targets/DiscoveryF4/System/discoveryf4.c
+++ b/flight/targets/DiscoveryF4/System/discoveryf4.c
@@ -112,7 +112,7 @@ initTask(void *parameters)
 #endif
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* terminate this task */
 	vTaskDelete(NULL);

--- a/flight/targets/FlyingF3/System/flyingf3.c
+++ b/flight/targets/FlyingF3/System/flyingf3.c
@@ -104,7 +104,7 @@ initTask(void *parameters)
 	PIOS_Board_Init();
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* terminate this task */
 	vTaskDelete(NULL);

--- a/flight/targets/FlyingF4/System/flyingf4.c
+++ b/flight/targets/FlyingF4/System/flyingf4.c
@@ -104,7 +104,7 @@ initTask(void *parameters)
 	PIOS_Board_Init();
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* terminate this task */
 	vTaskDelete(NULL);

--- a/flight/targets/Freedom/System/freedom.c
+++ b/flight/targets/Freedom/System/freedom.c
@@ -102,10 +102,10 @@ initTask(void *parameters)
 {
 	/* board driver init */
 	PIOS_Board_Init();
-	
+
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
-	
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
+
 	/* terminate this task */
 	vTaskDelete(NULL);
 }

--- a/flight/targets/PipXtreme/System/pipxtreme.c
+++ b/flight/targets/PipXtreme/System/pipxtreme.c
@@ -67,7 +67,7 @@ int main()
 	PIOS_Board_Init();
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* swap the stack to use the IRQ stack */
 	Stack_Change();

--- a/flight/targets/Quanton/System/quanton.c
+++ b/flight/targets/Quanton/System/quanton.c
@@ -104,7 +104,7 @@ initTask(void *parameters)
 	PIOS_Board_Init();
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* terminate this task */
 	vTaskDelete(NULL);

--- a/flight/targets/RevoMini/System/revolution.c
+++ b/flight/targets/RevoMini/System/revolution.c
@@ -103,10 +103,10 @@ initTask(void *parameters)
 {
 	/* board driver init */
 	PIOS_Board_Init();
-	
+
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
-	
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
+
 	/* terminate this task */
 	vTaskDelete(NULL);
 }

--- a/flight/targets/Revolution/System/revolution.c
+++ b/flight/targets/Revolution/System/revolution.c
@@ -103,10 +103,10 @@ initTask(void *parameters)
 {
 	/* board driver init */
 	PIOS_Board_Init();
-	
+
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
-	
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
+
 	/* terminate this task */
 	vTaskDelete(NULL);
 }

--- a/flight/targets/Sparky/System/sparky.c
+++ b/flight/targets/Sparky/System/sparky.c
@@ -106,7 +106,7 @@ initTask(void *parameters)
 	PIOS_Board_Init();
 
 	/* Initialize modules */
-	MODULE_INITIALISE_ALL;
+	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
 	/* terminate this task */
 	vTaskDelete(NULL);


### PR DESCRIPTION
This kicks the watchdog after each module init call.

Currently, our entire module init sequence must execute in less than the watchdog timeout.  That could (eventually) result in certain sets of enabled modules triggering the watchdog expiry which could be very difficult to debug.

Now, each module has a full watchdog time to execute so we remove the arbitrary limit on the _total_ init time being lower than the watchdog expiry time.
