### PR TITLE
Show new instances of multi-instance objects immediately upon creation.

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
@@ -187,11 +187,8 @@ void UAVObjectTreeModel::addInstance(UAVObject *obj, TreeItem *parent)
         item->setHighlightManager(m_highlightManager);
         connect(item, SIGNAL(updateHighlight(TreeItem*)), this, SLOT(updateHighlight(TreeItem*)));
 
-        ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-        UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
-
         // Inform the model that we will add a row
-        beginInsertRows(index(parent), objManager->getNumInstances(obj->getObjID()), objManager->getNumInstances(obj->getObjID()));
+        beginInsertRows(index(parent), parent->childCount(), parent->childCount());
 
         // Add the row
         parent->appendChild(item);


### PR DESCRIPTION
As per https://github.com/TauLabs/TauLabs/issues/342, the UAVO browser would not show new instances without requiring compacting and then expanding the child tree. This fixes that problem by targeting the individual branch and informing the model that rows have been inserted.
