### PR TITLE
fix map spinbox zoom

### DIFF
--- a/ground/gcs/src/plugins/opmap/opmapgadgetoptionspage.cpp
+++ b/ground/gcs/src/plugins/opmap/opmapgadgetoptionspage.cpp
@@ -68,7 +68,7 @@ QWidget *OPMapGadgetOptionsPage::createPage(QWidget *parent)
 	index = (index >= 0) ? index : 0;
 	m_page->providerComboBox->setCurrentIndex(index);
 
-    // if provider is userimage maximum zoom is 31
+    // if provider is userimage maximum zoom is 32
     if(m_config->mapProvider()=="UserImage")
         m_page->zoomSpinBox->setMaximum(32);
 


### PR DESCRIPTION
Fix the zoom spinbox on map options page that always load with maximum value of 21.

Fixes #921.
