### PR TITLE
CMSIS DSP: Only include the needed files

### DIFF
--- a/flight/Libraries/CMSIS3/DSP_Lib/library.mk
+++ b/flight/Libraries/CMSIS3/DSP_Lib/library.mk
@@ -3,6 +3,18 @@
 #
 
 CMSIS3_DSPLIB_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+ifeq ($(INCLUDE_ALL_DSP),YES)
 SRC += $(wildcard $(CMSIS3_DSPLIB_DIR)Source/*/*.c)
+else
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/TransformFunctions/arm_cfft_radix4_init_q15.c
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/TransformFunctions/arm_cfft_radix4_q15.c
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/BasicMathFunctions/arm_shift_q15.c
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/ComplexMathFunctions/arm_cmplx_mag_q15.c
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/FastMathFunctions/arm_sqrt_q15.c
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/CommonTables/arm_common_tables.c
+SRC += $(CMSIS3_DSPLIB_DIR)/Source/TransformFunctions/arm_bitreversal.c
+endif
+
 EXTRAINCDIRS += $(CMSIS3_DSPLIB_DIR)Include
 


### PR DESCRIPTION
This decreases the time of make all_flight from 10min to 5min (-j1). There
is an option

make INCLUDE_ALL_DSP=YES all_flight

which will include all of them to faciliate developing new features
and not needing to track down every source file then.  This should
also give Jenkins a bit of a break ;-).
