### PR TITLE
ComplementaryFilter: use z-axis correction from accels

### DIFF
--- a/flight/Modules/Attitude/revolution/attitude.c
+++ b/flight/Modules/Attitude/revolution/attitude.c
@@ -578,7 +578,7 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary)
 	// Correct rates based on error, integral component dealt with in updateSensors
 	gyrosData.x += accel_err[0] * attitudeSettings.AccelKp / dT;
 	gyrosData.y += accel_err[1] * attitudeSettings.AccelKp / dT;
-	gyrosData.z += mag_err[2] * attitudeSettings.MagKp / dT;
+	gyrosData.z += accel_err[2] * attitudeSettings.AccelKp / dT + mag_err[2] * attitudeSettings.MagKp / dT;
 
 	// Work out time derivative from INSAlgo writeup
 	// Also accounts for the fact that gyros are in deg/s


### PR DESCRIPTION
This doesn't matter normally when board is horizontal but
when at strong pitches or rolls this correctlys the
perpendicular axis.

Not applying to the integral component since during most flying
this won't be useful or could only add noise and the mag is
more useful for this axis.
