### PR TITLE
directories should be configured before $(OSFAMILY).mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@
 # import macros common to all supported build systems
 include $(CURDIR)/make/system-id.mk
 
-# import macros that are OS specific
-include $(ROOT_DIR)/make/$(OSFAMILY).mk
-
 # configure some directories that are relative to wherever ROOT_DIR is located
 TOOLS_DIR := $(ROOT_DIR)/tools
 BUILD_DIR := $(ROOT_DIR)/build
 DL_DIR := $(ROOT_DIR)/downloads
+
+# import macros that are OS specific
+include $(ROOT_DIR)/make/$(OSFAMILY).mk
 
 # include the tools makefile
 include $(ROOT_DIR)/make/tools.mk


### PR DESCRIPTION
Little bit of a brain fade... the directories should be configured before $(OSFAMILY).mk is imported, as the uavobjgenerator path needs $(BUILD_DIR).

I missed this until i did a make all_clean and had to rebuild uavo's again.
