### PR TITLE
Changed VibratonAnalysisOutput update mode to throttled.

### DIFF
--- a/shared/uavobjectdefinition/vibrationanalysisoutput.xml
+++ b/shared/uavobjectdefinition/vibrationanalysisoutput.xml
@@ -8,7 +8,7 @@
         <field name="z" units="m/s^2" type="float" elements="1"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
-        <telemetryflight acked="false" updatemode="manual" period="1000"/>
+        <telemetryflight acked="false" updatemode="throttled" period="1000"/>
         <logging updatemode="manual" period="0"/>
     </object>
 </xml>


### PR DESCRIPTION
This addresses a problem where the UAVO would have to be set to throttled when the user wanted to perform a vibration analysis.
