### PR TITLE
bl unified: use cable connected instead of check available

### DIFF
--- a/flight/targets/bl/common/main.c
+++ b/flight/targets/bl/common/main.c
@@ -466,13 +466,13 @@ int main(void)
 		/* check for changes in USB connection state */
 		if (!usb_connected) {
 			/* Check if a USB host becomes present */
-			if (PIOS_USB_CheckAvailable(0)) {
+			if (PIOS_USB_CableConnected(0)) {
 				bl_fsm_inject_event(&bl_fsm_context, BL_EVENT_USB_CONNECTED);
 				usb_connected = true;
 			}
 		} else {
 			/* Check if the USB host disappears */
-			if (!PIOS_USB_CheckAvailable(0)) {
+			if (!PIOS_USB_CableConnected(0)) {
 				bl_fsm_inject_event(&bl_fsm_context, BL_EVENT_USB_DISCONNECTED);
 				usb_connected = false;
 			}

--- a/flight/targets/discoveryf4/board-info/board-info.mk
+++ b/flight/targets/discoveryf4/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x85
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x01
 
 MCU                 := cortex-m4

--- a/flight/targets/flyingf3/board-info/board-info.mk
+++ b/flight/targets/flyingf3/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x83
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00		# seems to be unused
 
 MCU                 := cortex-m4

--- a/flight/targets/flyingf4/board-info/board-info.mk
+++ b/flight/targets/flyingf4/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x84
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00		# seems to be unused
 
 MCU                 := cortex-m4

--- a/flight/targets/freedom/board-info/board-info.mk
+++ b/flight/targets/freedom/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x81
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00
 
 MCU                 := cortex-m4

--- a/flight/targets/quanton/board-info/board-info.mk
+++ b/flight/targets/quanton/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x86
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00		# seems to be unused
 
 MCU                 := cortex-m4

--- a/flight/targets/revolution/board-info/board-info.mk
+++ b/flight/targets/revolution/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x7F
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00
 
 MCU                 := cortex-m4

--- a/flight/targets/revomini/board-info/board-info.mk
+++ b/flight/targets/revomini/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x09
 BOARD_REVISION      := 0x03
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00
 
 MCU                 := cortex-m4

--- a/flight/targets/sparky/board-info/board-info.mk
+++ b/flight/targets/sparky/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x88
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x80
+BOOTLOADER_VERSION  := 0x81
 HW_TYPE             := 0x00		# seems to be unused
 
 MCU                 := cortex-m4


### PR DESCRIPTION
PIOS_USB_CheckAvailable() checks for both cable connected
as well as whether the device is fully enumerated.  This
more stringent check takes a more variable amount of time
on different computers.

It is much more appropriate to simply check whether the
USB cable is connected to determine whether we should wait
further in the bootloader.

Also bumped the bootloader version on affected boards to 0x81.
