### PR TITLE
Added drop down comboboxes for configuring ADC inputs to battery and airspeed modules.

### DIFF
--- a/ground/gcs/src/plugins/config/modulesettingsform.h
+++ b/ground/gcs/src/plugins/config/modulesettingsform.h
@@ -29,8 +29,8 @@
 #define MODULESETTINGSFORM_H
 
 #include <QWidget>
-//#include "configinputwidget.h"
 #include "uavobjectwidgetutils/configtaskwidget.h"
+#include "adcrouting.h"
 
 namespace Ui {
     class ModuleSettingsWidget;
@@ -45,17 +45,27 @@ public:
     ~ModuleSettingsForm();
     friend class ConfigInputWidget;
 private slots:
+    void updateADCRoutingComboboxes(int);
+    void updateADCRoutingComboboxesFromUAVO(UAVObject *);
     void updateAirspeedUAVO(UAVObject *);
     void updateAirspeedGroupbox(UAVObject *);
     void updatePitotType(int comboboxValue);
     void toggleVibrationTest();
+    void reloadADCRoutingUAVO();
+    void applyADCRoutingUAVO();
+    void saveADCRoutingUAVO();
 
 private:
     QVariant getVariantFromWidget(QWidget * widget, double scale);
     bool setWidgetFromVariant(QWidget *widget, QVariant value, double scale);
+    void updateADCRoutingUAVO(ADCRouting::DataFields *adcRoutingData);
+    void updateADCRoutingComboboxes();
 
     static QString trueString;
     static QString falseString;
+
+    ADCRouting *adcRouting;
+    ADCRouting::DataFields adcRoutingDataPrivate;
 
     Ui::ModuleSettingsWidget *moduleSettingsWidget;
 };

--- a/ground/gcs/src/plugins/config/modulesettingsform.ui
+++ b/ground/gcs/src/plugins/config/modulesettingsform.ui
@@ -158,33 +158,43 @@
                 <item row="0" column="1">
                  <widget class="QComboBox" name="cb_pitotType"/>
                 </item>
-                <item row="1" column="0">
+                <item row="2" column="0">
                  <widget class="QLabel" name="label_7">
                   <property name="text">
                    <string>Calibration value:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="1">
+                <item row="2" column="1">
                  <widget class="QDoubleSpinBox" name="sb_pitotScale">
                   <property name="singleStep">
                    <double>0.100000000000000</double>
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
+                <item row="3" column="0">
                  <widget class="QLabel" name="label_16">
                   <property name="text">
                    <string>Calibration zero pt:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="1">
+                <item row="3" column="1">
                  <widget class="QDoubleSpinBox" name="sb_pitotZeroPoint">
                   <property name="singleStep">
                    <double>0.100000000000000</double>
                   </property>
                  </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_20">
+                  <property name="text">
+                   <string>Input ADC channel:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QComboBox" name="cb_airspeedADCChannel"/>
                 </item>
                </layout>
               </widget>
@@ -355,28 +365,28 @@
                 <bool>false</bool>
                </property>
                <layout class="QFormLayout" name="formLayout">
-                <item row="0" column="0">
+                <item row="1" column="0">
                  <widget class="QLabel" name="label_14">
                   <property name="text">
                    <string>Live reading:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="1">
+                <item row="1" column="1">
                  <widget class="QLineEdit" name="le_liveVoltageReading">
                   <property name="readOnly">
                    <bool>true</bool>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="0">
+                <item row="2" column="0">
                  <widget class="QLabel" name="label_13">
                   <property name="text">
                    <string>Calibration value:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="1">
+                <item row="2" column="1">
                  <widget class="QDoubleSpinBox" name="sb_voltageCalibration">
                   <property name="decimals">
                    <number>6</number>
@@ -389,14 +399,14 @@
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
+                <item row="3" column="0">
                  <widget class="QLabel" name="label_11">
                   <property name="text">
                    <string>Low voltage alarm:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="1">
+                <item row="3" column="1">
                  <widget class="QDoubleSpinBox" name="sb_lowVoltageAlarm">
                   <property name="suffix">
                    <string>V</string>
@@ -409,14 +419,14 @@
                   </property>
                  </widget>
                 </item>
-                <item row="3" column="0">
+                <item row="4" column="0">
                  <widget class="QLabel" name="label_12">
                   <property name="text">
                    <string>Low voltage warning:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="3" column="1">
+                <item row="4" column="1">
                  <widget class="QDoubleSpinBox" name="sb_lowVoltageWarning">
                   <property name="suffix">
                    <string>V</string>
@@ -426,6 +436,16 @@
                   </property>
                   <property name="value">
                    <double>10.150000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QComboBox" name="cb_batteryVoltageADCChannel"/>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_18">
+                  <property name="text">
+                   <string>Input ADC channel:</string>
                   </property>
                  </widget>
                 </item>
@@ -447,21 +467,21 @@
                 <property name="fieldGrowthPolicy">
                  <enum>QFormLayout::FieldsStayAtSizeHint</enum>
                 </property>
-                <item row="0" column="0">
+                <item row="1" column="0">
                  <widget class="QLabel" name="label_9">
                   <property name="text">
                    <string>Live reading:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="0">
+                <item row="2" column="0">
                  <widget class="QLabel" name="label_8">
                   <property name="text">
                    <string>Calibration value:</string>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="1">
+                <item row="2" column="1">
                  <widget class="QDoubleSpinBox" name="sb_currentCalibration">
                   <property name="decimals">
                    <number>6</number>
@@ -474,10 +494,20 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="1">
+                <item row="1" column="1">
                  <widget class="QLineEdit" name="le_liveCurrentReading">
                   <property name="readOnly">
                    <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QComboBox" name="cb_batteryCurrentADCChannel"/>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_19">
+                  <property name="text">
+                   <string>Input ADC channel:</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
This provides the ability to intelligently change the ADCRouting UAVObject directly from the Modules tab. This is a nice improvement, since configuring the ADC input channel is a necessary part of configuring the battery and airspeed modules, as well as future modules down the line.

When an input is taken by another channel, the combobox item is deactivated for the other modules.
![screen shot 2013-07-24 at 3 10 35 pm](https://f.cloud.github.com/assets/1118185/848261/1076650e-f45a-11e2-8784-a462b61f67d2.png)

This helps address the limitation in https://github.com/TauLabs/TauLabs/pull/791.
