### PR TITLE
CC3D: Bump manual control stack size 50

### DIFF
--- a/flight/targets/coptercontrol/fw/pios_config.h
+++ b/flight/targets/coptercontrol/fw/pios_config.h
@@ -99,7 +99,7 @@
 
 /* Task stack sizes */
 #define PIOS_ACTUATOR_STACK_SIZE        800
-#define PIOS_MANUAL_STACK_SIZE          550
+#define PIOS_MANUAL_STACK_SIZE          600
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   524
 #define PIOS_TELEM_STACK_SIZE           500


### PR DESCRIPTION
Reports of stack overflow when using rate mode.  Free stack when
not being used before this was 100 but it could go lower when
various modes are engaged.

Heap remaining for a standard configuration after this patch is 2880 so it should
work fine.

For testing purposes here is a diagnostics enabled version of CC3D without this patch:
https://dl.dropboxusercontent.com/u/6645063/fw_coptercontrol_diagnostics.tlfw
