### PR TITLE
resubmit from #909: Adds different VirtualBar parameters to TxPID

### DIFF
--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -267,6 +267,59 @@ static void updatePIDs(UAVObjEvent* ev)
 			case TXPIDSETTINGS_PIDS_GYROTAU:
 				needsUpdate |= update(&stab.GyroTau, value);
 				break;
+			case TXPIDSETTINGS_PIDS_ROLLVBARSENSITIVITY: 
+				needsUpdate |= update(&stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_ROLL], value);
+				break;
+			case TXPIDSETTINGS_PIDS_PITCHVBARSENSITIVITY:
+				needsUpdate |= update(&stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_PITCH], value);
+				break;
+			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARSENSITIVITY:
+				needsUpdate |= update(&stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_ROLL], value);
+				needsUpdate |= update(&stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_PITCH], value);
+				break;
+			
+			case TXPIDSETTINGS_PIDS_YAWVBARSENSITIVITY:
+				needsUpdate |= update(&stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_YAW], value);
+				break;
+			case TXPIDSETTINGS_PIDS_ROLLVBARKP:
+				needsUpdate |= update(&stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KP], value);
+				break;
+			case TXPIDSETTINGS_PIDS_ROLLVBARKI:
+				needsUpdate |= update(&stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KI], value);
+				break;	
+			case TXPIDSETTINGS_PIDS_ROLLVBARKD:
+				needsUpdate |= update(&stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KD], value);
+				break;
+			case TXPIDSETTINGS_PIDS_PITCHVBARKP:
+				needsUpdate |= update(&stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KP], value);
+				break;
+			case TXPIDSETTINGS_PIDS_PITCHVBARKI:
+				needsUpdate |= update(&stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KI], value);
+				break;
+			case TXPIDSETTINGS_PIDS_PITCHVBARKD:
+				needsUpdate |= update(&stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KD], value);
+				break;
+			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARKP:
+				needsUpdate |= update(&stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KP], value);
+				needsUpdate |= update(&stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KP], value);
+				break;
+			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARKI:
+				needsUpdate |= update(&stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KI], value);
+				needsUpdate |= update(&stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KI], value);
+				break;
+			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARKD:
+				needsUpdate |= update(&stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KD], value);
+				needsUpdate |= update(&stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KD], value);
+				break;
+			case TXPIDSETTINGS_PIDS_YAWVBARKP:
+				needsUpdate |= update(&stab.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KP], value);
+				break;
+			case TXPIDSETTINGS_PIDS_YAWVBARKI:
+				needsUpdate |= update(&stab.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KI], value);
+				break;
+			case TXPIDSETTINGS_PIDS_YAWVBARKD:
+				needsUpdate |= update(&stab.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KD], value);
+				break;
 			default:
 				PIOS_Assert(0);
 			}

--- a/shared/uavobjectdefinition/txpidsettings.xml
+++ b/shared/uavobjectdefinition/txpidsettings.xml
@@ -17,7 +17,11 @@
 			Roll Attitude.Kp, Pitch Attitude.Kp, Roll+Pitch Attitude.Kp, Yaw Attitude.Kp,
 			Roll Attitude.Ki, Pitch Attitude.Ki, Roll+Pitch Attitude.Ki, Yaw Attitude.Ki,
 			Roll Attitude.ILimit, Pitch Attitude.ILimit, Roll+Pitch Attitude.ILimit, Yaw Attitude.ILimit,
-			GyroTau"
+			GyroTau,
+			Roll VbarSensitivity, Pitch VbarSensitivity, Roll+Pitch VbarSensitivity, Yaw VbarSensitivity,
+			Roll Vbar.Kp, Pitch Vbar.Kp, Roll+Pitch Vbar.Kp, Yaw Vbar.Kp,
+			Roll Vbar.Ki,Pitch Vbar.Ki, Roll+Pitch Vbar.Ki, Yaw Vbar.Ki,
+			Roll Vbar.Kd, Pitch Vbar.Kd, Roll+Pitch Vbar.Kd, Yaw Vbar.Kd"
 		defaultvalue="Disabled"/>
         <field name="MinPID" units="" type="float" elementnames="Instance1,Instance2,Instance3" defaultvalue="0"/>
         <field name="MaxPID" units="" type="float" elementnames="Instance1,Instance2,Instance3" defaultvalue="0"/>


### PR DESCRIPTION
This adds those settings to TxPID:

Roll VbarSensitivity, Pitch VbarSensitivity, Yaw VbarSensitivity,Roll Vbar.Kp, Roll Vbar.Ki,
Roll Vbar.Kd, Pitch Vbar.Kp, Pitch Vbar.Ki,Pitch Vbar.Kd, Yaw Vbar.Kp, Yaw Vbar.Ki, Yaw Vbar.Kd

It's untested in flight, but setting part in GCS is ok.

Jenkins already gave the Good to merge ( Merged build finished ) from previous #909
