### PR TITLE
Add $(NAME)GetNumInstances() and $(NAME)GetNumBytes() to UAVO template.

### DIFF
--- a/flight/Modules/PathPlanner/path_saving.c
+++ b/flight/Modules/PathPlanner/path_saving.c
@@ -48,8 +48,8 @@ int32_t pathplanner_save_path(uint32_t path_id)
 	if (WaypointHandle() == 0)
 		return -30; // leave room for flashfs error codes
 
-	uint32_t num_waypoints = UAVObjGetNumInstances(WaypointHandle());
-	int32_t  waypoint_size = UAVObjGetNumBytes(WaypointHandle());
+	uint16_t num_waypoints = WaypointGetNumInstances();
+	uint32_t  waypoint_size = WaypointGetNumBytes();
 	int32_t  erase_retval  = 0;
 	int32_t  last_save_id  = -1;
 	int32_t  retval        = 0;
@@ -96,7 +96,7 @@ int32_t pathplanner_load_path(uint32_t path_id)
 	if (WaypointHandle() == 0)
 		return -30; // leave room for flashfs error codes
 
-	int32_t  waypoint_size = UAVObjGetNumBytes(WaypointHandle());
+	uint32_t  waypoint_size = WaypointGetNumBytes();
 	int32_t  retval = 0;
 
 	int32_t i;
@@ -110,7 +110,7 @@ int32_t pathplanner_load_path(uint32_t path_id)
 				break;
 
 			// Loaded waypoint locally, store in UAVO manager
-			if (i >= UAVObjGetNumInstances(WaypointHandle())) {
+			if (i >= WaypointGetNumInstances()) {
 				int32_t new_instance_id = WaypointCreateInstance();
 				if (new_instance_id != i) {
 					retval = -31;
@@ -125,7 +125,7 @@ int32_t pathplanner_load_path(uint32_t path_id)
 	// Set any remaining waypoints to INVALID to indicate they should not be used
 	// at this point i will be the index of the first waypoint that could not be
 	// loaded from flash.
-	for (; i <  UAVObjGetNumInstances(WaypointHandle()); i++) {
+	for (; i <  WaypointGetNumInstances(); i++) {
 		WaypointInstGet(i, &waypoint);
 		waypoint.Mode = WAYPOINT_MODE_INVALID;
 		WaypointInstSet(i, &waypoint);

--- a/flight/Modules/VibrationAnalysis/vibrationanalysis.c
+++ b/flight/Modules/VibrationAnalysis/vibrationanalysis.c
@@ -144,7 +144,7 @@ static int32_t VibrationAnalysisStart(void)
 		}
 	}
 	
-	if (UAVObjGetNumInstances(VibrationAnalysisOutputHandle()) != (fft_window_size>>1)){
+	if (VibrationAnalysisOutputGetNumInstances() != (fft_window_size>>1)){
 		// This is a more useful test for failure.
 		module_enabled = false;
 		return -1;
@@ -402,7 +402,7 @@ static void VibrationAnalysisTask(void *parameters)
 			for (int j=0; j < (vtd->fft_window_size>>1); j++) 
 			{
 				//Assertion check that we are not trying to write to instances that don't exist
-				if (j >= UAVObjGetNumInstances(VibrationAnalysisOutputHandle()))
+				if (j >= VibrationAnalysisOutputGetNumInstances())
 					continue;
 				
 				vibrationAnalysisOutputData.x = vtd->accel_buffer_complex_x_q15[j]/FLOAT_TO_Q15;

--- a/flight/UAVObjects/inc/uavobjecttemplate.h
+++ b/flight/UAVObjects/inc/uavobjecttemplate.h
@@ -88,6 +88,10 @@ static inline int32_t $(NAME)SetMetadata(const UAVObjMetadata *dataIn) { return 
 
 static inline int8_t $(NAME)ReadOnly() { return UAVObjReadOnly($(NAME)Handle()); }
 
+static inline uint16_t $(NAME)GetNumInstances(){ return UAVObjGetNumInstances($(NAME)Handle()); }
+
+static inline uint32_t $(NAME)GetNumBytes(){ return UAVObjGetNumBytes($(NAME)Handle()); }
+
 // Field information
 $(DATAFIELDINFO)
 


### PR DESCRIPTION
This fixes https://github.com/TauLabs/TauLabs/issues/206.

For instance, 

`numWaypointInstances = UAVObjGetNumInstances(WaypointHandle()))`

can be replaced by.

`numWaypointInstances = WaypointGetNumInstances()`

This PR demonstrates the replacement in several functions.

Has not been flight tested.
