### PR TITLE
Fix android java 1.7+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,7 +448,7 @@ $$(UAVO_COLLECTION_DIR)/$(1)/java-build/uavobjects.jar: $$(UAVO_COLLECTION_DIR)/
 	$$(V1) ( \
 		HASH=$$$$(cat $$(UAVO_COLLECTION_DIR)/$(1)/uavohash) && \
 		cd $$(UAVO_COLLECTION_DIR)/$(1)/java-build && \
-		javac java/*.java \
+		javac -source 1.6 -target 1.6 java/*.java \
 		   $$(ROOT_DIR)/androidgcs/src/org/taulabs/uavtalk/UAVDataObject.java \
 		   $$(ROOT_DIR)/androidgcs/src/org/taulabs/uavtalk/UAVObject*.java \
 		   $$(ROOT_DIR)/androidgcs/src/org/taulabs/uavtalk/UAVMetaObject.java \


### PR DESCRIPTION
Fixes #775.

Builds fine on ubuntu 13.04 using:

```
oracle-java8-installer - Oracle Java(TM) Development Kit (JDK) 8
```

Final android app is untested so I'm not positive this works.
