### PR TITLE
system-id.mk: fixed 64bit detection

### DIFF
--- a/make/system-id.mk
+++ b/make/system-id.mk
@@ -5,7 +5,7 @@
 # Make sure we know a few things about the architecture 
 UNAME := $(shell uname)
 ARCH := $(shell uname -m)
-ifeq (,$(filter $(ARCH), x86_64 amd64))
+ifneq (,$(filter $(ARCH), x86_64 amd64))
   X86-64 := 1
   X86_64 := 1
   AMD64 := 1


### PR DESCRIPTION
64-bit systems were not detected correctly, causing the download of a wrong Qt binary which didn't install with the following error:

Error during installation process (com.nokia.ndk.tools.harmattan.sysroot):
Execution failed(Unexpected exit code: 1): "/home/trooper/Desktop/devel/TauLabs/tools/qtsdk-v1.2.1/Madde/postinstall/harmattan-postinstall.sh"
