### PR TITLE
ManualControlCommand: use named channels

### DIFF
--- a/shared/uavobjectdefinition/manualcontrolcommand.xml
+++ b/shared/uavobjectdefinition/manualcontrolcommand.xml
@@ -1,15 +1,28 @@
 <xml>
     <object name="ManualControlCommand" singleinstance="true" settings="false">
-        <description>The output from the @ref ManualControlModule which descodes the receiver inputs.  Overriden by GCS for fly-by-wire control.</description>
+        <description>The output from the @ref ManualControlModule which decodes the receiver inputs.</description>
         <field name="Connected" units="" type="enum" elements="1" options="False,True"/>
         <field name="Throttle" units="%" type="float" elements="1"/>
         <field name="Roll" units="%" type="float" elements="1"/>
         <field name="Pitch" units="%" type="float" elements="1"/>
         <field name="Yaw" units="%" type="float" elements="1"/>
-	<field name="Rssi" units="%" type="int16" elements="1"/>
-	<field name="RawRssi" units="" type="uint32" elements="1"/>
+        <field name="Rssi" units="%" type="int16" elements="1"/>
+        <field name="RawRssi" units="" type="uint32" elements="1"/>
         <field name="Collective" units="%" type="float" elements="1"/>
-        <field name="Channel" units="us" type="uint16" elements="9"/>
+        <field name="Channel" units="us" type="uint16">
+            <!-- Must match order in ManualControlSettings.ChannelGroups -->
+            <elementnames>
+                <elementname>Throttle</elementname>
+                <elementname>Roll</elementname>
+                <elementname>Pitch</elementname>
+                <elementname>Yaw</elementname>
+                <elementname>FlightMode</elementname>
+                <elementname>Collective</elementname>
+                <elementname>Accessory0</elementname>
+                <elementname>Accessory1</elementname>
+                <elementname>Accessory2</elementname>
+            </elementnames>
+        </field>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="periodic" period="2000"/>


### PR DESCRIPTION
The channels field of ManualControlCommand has mapped to named
channels for quite some while but the fact it just shows us as
a vector lead people to believe it was related to the order of
the underlying driver layer.  This should decrease that
ambiguity.
