### PR TITLE
Bugfix GetHashofDirs

### DIFF
--- a/make/scripts/version-info.py
+++ b/make/scripts/version-info.py
@@ -263,7 +263,7 @@ def GetHashofDirs(directory, verbose=0, raw=0, what_to_hash='..*.xml'):
       if files:
           files.sort()
 
-      regexp = re.compile('.*.xml')
+      regexp = re.compile(what_to_hash)
       
       for names in [f for f in files if regexp.match(f)]:
         if verbose == 1:


### PR DESCRIPTION
GetHashofDirs would calculate an incorrect hash on directories with `.DS_Store` etc; 

now it only scans by default *.xml files.
