### PR TITLE
Modules: rename the "GPS" field more specifically

### DIFF
--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -477,8 +477,11 @@
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
         <widget class="QGroupBox" name="gb_airspeedGPS">
+         <property name="toolTip">
+          <string>Use the GPS to estimate the airspeed and windspeed from ground speed.</string>
+         </property>
          <property name="title">
-          <string>GPS</string>
+          <string>Premerlani GPS algorithm</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -518,6 +521,9 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gb_airspeedPitot">
+         <property name="toolTip">
+          <string>Use a pitot tube to directly measure airspeed</string>
+         </property>
          <property name="title">
           <string>Pitot sensor</string>
          </property>


### PR DESCRIPTION
This renames the check box for "GPS" in the airspeed tab to "Prelemari GPS Algorithm".  This makes it clear we aren't directly using the GPS to set the airspeed but rather running some calculations, as well as give credit to the author of the algorithm. This will also scale if we implement multiple algorithms based on GPS to get the airspeed.

Users have reported confusion as to what it means to use GPS to measure airspeed and thought we might mean groundspeed.  Specify the algorithm we are using in the selection box and clarify that it is uses the GPS to infer the wind speed.

Unfortunately the previous attempt to rename this more clearly was reverted without discussion so the end-user confusion is still an issue.
