### PR TITLE
Revert "Merge pull request #316 from kubark42/uavobrowser_update_fix"

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowser.ui
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowser.ui
@@ -219,6 +219,9 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QTreeView" name="treeView"/>
+   </item>
   </layout>
  </widget>
  <resources>

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -40,41 +40,24 @@
 #include <QtCore/QDebug>
 #include <QtGui/QItemEditorFactory>
 #include "extensionsystem/pluginmanager.h"
-#include <math.h>
 
-#define MAXIMUM_UPDATE_PERIOD 200
-
-UAVObjectBrowserWidget::UAVObjectBrowserWidget(QWidget *parent) : QWidget(parent),
-    updatePeriod(MAXIMUM_UPDATE_PERIOD)
+UAVObjectBrowserWidget::UAVObjectBrowserWidget(QWidget *parent) : QWidget(parent)
 {
-    // Create browser and configuration GUIs
     m_browser = new Ui_UAVObjectBrowser();
     m_viewoptions = new Ui_viewoptions();
     m_viewoptionsDialog = new QDialog(this);
     m_viewoptions->setupUi(m_viewoptionsDialog);
     m_browser->setupUi(this);
-
-    // Create data model
     m_model = new UAVObjectTreeModel();
-
-    // Create tree view and add to layout
-    treeView = new UAVOBrowserTreeView(m_model, MAXIMUM_UPDATE_PERIOD);
-    treeView->setObjectName(QString::fromUtf8("treeView"));
-    m_browser->verticalLayout->addWidget(treeView);
-
-    treeView->setModel(m_model);
-    treeView->setColumnWidth(0, 300);
-    treeView->setEditTriggers(QAbstractItemView::AllEditTriggers);
-    treeView->setSelectionBehavior(QAbstractItemView::SelectItems);
-    treeView->setUniformRowHeights(true);
-
+    m_browser->treeView->setModel(m_model);
+    m_browser->treeView->setColumnWidth(0, 300);
+    //m_browser->treeView->expandAll();
     BrowserItemDelegate *m_delegate = new BrowserItemDelegate();
-    treeView->setItemDelegate(m_delegate);
-
+    m_browser->treeView->setItemDelegate(m_delegate);
+    m_browser->treeView->setEditTriggers(QAbstractItemView::AllEditTriggers);
+    m_browser->treeView->setSelectionBehavior(QAbstractItemView::SelectItems);
     showMetaData(m_viewoptions->cbMetaData->isChecked());
-
-    // Connect signals
-    connect(treeView->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)), this, SLOT(toggleUAVOButtons(QModelIndex,QModelIndex)));
+    connect(m_browser->treeView->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)), this, SLOT(toggleUAVOButtons(QModelIndex,QModelIndex)));
     connect(m_viewoptions->cbMetaData, SIGNAL(toggled(bool)), this, SLOT(showMetaData(bool)));
     connect(m_viewoptions->cbCategorized, SIGNAL(toggled(bool)), this, SLOT(categorize(bool)));
     connect(m_browser->saveSDButton, SIGNAL(clicked()), this, SLOT(saveObject()));
@@ -87,169 +70,7 @@ UAVObjectBrowserWidget::UAVObjectBrowserWidget(QWidget *parent) : QWidget(parent
     connect(m_viewoptions->cbScientific, SIGNAL(toggled(bool)), this, SLOT(viewOptionsChangedSlot()));
     connect(m_viewoptions->cbMetaData, SIGNAL(toggled(bool)), this, SLOT(viewOptionsChangedSlot()));
     connect(m_viewoptions->cbCategorized, SIGNAL(toggled(bool)), this, SLOT(viewOptionsChangedSlot()));
-
-    connect((QTreeView*) treeView, SIGNAL(collapsed(QModelIndex)), this, SLOT(onTreeItemCollapsed(QModelIndex) ));
-    connect((QTreeView*) treeView, SIGNAL(expanded(QModelIndex)), this, SLOT(onTreeItemExpanded(QModelIndex) ));
-
-    // Set browser buttons to disabled
     enableUAVOBrowserButtons(false);
-}
-
-void UAVObjectBrowserWidget::onTreeItemExpanded(QModelIndex currentIndex)
-{
-    TreeItem *item = static_cast<TreeItem*>(currentIndex.internalPointer());
-    TopTreeItem *top = dynamic_cast<TopTreeItem*>(item->parent());
-
-    //Check if current tree index is the child of the top tree item
-    if (top)
-    {
-        ObjectTreeItem *objItem = dynamic_cast<ObjectTreeItem*>(item);
-        //If the cast succeeds, then this is a UAVO
-        if (objItem)
-        {
-            UAVObject *obj = objItem->object();
-            // Check for multiple instance UAVO
-            if(!obj){
-                objItem = dynamic_cast<ObjectTreeItem*>(item->getChild(0));
-                obj = objItem->object();
-            }
-            Q_ASSERT(obj);
-            UAVObject::Metadata mdata = obj->getMetadata();
-
-            // Determine fastest update
-            quint16 tmpUpdatePeriod = MAXIMUM_UPDATE_PERIOD;
-            int accessType = UAVObject::GetGcsTelemetryUpdateMode(mdata);
-            if (accessType != UAVObject::UPDATEMODE_MANUAL){
-                switch(accessType){
-                case UAVObject::UPDATEMODE_ONCHANGE:
-                    tmpUpdatePeriod = 0;
-                    break;
-                case UAVObject::UPDATEMODE_PERIODIC:
-                case UAVObject::UPDATEMODE_THROTTLED:
-                    tmpUpdatePeriod = std::min(mdata.gcsTelemetryUpdatePeriod, tmpUpdatePeriod);
-                    break;
-                }
-            }
-
-            accessType = UAVObject::GetFlightTelemetryUpdateMode(mdata);
-            if (accessType != UAVObject::UPDATEMODE_MANUAL){
-                switch(accessType){
-                case UAVObject::UPDATEMODE_ONCHANGE:
-                    tmpUpdatePeriod = 0;
-                    break;
-                case UAVObject::UPDATEMODE_PERIODIC:
-                case UAVObject::UPDATEMODE_THROTTLED:
-                    tmpUpdatePeriod = std::min(mdata.flightTelemetryUpdatePeriod, tmpUpdatePeriod);
-                    break;
-                }
-            }
-
-            expandedUavoItems.insert(obj->getName(), tmpUpdatePeriod);
-
-            if (tmpUpdatePeriod < updatePeriod){
-                updatePeriod = tmpUpdatePeriod;
-                treeView->updateTimerPeriod(updatePeriod);
-            }
-        }
-    }
-}
-
-void UAVObjectBrowserWidget::onTreeItemCollapsed(QModelIndex currentIndex)
-{
-
-    TreeItem *item = static_cast<TreeItem*>(currentIndex.internalPointer());
-    TopTreeItem *top = dynamic_cast<TopTreeItem*>(item->parent());
-
-    //Check if current tree index is the child of the top tree item
-    if (top)
-    {
-        ObjectTreeItem *objItem = dynamic_cast<ObjectTreeItem*>(item);
-        //If the cast succeeds, then this is a UAVO
-        if (objItem)
-        {
-            UAVObject *obj = objItem->object();
-
-            // Check for multiple instance UAVO
-            if(!obj){
-                objItem = dynamic_cast<ObjectTreeItem*>(item->getChild(0));
-                obj = objItem->object();
-            }
-            Q_ASSERT(obj);
-
-            //Remove the UAVO, getting its stored value first.
-            quint16 tmpUpdatePeriod = expandedUavoItems.value(obj->getName());
-            expandedUavoItems.take(obj->getName());
-
-            // Check if this was the fastest UAVO
-            if (tmpUpdatePeriod == updatePeriod){
-                // If so, search for the new fastest UAVO
-                updatePeriod = MAXIMUM_UPDATE_PERIOD;
-                foreach(tmpUpdatePeriod, expandedUavoItems)
-                {
-                    if (tmpUpdatePeriod < updatePeriod)
-                        updatePeriod = tmpUpdatePeriod;
-                }
-                treeView->updateTimerPeriod(updatePeriod);
-            }
-
-
-        }
-    }
-}
-
-void UAVObjectBrowserWidget::updateThrottlePeriod(UAVObject *obj)
-{
-    // Test if this is a metadata object. A UAVO's metadata's object ID is the UAVO's object ID + 1
-    if ((obj->getObjID() & 0x01) == 1){
-        ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-        Q_ASSERT(pm);
-        UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
-        Q_ASSERT(objManager);
-        QVector<UAVObject*> list = objManager->getObjectInstances(obj->getObjID() - 1);
-        obj = list.at(0);
-    }
-
-
-    UAVObject::Metadata mdata = obj->getMetadata();
-
-    // Determine fastest update
-    quint16 tmpUpdatePeriod = MAXIMUM_UPDATE_PERIOD;
-    int accessType = UAVObject::GetGcsTelemetryUpdateMode(mdata);
-    if (accessType != UAVObject::UPDATEMODE_MANUAL){
-        switch(accessType){
-        case UAVObject::UPDATEMODE_ONCHANGE:
-            tmpUpdatePeriod = 0;
-            break;
-        case UAVObject::UPDATEMODE_PERIODIC:
-        case UAVObject::UPDATEMODE_THROTTLED:
-            tmpUpdatePeriod = std::min(mdata.gcsTelemetryUpdatePeriod, tmpUpdatePeriod);
-            break;
-        }
-    }
-
-    accessType = UAVObject::GetFlightTelemetryUpdateMode(mdata);
-    if (accessType != UAVObject::UPDATEMODE_MANUAL){
-        switch(accessType){
-        case UAVObject::UPDATEMODE_ONCHANGE:
-            tmpUpdatePeriod = 0;
-            break;
-        case UAVObject::UPDATEMODE_PERIODIC:
-        case UAVObject::UPDATEMODE_THROTTLED:
-            tmpUpdatePeriod = std::min(mdata.flightTelemetryUpdatePeriod, tmpUpdatePeriod);
-            break;
-        }
-    }
-
-    expandedUavoItems.insert(obj->getName(), tmpUpdatePeriod);
-
-
-    updatePeriod = MAXIMUM_UPDATE_PERIOD;
-    foreach(tmpUpdatePeriod, expandedUavoItems)
-    {
-        if (tmpUpdatePeriod < updatePeriod)
-            updatePeriod = tmpUpdatePeriod;
-    }
-    treeView->updateTimerPeriod(updatePeriod);
 }
 
 UAVObjectBrowserWidget::~UAVObjectBrowserWidget()
@@ -281,7 +102,7 @@ void UAVObjectBrowserWidget::showMetaData(bool show)
     QList<QModelIndex> metaIndexes = m_model->getMetaDataIndexes();
     foreach(QModelIndex index , metaIndexes)
     {
-        treeView->setRowHidden(index.row(), index.parent(), !show);
+        m_browser->treeView->setRowHidden(index.row(), index.parent(), !show);
     }
 }
 
@@ -303,7 +124,7 @@ void UAVObjectBrowserWidget::categorize(bool categorize)
     m_model->setManuallyChangedColor(m_manuallyChangedColor);
     m_model->setRecentlyUpdatedTimeout(m_recentlyUpdatedTimeout);
     m_model->setOnlyHighlightChangedValues(m_onlyHighlightChangedValues);
-    treeView->setModel(m_model);
+    m_browser->treeView->setModel(m_model);
     showMetaData(m_viewoptions->cbMetaData->isChecked());
 
     delete tmpModel;
@@ -326,7 +147,7 @@ void UAVObjectBrowserWidget::useScientificNotation(bool scientific)
     m_model->setRecentlyUpdatedColor(m_recentlyUpdatedColor);
     m_model->setManuallyChangedColor(m_manuallyChangedColor);
     m_model->setRecentlyUpdatedTimeout(m_recentlyUpdatedTimeout);
-    treeView->setModel(m_model);
+    m_browser->treeView->setModel(m_model);
     showMetaData(m_viewoptions->cbMetaData->isChecked());
 
     delete tmpModel;
@@ -348,9 +169,6 @@ void UAVObjectBrowserWidget::sendUpdate()
     UAVObject *obj = objItem->object();
     Q_ASSERT(obj);
     obj->updated();
-
-    // Search for the new fastest UAVO
-    updateThrottlePeriod(obj);
 }
 
 
@@ -364,9 +182,6 @@ void UAVObjectBrowserWidget::requestUpdate()
     UAVObject *obj = objItem->object();
     Q_ASSERT(obj);
     obj->requestUpdate();
-
-    // Search for the new fastest UAVO
-    updateThrottlePeriod(obj);
 }
 
 
@@ -376,23 +191,17 @@ void UAVObjectBrowserWidget::requestUpdate()
  */
 ObjectTreeItem *UAVObjectBrowserWidget::findCurrentObjectTreeItem()
 {
-    QModelIndex current = treeView->currentIndex();
+    QModelIndex current = m_browser->treeView->currentIndex();
     TreeItem *item = static_cast<TreeItem*>(current.internalPointer());
     ObjectTreeItem *objItem = 0;
 
-    // Recursively iterate over child branches until the parent UAVO branch is found
+    //What is this doing?
     while (item) {
-        //Attempt a dynamic cast
         objItem = dynamic_cast<ObjectTreeItem*>(item);
-
-        //If the cast succeeds, then this is a UAVO or UAVO metada. Stop the while loop.
         if (objItem)
             break;
-
-        //If it fails, then set item equal to the parent branch, and try again.
         item = item->parent();
     }
-
     return objItem;
 }
 
@@ -414,9 +223,6 @@ void UAVObjectBrowserWidget::saveObject()
     UAVObject *obj = objItem->object();
     Q_ASSERT(obj);
     updateObjectPersistance(ObjectPersistence::OPERATION_SAVE, obj);
-
-    // Search for the new fastest UAVO
-    updateThrottlePeriod(obj);
 }
 
 
@@ -433,9 +239,6 @@ void UAVObjectBrowserWidget::loadObject()
     updateObjectPersistance(ObjectPersistence::OPERATION_LOAD, obj);
     // Retrieve object so that latest value is displayed
     requestUpdate();
-
-    // Search for the new fastest UAVO
-    updateThrottlePeriod(obj);
 }
 
 
@@ -492,7 +295,7 @@ void UAVObjectBrowserWidget::toggleUAVOButtons(const QModelIndex &currentIndex, 
 
     bool enableState = true;
 
-    //Check if current index refers to an empty index
+    //Check if current index refers to an empty index?
     if (currentIndex == QModelIndex())
         enableState = false;
 
@@ -548,107 +351,3 @@ void UAVObjectBrowserWidget::enableUAVOBrowserButtons(bool enableState)
 }
 
 
-//============================
-
-/**
- * @brief UAVOBrowserTreeView::UAVOBrowserTreeView Constructor for reimplementation of QTreeView
- */
-UAVOBrowserTreeView::UAVOBrowserTreeView(UAVObjectTreeModel *m_model_new, unsigned int updateTimerPeriod) : QTreeView(),
-    m_model(m_model_new),
-    topmostData(-1),
-    bottommostData(-1),
-    topmostSettings(-1),
-    bottommostSettings(-1)
-{
-    // Start timer at 100ms
-    m_updateViewTimer.start(updateTimerPeriod);
-
-    // Connect the timer
-    connect(&m_updateViewTimer, SIGNAL(timeout()), this, SLOT(onTimeout_updateView()));
-}
-
-void UAVOBrowserTreeView::updateTimerPeriod(unsigned int val)
-{
-    if (val == 0){
-        // If val == 0, disable throttling by stopping the timer.
-        m_updateViewTimer.stop();
-    }
-    else
-    {
-        // If the UAVO has a very fast data rate, then don't go the full speed.
-        if (val < 100)
-        {
-            val = 100- powf((100-val),0.914); //This drives the throttled speed exponentially toward 30Hz.
-        }
-        m_updateViewTimer.start(val);
-    }
-}
-
-
-/**
- * @brief UAVOBrowserTreeView::onTimeout_updateView On timeout, emits dataChanged() SIGNAL for
- * all data tree indices that have changed since last timeout.
- */
-void UAVOBrowserTreeView::onTimeout_updateView()
-{
-    if (topmostData > -1){
-        QModelIndex topLeftData = m_model->getIndex(topmostData, 0, m_model->getNonSettingsTree());
-        QModelIndex bottomRightData = m_model->getIndex(bottommostData, 1, m_model->getNonSettingsTree());
-
-        QTreeView::dataChanged(topLeftData, bottomRightData);
-
-        topmostData = -1;
-        bottommostData = -1;
-    }
-
-    if (topmostSettings > -1){
-        QModelIndex topLeftSettings = m_model->getIndex(topmostSettings, 0, m_model->getSettingsTree());
-        QModelIndex bottomRightSettings = m_model->getIndex(bottommostSettings, 1, m_model->getSettingsTree());
-
-        QTreeView::dataChanged(topLeftSettings, bottomRightSettings);
-
-        topmostSettings = -1;
-        bottommostSettings = -1;
-    }
-}
-
-/**
- * @brief UAVOBrowserTreeView::updateView Determines if a view updates lies outside the
- * range of updates queued for update
- * @param topLeft Top left index from data model update
- * @param bottomRight Bottom right index from data model update
- */
-void UAVOBrowserTreeView::updateView(QModelIndex topLeft, QModelIndex bottomRight)
-{
-    TopTreeItem *treeItemPtr = static_cast<TopTreeItem*>(topLeft.internalPointer());
-
-    // Determine if the new indices lie outside of the set of indices queued for update
-    if (treeItemPtr->parent() == m_model->getNonSettingsTree()){
-        if (topmostData < 0 || topmostData > topLeft.row())
-            topmostData = topLeft.row();
-        if (bottommostData < 0 || bottommostData < bottomRight.row())
-            bottommostData = bottomRight.row();
-    }
-    else if(treeItemPtr->parent() == m_model->getSettingsTree()){
-        if (topmostSettings < 0 || topmostSettings > topLeft.row())
-            topmostSettings = topLeft.row();
-        if (bottommostSettings < 0 || bottommostSettings < bottomRight.row())
-            bottommostSettings = bottomRight.row();
-    }
-    else{
-        // Do nothing. These QModelIndices are generated by the highlight manager or for individual
-        // UAVO fields, which are both updated when updating that UAVO's branch of the settings or
-        // dynamic data tree.
-    }
-}
-
-void UAVOBrowserTreeView::dataChanged(const QModelIndex & topLeft, const QModelIndex & bottomRight)
-{
-    // If the timer is active, then throttle updates...
-    if (m_updateViewTimer.isActive()){
-        updateView(topLeft, bottomRight);
-    }
-    else { // ... otherwise pass them directly on to the treeview.
-       QTreeView::dataChanged(topLeft, bottomRight);
-    }
-}

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -28,7 +28,6 @@
 #ifndef UAVOBJECTBROWSERWIDGET_H_
 #define UAVOBJECTBROWSERWIDGET_H_
 
-#include <QModelIndex>
 #include <QtGui/QWidget>
 #include <QtGui/QTreeView>
 #include "objectpersistence.h"
@@ -38,41 +37,6 @@ class QPushButton;
 class ObjectTreeItem;
 class Ui_UAVObjectBrowser;
 class Ui_viewoptions;
-
-class UAVOBrowserTreeView : public QTreeView
-{
-    Q_OBJECT
-public:
-    UAVOBrowserTreeView(UAVObjectTreeModel *m_model, unsigned int updateTimerPeriod);
-    void updateView(QModelIndex topLeft, QModelIndex bottomRight);
-    void updateTimerPeriod(unsigned int val);
-
-    /**
-     * @brief dataChanged Reimplements QTreeView::dataChanged signal
-     * @param topLeft
-     * @param bottomRight
-     * @param updateFlag If true, send dataChanged signal. If false, do nothing.
-     */
-    virtual void dataChanged(const QModelIndex & topLeft, const QModelIndex & bottomRight);
-
-
-private slots:
-    void onTimeout_updateView();
-
-private:
-    UAVObjectTreeModel *m_model;
-
-    int topmostData;
-    int bottommostData;
-    int topmostSettings;
-    int bottommostSettings;
-
-    bool m_updateViewFlagData;
-    bool m_updateViewFlagSettings;
-
-    QTimer m_updateViewTimer;
-
-};
 
 class UAVObjectBrowserWidget : public QWidget
 {
@@ -86,7 +50,6 @@ public:
     void setRecentlyUpdatedTimeout(int timeout) { m_recentlyUpdatedTimeout = timeout; m_model->setRecentlyUpdatedTimeout(timeout); }
     void setOnlyHighlightChangedValues(bool highlight) { m_onlyHighlightChangedValues = highlight; m_model->setOnlyHighlightChangedValues(highlight); }
     void setViewOptions(bool categorized,bool scientific,bool metadata);
-
 public slots:
     void showMetaData(bool show);
     void categorize(bool categorize);
@@ -101,10 +64,6 @@ private slots:
     void toggleUAVOButtons(const QModelIndex &current, const QModelIndex &previous);
     void viewSlot();
     void viewOptionsChangedSlot();
-
-    void onTreeItemCollapsed(QModelIndex);
-    void onTreeItemExpanded(QModelIndex);
-
 signals:
     void viewOptionsChanged(bool categorized,bool scientific,bool metadata);
 private:
@@ -123,13 +82,6 @@ private:
     void updateObjectPersistance(ObjectPersistence::OperationOptions op, UAVObject *obj);
     void enableUAVOBrowserButtons(bool enableState);
     ObjectTreeItem *findCurrentObjectTreeItem();
-    void updateThrottlePeriod(UAVObject *);
-
-    UAVOBrowserTreeView *treeView;
-
-    QMap<QString, unsigned int> expandedUavoItems;
-
-    unsigned int updatePeriod;
 };
 
 #endif /* UAVOBJECTBROWSERWIDGET_H_ */

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
@@ -40,12 +40,12 @@
 #include <math.h>
 
 UAVObjectTreeModel::UAVObjectTreeModel(QObject *parent, bool categorize, bool useScientificNotation) :
-    QAbstractItemModel(parent),
-    m_recentlyUpdatedTimeout(500), // ms
-    m_recentlyUpdatedColor(QColor(255, 230, 230)),
-    m_manuallyChangedColor(QColor(230, 230, 255)),
-    m_updatedOnlyColor(QColor(174,207,250,255)),
-    m_useScientificFloatNotation(useScientificNotation)
+        QAbstractItemModel(parent),
+        m_useScientificFloatNotation(useScientificNotation),
+        m_recentlyUpdatedTimeout(500), // ms
+        m_recentlyUpdatedColor(QColor(255, 230, 230)),
+        m_manuallyChangedColor(QColor(230, 230, 255)),
+        m_updatedOnlyColor(QColor(255,255,0))
 {
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
@@ -109,7 +109,6 @@ void UAVObjectTreeModel::newObject(UAVObject *obj)
 
 void UAVObjectTreeModel::addDataObject(UAVDataObject *obj, bool categorize)
 {
-    //Determine if the root tree is the settings or dynamic data tree
     TopTreeItem *root = obj->isSettings() ? m_settingsTree : m_nonSettingsTree;
 
     TreeItem* parent = root;
@@ -436,7 +435,7 @@ void UAVObjectTreeModel::highlightUpdatedObject(UAVObject *obj)
     }
 }
 
-ObjectTreeItem* UAVObjectTreeModel::findObjectTreeItem(UAVObject *object)
+ObjectTreeItem *UAVObjectTreeModel::findObjectTreeItem(UAVObject *object)
 {
     UAVDataObject *dataObject = qobject_cast<UAVDataObject*>(object);
     UAVMetaObject *metaObject = qobject_cast<UAVMetaObject*>(object);
@@ -451,7 +450,6 @@ ObjectTreeItem* UAVObjectTreeModel::findObjectTreeItem(UAVObject *object)
 
 DataObjectTreeItem* UAVObjectTreeModel::findDataObjectTreeItem(UAVDataObject *obj)
 {
-    //Determine if the root tree is the settings or dynamic data tree
     TopTreeItem *root = obj->isSettings() ? m_settingsTree : m_nonSettingsTree;
     return root->findDataObjectTreeItemByObjectId(obj->getObjID());
 }
@@ -460,8 +458,6 @@ MetaObjectTreeItem* UAVObjectTreeModel::findMetaObjectTreeItem(UAVMetaObject *ob
 {
     UAVDataObject *dataObject = qobject_cast<UAVDataObject*>(obj->getParentObject());
     Q_ASSERT(dataObject);
-
-    //Determine if the root tree is the settings or dynamic data tree
     TopTreeItem *root = dataObject->isSettings() ? m_settingsTree : m_nonSettingsTree;
     return root->findMetaObjectTreeItemByObjectId(obj->getObjID());
 }
@@ -472,7 +468,6 @@ void UAVObjectTreeModel::updateHighlight(TreeItem *item)
     Q_ASSERT(itemIndex != QModelIndex());
     emit dataChanged(itemIndex, itemIndex.sibling(itemIndex.row(), TreeItem::dataColumn));
 }
-
 
 /**
  * @brief TreeItem::updateCurrentTime  This single timer sets the rhythm for all highlight events.

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.h
@@ -63,9 +63,6 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
 
-    TopTreeItem* getSettingsTree(){return m_settingsTree;}
-    TopTreeItem* getNonSettingsTree(){return m_nonSettingsTree;}
-
     void setRecentlyUpdatedColor(QColor color) { m_recentlyUpdatedColor = color; }
     void setManuallyChangedColor(QColor color) { m_manuallyChangedColor = color; }
     void setRecentlyUpdatedTimeout(int timeout) {
@@ -75,8 +72,6 @@ public:
     void setOnlyHighlightChangedValues(bool highlight) {m_onlyHighlightChangedValues = highlight; }
 
     QList<QModelIndex> getMetaDataIndexes();
-
-    QModelIndex getIndex(int indexRow, int indexCol, TopTreeItem *topTreeItem){return createIndex(indexRow, indexCol, topTreeItem);}
 
 signals:
 


### PR DESCRIPTION
Right now we have two bugs (#745 and #769) that seem to arise from #316.  Unfortunately the proposed fix #770 results in segfaults and does not fix the issue.

Because having a browser to inspect objects and debug peoples setups is so important, this reverts the PR that introduced these bugs. Full disclaimer - 316 brought some efficiency improves to the browser so we'll lose those temporarily.

Once the benefits of 316 have been achieved without the unwanted side effects it should be remerged.  Also if a robust fix to #745 and #769 is available this should not be merged.  However, I don't think we should let the browser stay in a state where it stops showing updates (especially for the default user configuration most people will have).

Fixes #745 
Fixes #769 
Fixes #799 
