### PR TITLE
ManualControl: remove unused block of code

### DIFF
--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -49,12 +49,10 @@
 #include "systemalarms.h"
 
 // Private constants
-#if defined(PIOS_CONTROL_STACK_SIZE)
+#if defined(PIOS_MANUAL_STACK_SIZE)
 #define STACK_SIZE_BYTES PIOS_MANUAL_STACK_SIZE
-#elif !defined(COPTERCONTROL)
-#define STACK_SIZE_BYTES 1424
 #else
-#define STACK_SIZE_BYTES 550
+#define STACK_SIZE_BYTES 1424
 #endif
 
 #define TASK_PRIORITY (tskIDLE_PRIORITY+4)

--- a/flight/targets/coptercontrol/fw/pios_config.h
+++ b/flight/targets/coptercontrol/fw/pios_config.h
@@ -99,7 +99,7 @@
 
 /* Task stack sizes */
 #define PIOS_ACTUATOR_STACK_SIZE        800
-#define PIOS_MANUAL_STACK_SIZE          800
+#define PIOS_MANUAL_STACK_SIZE          550
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   524
 #define PIOS_TELEM_STACK_SIZE           500


### PR DESCRIPTION
This conditional was never triggered since CC defines
PIOS_MANUAL_STACK_SIZE
but it was misleading since it read like it was used.
