### PR TITLE
quanton: fix outputs for rcvport settings ppm+pwm and ppm+pwm+adc

### DIFF
--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -1180,6 +1180,8 @@ void PIOS_Board_Init(void) {
 		case HWQUANTON_RCVRPORT_PWMADC:
 		case HWQUANTON_RCVRPORT_PPM:
 		case HWQUANTON_RCVRPORT_PPMADC:
+		case HWQUANTON_RCVRPORT_PPMPWM:
+		case HWQUANTON_RCVRPORT_PPMPWMADC:
 			/* Set up the servo outputs */
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_cfg);


### PR DESCRIPTION
fixes #878
