### PR TITLE
[Splash screen]: Remove float on top property.

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
     QTranslator qtTranslator;
 
     QPixmap pixmap(":/images/resources/tau_trans.png");
-    CustomSplash splash(pixmap,Qt::WindowStaysOnTopHint);
+    CustomSplash splash(pixmap);
     splash.show();
 
     splash.showMessage("Loading translations",Qt::AlignCenter | Qt::AlignBottom,Qt::black);


### PR DESCRIPTION
Fixes #868. Splash screen now starts on top of all windows, but other windows can be raised above it. 

UPDATE: @guilhermito reports that on Windows 32, Windows 64, Ubuntu, and Kubuntu clicking on the splash screen makes it disappear. However, both @peabody124 and I have noticed that this behavior does not work on OSX. In addition, I have tested this on Linux Mint and seen the same behavior as OSX. It seems that the "click to destroy" behavior is system dependent.
