### PR TITLE
[Logging]: Fix crash while exiting GCS during logfile playback 

### DIFF
--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -118,8 +118,13 @@ QString LoggingConnection::shortName()
 
 
 
-
-
+/**
+ * @brief LoggingThread::~LoggingThread Destructor
+ */
+LoggingThread::~LoggingThread()
+{
+    stopLogging();
+}
 
 /**
   * Sets the file to use for logging and takes the parent plugin
@@ -413,7 +418,6 @@ void LoggingPlugin::stopLogging()
 {
     emit stopLoggingSignal();
     disconnect( this,SIGNAL(stopLoggingSignal()),0,0);
-
 }
 
 
@@ -428,7 +432,7 @@ void LoggingPlugin::loggingStopped()
 
     emit stateChanged("IDLE");
 
-    free(loggingThread);
+    delete loggingThread;
     loggingThread = NULL;
 }
 

--- a/ground/gcs/src/plugins/logging/loggingplugin.h
+++ b/ground/gcs/src/plugins/logging/loggingplugin.h
@@ -87,6 +87,7 @@ class LoggingThread : public QThread
 {
 Q_OBJECT
 public:
+    ~LoggingThread();
     bool openFile(QString file, LoggingPlugin * parent);
 
 private slots:


### PR DESCRIPTION
Inspired by http://git.openpilot.org/cru/OPReview-571.

This is easy to recreate. Simply quit GCS after opening a logfile, but before it has finished playing.
