### PR TITLE
Fixed missing plugin dependencies in TelemetryScheduler

### DIFF
--- a/ground/gcs/src/plugins/plugins.pro
+++ b/ground/gcs/src/plugins/plugins.pro
@@ -175,6 +175,7 @@ SUBDIRS += plugin_waypointeditor
 plugin_telemetryscheduler.subdir = telemetryscheduler
 plugin_telemetryscheduler.depends = plugin_coreplugin
 plugin_telemetryscheduler.depends += plugin_uavobjects
+plugin_telemetryscheduler.depends += plugin_uavobjectutil
 SUBDIRS += plugin_telemetryscheduler
 
 # Primary Flight Display (PFD) gadget, QML version

--- a/ground/gcs/src/plugins/telemetryscheduler/TelemetryScheduler.pluginspec
+++ b/ground/gcs/src/plugins/telemetryscheduler/TelemetryScheduler.pluginspec
@@ -7,7 +7,6 @@
     <dependencyList>
         <dependency name="Core" version="1.0.0"/>
         <dependency name="UAVObjects" version="1.0.0"/>
-        <dependency name="UAVTalk" version="1.0.0"/>
         <dependency name="UAVObjectUtil" version="1.0.0"/>
     </dependencyList>
 </plugin>    

--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.pro
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryscheduler.pro
@@ -7,7 +7,6 @@ DEFINES += TELEMETRYSCHEDULER_LIBRARY
 include(../../taulabsgcsplugin.pri) 
 include(../../plugins/coreplugin/coreplugin.pri) 
 include(../../plugins/uavobjects/uavobjects.pri)
-include(../../plugins/uavtalk/uavtalk.pri)
 include(../../plugins/uavobjectutil/uavobjectutil.pri)
 
 HEADERS += telemetryschedulergadget.h


### PR DESCRIPTION
I think this is what @solidgoldbomb noticed when building with a high number of cores.
