### PR TITLE
EntireFlash: make work on OSX

### DIFF
--- a/flight/targets/EntireFlash/Makefile
+++ b/flight/targets/EntireFlash/Makefile
@@ -47,13 +47,13 @@ FWINFO_BIN := $(FW_BIN).firmwareinfo.bin
 FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(BL_BANK_BASE)-$(BL_BANK_SIZE)])
 $(OUTDIR)/$(TARGET).fw_pre.pad: FORCE
 	$(V0) @echo $(MSG_PADDING) $(call toprel, $@)
-	$(V1) dd if=/dev/zero count=$(FW_PRE_PAD) bs=1 2> /dev/null | tr '\000' '\377' > $@ && [ $${PIPESTATUS[0]} -eq "0" ]
+	$(V1) dd if=/dev/zero count=$(FW_PRE_PAD) bs=1 2> /dev/null | LC_CTYPE=c tr '\000' '\377' > $@ && [ $${PIPESTATUS[0]} -eq "0" ]
 
 # force this target as FW_POST_PAD could have been changed without us knowing
 FW_POST_PAD := $(shell echo $$[$(FW_BANK_SIZE)-$(FW_DESC_SIZE)-$(FW_DESC_SIZE)-$(shell wc -c < $(FW_BIN))])
 $(OUTDIR)/$(TARGET).fw_post.pad: FORCE
 	$(V0) @echo $(MSG_PADDING) $(call toprel, $@)
-	$(V1) dd if=/dev/zero count=$(FW_POST_PAD) bs=1 2> /dev/null | tr '\000' '\377' > $@ && [ $${PIPESTATUS[0]} -eq "0" ]
+	$(V1) dd if=/dev/zero count=$(FW_POST_PAD) bs=1 2> /dev/null | LC_CTYPE=c tr '\000' '\377' > $@ && [ $${PIPESTATUS[0]} -eq "0" ]
 
 # force this target as $(BL_BIN), $(FW_BIN) and $(FWINFO_BIN) could have been changed without us knowing
 # add $(FWINFO_BIN) after $(FW_BIN) to imitate flash contents after manual firmware upload via gcs


### PR DESCRIPTION
The tr '\000' '\377' command on OSX for some reason increases
the size of the file generated.  It also doesn't produce the
desired output.  Doing this means the ef_ file won't produce
identical flash to using the uploader but does run fine.
