### PR TITLE
Moved tool definitions to more appropriate location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,6 @@ include $(ROOT_DIR)/flight/targets/*/target-defs.mk
 # OpenPilot GCS build configuration (debug | release)
 GCS_BUILD_CONF ?= debug
 
-# Set up misc host tools
-RM=rm
-
 ##############################
 #
 # Check that environmental variables are sane
@@ -237,51 +234,6 @@ $(TOOLS_DIR):
 
 $(BUILD_DIR):
 	mkdir -p $@
-
-##############################
-#
-# Set up paths to tools
-#
-##############################
-
-ifeq ($(shell [ -d "$(QT_SDK_DIR)" ] && echo "exists"), exists)
-  QMAKE = $(QT_SDK_QMAKE_PATH)
-else
-  # not installed, hope it's in the path...
-  QMAKE = qmake
-endif
-
-ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
-  ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
-else
-  # not installed, hope it's in the path...
-  ARM_SDK_PREFIX ?= arm-none-eabi-
-endif
-
-ifeq ($(shell [ -d "$(OPENOCD_DIR)" ] && echo "exists"), exists)
-  OPENOCD := $(OPENOCD_DIR)/bin/openocd
-else
-  # not installed, hope it's in the path...
-  OPENOCD ?= openocd
-endif
-
-ifeq ($(shell [ -d "$(ANDROID_SDK_DIR)" ] && echo "exists"), exists)
-  ANDROID     := $(ANDROID_SDK_DIR)/tools/android
-  ANDROID_DX  := $(ANDROID_SDK_DIR)/platform-tools/dx
-  ANDROID_ADB := $(ANDROID_SDK_DIR)/platform-tools/adb
-else
-  # not installed, hope it's in the path...
-  ANDROID     ?= android
-  ANDROID_DX  ?= dx
-  ANDROID_ADB ?= adb
-endif
-
-ifeq ($(shell [ -d "$(ASTYLE_DIR)" ] && echo "exists"), exists)
-  ASTYLE := $(ASTYLE_DIR)/bin/astyle
-else
-  # not installed, hope it's in the path...
-  ASTYLE ?= astyle
-endif
 
 ##############################
 #

--- a/make/linux.mk
+++ b/make/linux.mk
@@ -6,6 +6,9 @@
 #   and the ARM toolchain installed to either the Taulabs/tools directory, their 
 #   respective default installation locations,  or made available on the system path.
 
+# misc tools
+RM=rm
+
 QT_SPEC=linux-g++
 
 UAVOBJGENERATOR="$(BUILD_DIR)/ground/uavobjgenerator/uavobjgenerator"

--- a/make/macosx.mk
+++ b/make/macosx.mk
@@ -6,6 +6,9 @@
 #   and the ARM toolchain installed to either the Taulabs/tools directory, their 
 #   respective default installation locations, or made available on the system path.
 
+# misc tools
+RM=rm
+
 QT_SPEC=macx-g++
 
 UAVOBJGENERATOR="$(BUILD_DIR)/ground/uavobjgenerator/uavobjgenerator"

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -506,3 +506,49 @@ libkml_clean:
 	$(V1) [ ! -d "$(LIBKML_INSTALL_DIR)" ] || $(RM) -rf "$(LIBKML_INSTALL_DIR)"
 	$(V0) @echo " CLEAN        $(LIBKML_BUILD_DIR)"
 	$(V1) [ ! -d "$(LIBKML_BUILD_DIR)" ] || $(RM) -rf "$(LIBKML_BUILD_DIR)"
+
+##############################
+#
+# Set up paths to tools
+#
+##############################
+
+ifeq ($(shell [ -d "$(QT_SDK_DIR)" ] && echo "exists"), exists)
+  QMAKE = $(QT_SDK_QMAKE_PATH)
+else
+  # not installed, hope it's in the path...
+  QMAKE = qmake
+endif
+
+ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
+  ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
+else
+  # not installed, hope it's in the path...
+  ARM_SDK_PREFIX ?= arm-none-eabi-
+endif
+
+ifeq ($(shell [ -d "$(OPENOCD_DIR)" ] && echo "exists"), exists)
+  OPENOCD := $(OPENOCD_DIR)/bin/openocd
+else
+  # not installed, hope it's in the path...
+  OPENOCD ?= openocd
+endif
+
+ifeq ($(shell [ -d "$(ANDROID_SDK_DIR)" ] && echo "exists"), exists)
+  ANDROID     := $(ANDROID_SDK_DIR)/tools/android
+  ANDROID_DX  := $(ANDROID_SDK_DIR)/platform-tools/dx
+  ANDROID_ADB := $(ANDROID_SDK_DIR)/platform-tools/adb
+else
+  # not installed, hope it's in the path...
+  ANDROID     ?= android
+  ANDROID_DX  ?= dx
+  ANDROID_ADB ?= adb
+endif
+
+ifeq ($(shell [ -d "$(ASTYLE_DIR)" ] && echo "exists"), exists)
+  ASTYLE := $(ASTYLE_DIR)/bin/astyle
+else
+  # not installed, hope it's in the path...
+  ASTYLE ?= astyle
+endif	
+	

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -12,6 +12,9 @@
 #   msysGit
 #   Python
 
+# misc tools
+RM=rm
+
 QT_SPEC := win32-g++
 
 # this might need to switch on debug/release


### PR DESCRIPTION
This commit moves the RM definition out of the make file and into an OS specific make file and the tool specific definitions into the tools.mk.

Note the Windows command should probably change and is intended as a future PR, and I intend another PR to modify the tools definitions. I think the tools may need to be in OS specific sections but am still working on that.
