### PR TITLE
Actuator: Fix negative ranges

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -494,11 +494,11 @@ static uint16_t scaleChannel(float value, uint16_t max, uint16_t min, uint16_t n
 	// Scale
 	if ( value >= 0.0f)
 	{
-		valueScaled = (uint16_t)(value*((float)(max-neutral))) + neutral;
+		valueScaled = (int16_t)(value*((float)(max-neutral))) + neutral;
 	}
 	else
 	{
-		valueScaled = (uint16_t)(value*((float)(neutral-min))) + neutral;
+		valueScaled = (int16_t)(value*((float)(neutral-min))) + neutral;
 	}
 
 	if (max>min)


### PR DESCRIPTION
Fixes a mixer bug that I introduced when changing the ActuatorSettings to unsigned integers. While valueScaled cannot be negative, their is no guarantee on the sign of (neutral-min) or (max-neutral).

This wasn't caught in flight testing because quadcopters only use positive values for motors, and bench testing was with a logic analyzer in test mode, which bypasses the actuator mixer.
