### PR TITLE
InputWizard: cancel out when board is disconnected

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.h
+++ b/ground/gcs/src/plugins/config/configinputwidget.h
@@ -160,6 +160,9 @@ private:
         void wizardSetUpStep(enum wizardSteps);
         void wizardTearDownStep(enum wizardSteps);
 
+        //! Handle to telemetry manager for monitoring for disconnects
+        TelemetryManager* telMngr;
+
 private slots:
         void wzNext();
         void wzBack();


### PR DESCRIPTION
If a user plugs in a board and then unplugs it during the middle
of calibration their original settings (including arming) will be
restored.  However, if they then start moving the sticks to test
the range they will end up arming the system which is dangerous
(although props should have been removed to do this step).
