### PR TITLE
Fixes an issue by which the PFD was continuing to process events even when it was no longer visible.

### DIFF
--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
@@ -58,7 +58,6 @@ PfdQmlGadgetWidget::PfdQmlGadgetWidget(QWidget *parent) :
 
     //setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers)));
 
-    QStringList objectsToExport;
     objectsToExport << "VelocityActual" <<
                        "PositionActual" <<
                        "AttitudeActual" <<
@@ -97,6 +96,13 @@ PfdQmlGadgetWidget::~PfdQmlGadgetWidget()
 {
 }
 
+
+/**
+ * @brief PfdQmlGadgetWidget::exportUAVOInstance Makes the UAVO available inside the QML. This works via the Q_PROPERTY()
+ * values in the UAVO synthetic-headers
+ * @param objectName UAVObject name
+ * @param instId Instance ID
+ */
 void PfdQmlGadgetWidget::exportUAVOInstance(const QString &objectName, int instId)
 {
     UAVObject* object = m_objManager->getObject(objectName, instId);
@@ -106,6 +112,20 @@ void PfdQmlGadgetWidget::exportUAVOInstance(const QString &objectName, int instI
         qWarning() << "Failed to load object" << objectName;
 }
 
+
+/**
+ * @brief PfdQmlGadgetWidget::resetUAVOExport Makes the UAVO no longer available inside the QML.
+ * @param objectName UAVObject name
+ * @param instId Instance ID
+ */
+void PfdQmlGadgetWidget::resetUAVOExport(const QString &objectName, int instId)
+{
+    UAVObject* object = m_objManager->getObject(objectName, instId);
+    if (object)
+        engine()->rootContext()->setContextProperty(objectName, (QObject*)NULL);
+    else
+        qWarning() << "Failed to load object" << objectName;
+}
 
 void PfdQmlGadgetWidget::setQmlFile(QString fn)
 {
@@ -198,4 +218,40 @@ void PfdQmlGadgetWidget::setAltitude(double arg)
         m_altitude = arg;
         emit altitudeChanged(arg);
     }
+}
+
+
+/**
+ * @brief PfdQmlGadgetWidget::hideEvent Reimplements hideEvent() in order to break
+ * the connection between the UAVO and the QML state updates
+ * @param event
+ */
+void PfdQmlGadgetWidget::hideEvent(QHideEvent *event)
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    m_objManager = pm->getObject<UAVObjectManager>();
+
+    foreach (const QString &objectName, objectsToExport) {
+        resetUAVOExport(objectName, 0);
+    }
+
+    QWidget::hideEvent(event);
+}
+
+
+/**
+ * @brief PfdQmlGadgetWidget::showEvent Reimplements showEvent() in order to recreate
+ * the connection between the UAVO and the QML state updates
+ * @param event
+ */
+void PfdQmlGadgetWidget::showEvent(QShowEvent *event)
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    m_objManager = pm->getObject<UAVObjectManager>();
+
+    foreach (const QString &objectName, objectsToExport) {
+        exportUAVOInstance(objectName, 0);
+    }
+
+    QWidget::showEvent(event);
 }

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.h
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.h
@@ -60,8 +60,6 @@ public slots:
     void setActualPositionUsed(bool arg);
     void setSettingsMap(const QVariantMap &settings);
 
-    void exportUAVOInstance(const QString &objectName, int instId);
-
 signals:
     void earthFileChanged(QString arg);
     void terrainEnabledChanged(bool arg);
@@ -72,6 +70,7 @@ signals:
     void altitudeChanged(double arg);
 
 private:
+    QStringList objectsToExport;
     QString m_qmlFileName;
     QString m_earthFile;
     bool m_openGLEnabled;
@@ -83,6 +82,10 @@ private:
     double m_altitude;
 
     UAVObjectManager *m_objManager;
+    void hideEvent(QHideEvent *event);
+    void showEvent(QShowEvent *event);
+    void exportUAVOInstance(const QString &objectName, int instId);
+    void resetUAVOExport(const QString &objectName, int instId);
 };
 
 #endif /* PFDQMLGADGETWIDGET_H_ */


### PR DESCRIPTION
1. Plug in board
2. Start GCS
3. On Welcome screen, processor load is 6%
4. Go to Flight screen
5. Processor load increases to 20%
6. Return to Welcome screen, processor load stays at 20%

This is because the QML is still processing the state changes, even though it is no longer visible.

The proposed fix disables the UAVO connection to the QML when the QML is hidden. On OSX with Qt 4.8, this saved 14% processor load. This might not be an issue on other platforms. It also might be fixed in Qt 5.1: https://bugreports.qt-project.org/browse/QTBUG-29137, but this is unclear since the described behavior is not the same as here.

UPDATE: On all tested platforms, this shows sizable gains, although it's interesting to note that on Linux platforms there is variability on whether the gain comes as a result of switching to the Welcome screen or minimizing/hiding the GCS. It's unclear why QML doesn't behave universally across all platforms, but this PR does not seek to address that.
