### PR TITLE
Fix bug by which accelerometer calibration values were overwritten when canceling out of a magnetometer-only 6-point calibration.

### DIFF
--- a/ground/gcs/src/plugins/config/calibration.cpp
+++ b/ground/gcs/src/plugins/config/calibration.cpp
@@ -1480,22 +1480,22 @@ void Calibration::resetSensorCalibrationToOriginalValues()
     SensorSettings::DataFields sensorSettingsData = sensorSettings->getData();
 
     if (calibrateAccels) {
-        sensorSettingsData.AccelScale[SensorSettings::ACCELSCALE_X]=initialAccelsScale[0];
-        sensorSettingsData.AccelScale[SensorSettings::ACCELSCALE_Y]=initialAccelsScale[1];
-        sensorSettingsData.AccelScale[SensorSettings::ACCELSCALE_Z]=initialAccelsScale[2];
-        sensorSettingsData.AccelBias[SensorSettings::ACCELBIAS_X]=initialAccelsBias[0];
-        sensorSettingsData.AccelBias[SensorSettings::ACCELBIAS_Y]=initialAccelsBias[1];
-        sensorSettingsData.AccelBias[SensorSettings::ACCELBIAS_Z]=initialAccelsBias[2];
+        sensorSettingsData.AccelScale[SensorSettings::ACCELSCALE_X] = initialAccelsScale[0];
+        sensorSettingsData.AccelScale[SensorSettings::ACCELSCALE_Y] = initialAccelsScale[1];
+        sensorSettingsData.AccelScale[SensorSettings::ACCELSCALE_Z] = initialAccelsScale[2];
+        sensorSettingsData.AccelBias[SensorSettings::ACCELBIAS_X] = initialAccelsBias[0];
+        sensorSettingsData.AccelBias[SensorSettings::ACCELBIAS_Y] = initialAccelsBias[1];
+        sensorSettingsData.AccelBias[SensorSettings::ACCELBIAS_Z] = initialAccelsBias[2];
     }
 
     if (calibrateMags) {
         //Write the original magnetometer values back to the device
-        sensorSettingsData.MagScale[SensorSettings::MAGSCALE_X]=initialMagsScale[0];
-        sensorSettingsData.MagScale[SensorSettings::MAGSCALE_Y]=initialMagsScale[1];
-        sensorSettingsData.MagScale[SensorSettings::MAGSCALE_Z]=initialMagsScale[2];
-        sensorSettingsData.MagBias[SensorSettings::MAGBIAS_X]=initialMagsBias[0];
-        sensorSettingsData.MagBias[SensorSettings::MAGBIAS_Y]=initialMagsBias[1];
-        sensorSettingsData.MagBias[SensorSettings::MAGBIAS_Z]=initialMagsBias[2];
+        sensorSettingsData.MagScale[SensorSettings::MAGSCALE_X] = initialMagsScale[0];
+        sensorSettingsData.MagScale[SensorSettings::MAGSCALE_Y] = initialMagsScale[1];
+        sensorSettingsData.MagScale[SensorSettings::MAGSCALE_Z] = initialMagsScale[2];
+        sensorSettingsData.MagBias[SensorSettings::MAGBIAS_X] = initialMagsBias[0];
+        sensorSettingsData.MagBias[SensorSettings::MAGBIAS_Y] = initialMagsBias[1];
+        sensorSettingsData.MagBias[SensorSettings::MAGBIAS_Z] = initialMagsBias[2];
     }
 
     sensorSettings->setData(sensorSettingsData);


### PR DESCRIPTION
Fixes https://github.com/TauLabs/TauLabs/issues/830
