### PR TITLE
[RevoMini]: Fix an error in the RevoMini input channels.

### DIFF
--- a/flight/targets/revomini/board-info/board_hw_defs.c
+++ b/flight/targets/revomini/board-info/board_hw_defs.c
@@ -1325,22 +1325,6 @@ const struct pios_servo_cfg pios_servo_cfg = {
 static const struct pios_tim_channel pios_tim_rcvrport_all_channels[] = {
 	{
 		.timer = TIM12,
-		.timer_chan = TIM_Channel_1,
-		.pin = {
-			.gpio = GPIOB,
-			.init = {
-				.GPIO_Pin = GPIO_Pin_14,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
-			},
-			.pin_source = GPIO_PinSource14,
-		},
-		.remap = GPIO_AF_TIM12,
-	},
-	{
-		.timer = TIM12,
 		.timer_chan = TIM_Channel_2,
 		.pin = {
 			.gpio = GPIOB,
@@ -1418,6 +1402,22 @@ static const struct pios_tim_channel pios_tim_rcvrport_all_channels[] = {
 			.pin_source = GPIO_PinSource9,
 		},
 		.remap = GPIO_AF_TIM8,
+	},
+	{
+		.timer = TIM12,
+		.timer_chan = TIM_Channel_1,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_14,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource14,
+		},
+		.remap = GPIO_AF_TIM12,
 	},
 };
 


### PR DESCRIPTION
I initially thought this fix was only for the prototype, ~~but looking at OpenPilot's RevoMini source code it seems that it's a code error~~.

This effectively shifts channels, so that the first input pin to RM is also the PPM input pin.
