### PR TITLE
ppm: only hold off supervisor when we have full frame lock

### DIFF
--- a/flight/PiOS/STM32F10x/pios_ppm.c
+++ b/flight/PiOS/STM32F10x/pios_ppm.c
@@ -272,9 +272,6 @@ static void PIOS_PPM_tim_edge_cb (uintptr_t tim_id, uintptr_t context, uint8_t c
 			&& ppm_dev->PulseIndex >= PIOS_PPM_IN_MIN_NUM_CHANNELS
 			&& ppm_dev->PulseIndex <= PIOS_PPM_IN_MAX_NUM_CHANNELS)
 		{
-			/* Regardless of whether we have lock, note that this is a sane frame */
-			ppm_dev->Fresh = true;
-
 			/* If we see n simultaneous frames of the same
 			   number of channels we save it as our frame size */
 			if (ppm_dev->NumChannelCounter < PIOS_PPM_STABLE_CHANNEL_COUNT)
@@ -288,6 +285,8 @@ static void PIOS_PPM_tim_edge_cb (uintptr_t tim_id, uintptr_t context, uint8_t c
 		/* Check if the last frame was well formed */
 		if (ppm_dev->PulseIndex == ppm_dev->NumChannels && ppm_dev->Tracking) {
 			/* The last frame was well formed */
+			ppm_dev->Fresh = true;
+
 			for (uint32_t i = 0; i < ppm_dev->NumChannels; i++) {
 				ppm_dev->CaptureValue[i] = ppm_dev->CaptureValueNewFrame[i];
 			}

--- a/flight/PiOS/STM32F30x/pios_ppm.c
+++ b/flight/PiOS/STM32F30x/pios_ppm.c
@@ -273,9 +273,6 @@ static void PIOS_PPM_tim_edge_cb (uintptr_t tim_id, uintptr_t context, uint8_t c
 			&& ppm_dev->PulseIndex >= PIOS_PPM_IN_MIN_NUM_CHANNELS
 			&& ppm_dev->PulseIndex <= PIOS_PPM_IN_MAX_NUM_CHANNELS)
 		{
-			/* Regardless of whether we have lock, note that this is a sane frame */
-			ppm_dev->Fresh = true;
-
 			/* If we see n simultaneous frames of the same
 			   number of channels we save it as our frame size */
 			if (ppm_dev->NumChannelCounter < PIOS_PPM_STABLE_CHANNEL_COUNT)
@@ -289,6 +286,8 @@ static void PIOS_PPM_tim_edge_cb (uintptr_t tim_id, uintptr_t context, uint8_t c
 		/* Check if the last frame was well formed */
 		if (ppm_dev->PulseIndex == ppm_dev->NumChannels && ppm_dev->Tracking) {
 			/* The last frame was well formed */
+			ppm_dev->Fresh = true;
+
 			for (uint32_t i = 0; i < ppm_dev->NumChannels; i++) {
 				ppm_dev->CaptureValue[i] = ppm_dev->CaptureValueNewFrame[i];
 			}

--- a/flight/PiOS/STM32F4xx/pios_ppm.c
+++ b/flight/PiOS/STM32F4xx/pios_ppm.c
@@ -272,9 +272,6 @@ static void PIOS_PPM_tim_edge_cb (uintptr_t tim_id, uintptr_t context, uint8_t c
 			&& ppm_dev->PulseIndex >= PIOS_PPM_IN_MIN_NUM_CHANNELS
 			&& ppm_dev->PulseIndex <= PIOS_PPM_IN_MAX_NUM_CHANNELS)
 		{
-			/* Regardless of whether we have lock, note that this is a sane frame */
-			ppm_dev->Fresh = true;
-
 			/* If we see n simultaneous frames of the same
 			   number of channels we save it as our frame size */
 			if (ppm_dev->NumChannelCounter < PIOS_PPM_STABLE_CHANNEL_COUNT)
@@ -288,6 +285,8 @@ static void PIOS_PPM_tim_edge_cb (uintptr_t tim_id, uintptr_t context, uint8_t c
 		/* Check if the last frame was well formed */
 		if (ppm_dev->PulseIndex == ppm_dev->NumChannels && ppm_dev->Tracking) {
 			/* The last frame was well formed */
+			ppm_dev->Fresh = true;
+
 			for (uint32_t i = 0; i < ppm_dev->NumChannels; i++) {
 				ppm_dev->CaptureValue[i] = ppm_dev->CaptureValueNewFrame[i];
 			}


### PR DESCRIPTION
Prior to this, the supervisor was held off any time we saw
valid frame pulses, even if the frame wasn't otherwise sane.

This causes a particular issue on Graupner Rx's when they
trigger failsafe mode (ie. when the Tx signal goes away).
These Rx's output a 50Hz square wave which will look to the
PPM code like a continual series of frame pulses with zero
valid channels.  This was previously enough to hold off the
supervisor and resulted in the PPM code holding the last good
value on all of its inputs.  This entirely invalidated the
failsafe behaviour on the Graupner Rx.

The 50Hz square wave should now be properly detected as an
invalid frame (zero channel pulses) and should allow the
supervisor to declare all channels as being in the TIMEOUT
state so the FC can activate its own failsafe mode.

Fixes #810.

Tested on sparky with FrSky D4R-II to ensure that regular PPM still works.  Can't test the 50Hz square wave behaviour easily.
