### PR TITLE
TabletControl: do not segfault if PathDesired not initialized

### DIFF
--- a/flight/Modules/ManualControl/tablet_control.c
+++ b/flight/Modules/ManualControl/tablet_control.c
@@ -79,6 +79,9 @@ int32_t tablet_control_select(bool reset_controller)
 	FlightStatusData flightStatus;
 	FlightStatusGet(&flightStatus);
 
+	if (PathDesiredHandle() == NULL)
+		return -1;
+
 	PathDesiredData pathDesired;
 	PathDesiredGet(&pathDesired);
 


### PR DESCRIPTION
Because you can enable tablet control without enabling the pathfollower module
this will lead to a segfault.  It was covered by the sanity check so no one could
fly like this, but rebooting FCs are still bad.
