### PR TITLE
Removes explicit dependency on SystemAlarms UAVObjID value

### DIFF
--- a/ground/gcs/src/plugins/sysalarmsmessaging/sysalarmsmessagingplugin.cpp
+++ b/ground/gcs/src/plugins/sysalarmsmessaging/sysalarmsmessagingplugin.cpp
@@ -89,8 +89,6 @@ bool SysAlarmsMessagingPlugin::initialize(const QStringList &arguments, QString 
  */
 void SysAlarmsMessagingPlugin::updateAlarms(UAVObject* systemAlarm)
 {
-    Q_ASSERT(systemAlarm->getObjID() == SystemAlarms::OBJID);
-
     foreach (UAVObjectField *field, systemAlarm->getFields()) {
         for (uint i = 0; i < field->getNumElements(); ++i) {
             QString element = field->getElementNames()[i];


### PR DESCRIPTION
In https://github.com/TauLabs/TauLabs/pull/873, @guilhermito explained that enforcing that all plugins are compiled at the same time as the uavos library is a bad use of a shared library. "Using a shared library allows us (should allow us) to use different versions of the uavos library without failing the assertion. Imagine we only change the default value of an object field, we could recompile the uavos lib and only distribute that. All the plugins would then use it without any problems."

This PR removes the explicit dependency on the SystemAlarms UAVObjID value, as "if the methods used don't change (in terms of signature) I don't see a need for recompilation, that is how shared libs are supposed to work."
