### PR TITLE
Explicitly add SystemAlarms UAVO to SysAlarmsMessaging .pro

### DIFF
--- a/ground/gcs/src/plugins/sysalarmsmessaging/sysalarmsmessaging.pro
+++ b/ground/gcs/src/plugins/sysalarmsmessaging/sysalarmsmessaging.pro
@@ -4,7 +4,8 @@ QT += svg
 include(../../taulabsgcsplugin.pri)
 include(../../plugins/coreplugin/coreplugin.pri)
 include(sysalarmsmessaging_dependencies.pri)
-HEADERS += sysalarmsmessagingplugin.h
+HEADERS += sysalarmsmessagingplugin.h \
+    $$UAVOBJECT_SYNTHETICS/systemalarms.h
 SOURCES += sysalarmsmessagingplugin.cpp
 FORMS +=  
 OTHER_FILES += SysAlarmsMessaging.pluginspec


### PR DESCRIPTION
On the advice of a Qt developer ("Just put that header file in the .pro and be done with it") this fixes the issue where SysAlarmsMessaging was not recompiling when the SystemAlarms UAVO was changed.

Fixes https://github.com/TauLabs/TauLabs/issues/777.
