### PR TITLE
Fixes an unsightly empty groupbox.

### DIFF
--- a/ground/gcs/src/plugins/config/modulesettingsform.ui
+++ b/ground/gcs/src/plugins/config/modulesettingsform.ui
@@ -517,7 +517,7 @@
             <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>50</height>
+              <height>0</height>
              </size>
             </property>
             <property name="title">
@@ -529,6 +529,15 @@
             <property name="checked">
              <bool>false</bool>
             </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="label_18">
+               <property name="text">
+                <string>Nothing to configure here.</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>


### PR DESCRIPTION
As pointed out in https://github.com/TauLabs/TauLabs/pull/789, the OveroSync groupbox was empty. This PR fixes this unsightly groupbox by allowing the user to know that there is nothing to be configured.

![screen shot 2013-07-24 at 10 45 58 am](https://f.cloud.github.com/assets/1118185/847192/59d65800-f435-11e2-871e-dc50d4f6c3ad.png)
