### PR TITLE
Shuts off all actuator output during calibration.

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -710,10 +710,13 @@ void ConfigInputWidget::fastMdata()
                         break;
                     case ActuatorCommand::OBJID:
                         UAVObject::SetFlightAccess(mdata, UAVObject::ACCESS_READONLY);
+                        UAVObject::SetFlightTelemetryUpdateMode(mdata, UAVObject::UPDATEMODE_PERIODIC);
+                        mdata.flightTelemetryUpdatePeriod = slowUpdate;
                         break;
                     default:
                         UAVObject::SetFlightTelemetryUpdateMode(mdata, UAVObject::UPDATEMODE_PERIODIC);
                         mdata.flightTelemetryUpdatePeriod = slowUpdate;
+                        break;
                 }
 
                 metaDataList.insert(obj->getName(), mdata);


### PR DESCRIPTION
This prevented a dangerous situation where until the TX channels were calibrated the actuators would respond to transmitter jitter.

Tested and works as intended.

Fixes #579.
