### PR TITLE
Remove unused ChannelAddress field from ActuatorSettings UAVO.

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -677,18 +677,18 @@ static bool set_channel(uint8_t mixer_channel, uint16_t value, const ActuatorSet
                                     lastSysTime = thisSysTime;
                             }
 			}
-			PIOS_Servo_Set(actuatorSettings->ChannelAddr[mixer_channel],
-							buzzOn?actuatorSettings->ChannelMax[mixer_channel]:actuatorSettings->ChannelMin[mixer_channel]);
+			PIOS_Servo_Set(mixer_channel,
+							buzzOn ? actuatorSettings->ChannelMax[mixer_channel] : actuatorSettings->ChannelMin[mixer_channel]);
 			return true;
 		}
 		case ACTUATORSETTINGS_CHANNELTYPE_PWM:
-			PIOS_Servo_Set(actuatorSettings->ChannelAddr[mixer_channel], value);
+			PIOS_Servo_Set(mixer_channel, value);
 			return true;
 #if defined(PIOS_INCLUDE_I2C_ESC)
 		case ACTUATORSETTINGS_CHANNELTYPE_MK:
-			return PIOS_SetMKSpeed(actuatorSettings->ChannelAddr[mixer_channel],value);
+			return PIOS_SetMKSpeed(mixer_channel, value);
 		case ACTUATORSETTINGS_CHANNELTYPE_ASTEC4:
-			return PIOS_SetAstec4Speed(actuatorSettings->ChannelAddr[mixer_channel],value);
+			return PIOS_SetAstec4Speed(mixer_channel, value);
 			break;
 #endif
 		default:

--- a/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
+++ b/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
@@ -118,8 +118,7 @@ ConfigVehicleTypeWidget::ConfigVehicleTypeWidget(QWidget *parent) : ConfigTaskWi
 
     //Generate lists of mixerTypeNames, mixerVectorNames, channelNames
     channelNames << "None";
-    for (int i = 0; i < (int)ActuatorSettings::CHANNELADDR_NUMELEM; i++) {
-
+    for (int i = 0; i < (int)ActuatorSettings::CHANNELTYPE_NUMELEM; i++) {
         mixerTypes << QString("Mixer%1Type").arg(i+1);
         mixerVectors << QString("Mixer%1Vector").arg(i+1);
         channelNames << QString("Channel%1").arg(i+1);

--- a/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -183,7 +183,6 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
         QList<actuatorChannelSettings> actuatorSettings = m_configSource->getActuatorSettings();
         for (quint16 i = 0; i < ActuatorSettings::CHANNELMAX_NUMELEM; i++) {
             data.ChannelType[i]    = ActuatorSettings::CHANNELTYPE_PWM;
-            data.ChannelAddr[i]    = i;
             data.ChannelMin[i]     = actuatorSettings[i].channelMin;
             data.ChannelNeutral[i] = actuatorSettings[i].channelNeutral;
             data.ChannelMax[i]     = actuatorSettings[i].channelMax;

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -6,7 +6,6 @@
         <field name="ChannelNeutral" units="us" type="int16" elements="10" defaultvalue="1000"/>
         <field name="ChannelMin" units="us" type="int16" elements="10" defaultvalue="1000"/>
         <field name="ChannelType" units="" type="enum" elements="10" options="PWM,MK,ASTEC4,PWM Alarm Buzzer,Arming led,Info led" defaultvalue="PWM"/>
-        <field name="ChannelAddr" units="" type="uint8" elements="10" defaultvalue="0,1,2,3,4,5,6,7,8,9"/>
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
It was first introduced in b173d74821e229ce4f57400f91e7ffb67db0b571 but was never used.
