### PR TITLE
Transmitter Control: only set AltHoldDesired when exists

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -809,8 +809,10 @@ static void update_path_desired(ManualControlCommandData * cmd, bool flightModeC
 	if (!flightModeChanged)
 		return;
 
-	if (PathDesiredHandle() == NULL)
+	if (PathDesiredHandle() == NULL) {
+		set_manual_control_error(SYSTEMALARMS_MANUALCONTROL_PATHFOLLOWER);
 		return;
+	}
 
 	PositionActualData positionActual;
 	PositionActualGet(&positionActual);

--- a/shared/uavobjectdefinition/systemalarms.xml
+++ b/shared/uavobjectdefinition/systemalarms.xml
@@ -24,7 +24,7 @@
             </elementnames>
         </field>
         <field name="ConfigError" units="" type="enum" elements="1" options="Stabilization,Multirotor,AutoTune,AltitudeHold,VelocityControl,PositionHold,PathPlanner,Undefined,None" defaultvalue="None" />
-        <field name="ManualControl" units="" type="enum" elements="1" options="Settings,NoRx,Accessory,AltitudeHold,Undefined,None" defaultvalue="None" />
+        <field name="ManualControl" units="" type="enum" elements="1" options="Settings,NoRx,Accessory,AltitudeHold,PathFollower,Undefined,None" defaultvalue="None" />
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>
         <telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Because AltitudeHoldDesired is only initialized when the module
is running (which applies at startup) but the flight mode
position can be changed on the fly, this can allow the FC to
write to an object that doesn't exist and then crash.

Fixes #865
