### PR TITLE
Revert "Modules: clarify selection of GPS in airspeed algorithm"

### DIFF
--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -477,11 +477,8 @@
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
         <widget class="QGroupBox" name="gb_airspeedGPS">
-         <property name="toolTip">
-          <string>Use the GPS to estimate the airspeed and windspeed from ground speed.</string>
-         </property>
          <property name="title">
-          <string>GPS based estimate</string>
+          <string>GPS</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -521,9 +518,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gb_airspeedPitot">
-         <property name="toolTip">
-          <string>Use a pitot tube to directly measure airspeed</string>
-         </property>
          <property name="title">
           <string>Pitot sensor</string>
          </property>


### PR DESCRIPTION
This reverts commit 643daef1fc3b436f988fb8b63c318414728a2e2f.

The text changes were incorrect. I'll merge this as soon as Jenkins okays it.
