### PR TITLE
Explicitly added "phonon" directory in order to solve compile problem on certain Linux platforms.

### DIFF
--- a/ground/gcs/src/plugins/notify/notifyplugin.cpp
+++ b/ground/gcs/src/plugins/notify/notifyplugin.cpp
@@ -41,7 +41,7 @@
 
 #include <iostream>
 #include "qxttimer.h"
-#include "backendcapabilities.h"
+#include "phonon/backendcapabilities.h"
 
 static const QString VERSION = "1.0.0";
 


### PR DESCRIPTION
This problem was seen with both [Tau Labs](https://groups.google.com/d/msg/phoenixpilot/guaO7yu8fZs/96CGdChM8nkJ) and [OpenPilot](http://forums.openpilot.org/topic/21678-problem-compiling-srcpluginsnotifynotifyplugincpp/) code.

Since Phonon is removed in Qt5, this won't hang around long.

This should be tested to see if it compiles properly on all platforms. There are no compiling issues on OSX.
