### PR TITLE
Enable a warning message when a modules tab groupbox is enabled but not running

### DIFF
--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -36,11 +36,13 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     ui->setupUi(this);
 
     // Create the general modules page
-    ModuleSettingsForm *optionalModuleSettings =
-            new ModuleSettingsForm(this, ui->saveButton, ui->applyButton, ui->reloadButton);
+    ModuleSettingsForm *optionalModuleSettings = new ModuleSettingsForm(ui, this);
     QString modulesTabText = ui->tabWidget->tabText(ui->tabWidget->indexOf(ui->general));
     ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->general));
     ui->tabWidget->addTab(optionalModuleSettings, modulesTabText);
+
+    // Hide reboot message
+    ui->lb_rebootMessage->hide();
 }
 
 ConfigModuleWidget::~ConfigModuleWidget()

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -32,6 +32,16 @@
       <number>4</number>
      </property>
      <item>
+      <widget class="QLabel" name="lb_rebootMessage">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Save and reboot board before proceeding.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_5">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/ground/gcs/src/plugins/config/modulesettingsform.h
+++ b/ground/gcs/src/plugins/config/modulesettingsform.h
@@ -29,8 +29,10 @@
 #define MODULESETTINGSFORM_H
 
 #include <QWidget>
-//#include "configinputwidget.h"
 #include "uavobjectwidgetutils/configtaskwidget.h"
+#include "ui_modules.h"
+
+#include "taskinfo.h"
 
 namespace Ui {
     class ModuleSettingsWidget;
@@ -40,8 +42,14 @@ class ModuleSettingsForm : public ConfigTaskWidget
 {
     Q_OBJECT
 
+    enum messageFlag {AIRSPEED = 0x01,
+                      BATTERY = 0x02,
+                      COMBRIDGE = 0x04,
+                      OVEROSYNC = 0x08,
+                      VIBRATION = 0x10};
+
 public:
-    explicit ModuleSettingsForm(QWidget *parent = 0, QPushButton *save = 0, QPushButton *apply = 0, QPushButton *reloadButton = 0);
+    explicit ModuleSettingsForm(Ui::Modules *ui, QWidget *parent = 0);
     ~ModuleSettingsForm();
     friend class ConfigInputWidget;
 private slots:
@@ -50,14 +58,26 @@ private slots:
     void updatePitotType(int comboboxValue);
     void toggleVibrationTest();
 
+    void toggleAirspeedModule(bool toggleState);
+    void toggleBatteryModule(bool toggleState);
+    void toggleComBridgeModule(bool toggleState);
+    void toggleOveroSyncModule(bool toggleState);
+    void toggleVibrationAnalysisModule(bool toggleState);
+
 private:
     QVariant getVariantFromWidget(QWidget * widget, double scale);
     bool setWidgetFromVariant(QWidget *widget, QVariant value, double scale);
+    void toggleErrorMessage();
 
     static QString trueString;
     static QString falseString;
 
+    TaskInfo *taskInfo;
+
     Ui::ModuleSettingsWidget *moduleSettingsWidget;
+    Ui::Modules *modulesTab;
+
+    uint32_t rebootMessage_flag;
 };
 
 #endif // MODULESETTINGSFORM_H


### PR DESCRIPTION
As pointed out in https://github.com/TauLabs/TauLabs/pull/789, there was no indication that a module could not be configured because a reboot was necessary. This addresses that problem.

![screen shot 2013-07-24 at 12 04 27 pm](https://f.cloud.github.com/assets/1118185/847525/1a0eb770-f440-11e2-9694-bab1fed762a7.png)

There is a remaining issue that the battery module can be enabled but will not run because the ADC input channel has not been set. I will fix that in a forthcoming PR. Right now there are no adverse effects, as the message is still correct that a save/reboot cycle is necessary.

Support for disabling the contents of a groupbox when the module is not running exists in a private branch, but it does't work cleanly because of the battery ADC routing problem.

An alternative approach is to display the message any time a groupbox is toggled, but this leads to a problem when the user clicks and then "unclicks". Ideally, the message would go away if the user returned to the previous state, but this is dependent on the true running state and not the admin state. Otherwise, a user who saves a ModuleSettings->AdminState change,and then disconnects/reconnects the telemetry connection will no longer receive the message even though it is still appropriate.
