### PR TITLE
SparkyBGC: remove paths.c from Makefile

### DIFF
--- a/flight/targets/sparkybgc/fw/Makefile
+++ b/flight/targets/sparkybgc/fw/Makefile
@@ -96,7 +96,6 @@ SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
 endif
 
-SRC += $(FLIGHTLIB)/paths.c
 SRC += $(FLIGHTLIB)/fifo_buffer.c
 SRC += $(FLIGHTLIB)/WorldMagModel.c
 SRC += $(FLIGHTLIB)/insgps13state.c


### PR DESCRIPTION
Sparky doesn't need the paths.c file for anything.
