### PR TITLE
uploader: make bootloader version unsigned to fix -128

### DIFF
--- a/ground/gcs/src/plugins/uploader/op_dfu.h
+++ b/ground/gcs/src/plugins/uploader/op_dfu.h
@@ -109,7 +109,7 @@ namespace OP_DFU {
     {
             quint16 ID;
             quint32 FW_CRC;
-            int BL_Version;
+            quint8 BL_Version;
             int SizeOfDesc;
             quint32 SizeOfCode;
             bool Readable;


### PR DESCRIPTION
New Tau Labs bootloader versions are 0x80.  This shows
up as -128 in GCS uploader gadget.  Change version to
unsigned to fix.
