### PR TITLE
Revert "[Actuator]: Fixed ActuatorSettings to use uint16"

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -76,7 +76,7 @@ static volatile bool mixer_settings_updated;
 
 // Private functions
 static void actuatorTask(void* parameters);
-static uint16_t scaleChannel(float value, uint16_t max, uint16_t min, uint16_t neutral);
+static int16_t scaleChannel(float value, int16_t max, int16_t min, int16_t neutral);
 static void setFailsafe(const ActuatorSettingsData * actuatorSettings, const MixerSettingsData * mixerSettings);
 static float MixerCurve(const float throttle, const float* curve, uint8_t elements);
 static bool set_channel(uint8_t mixer_channel, uint16_t value, const ActuatorSettingsData * actuatorSettings);
@@ -488,17 +488,17 @@ static float MixerCurve(const float throttle, const float* curve, uint8_t elemen
 /**
  * Convert channel from -1/+1 to servo pulse duration in microseconds
  */
-static uint16_t scaleChannel(float value, uint16_t max, uint16_t min, uint16_t neutral)
+static int16_t scaleChannel(float value, int16_t max, int16_t min, int16_t neutral)
 {
-	uint16_t valueScaled;
+	int16_t valueScaled;
 	// Scale
 	if ( value >= 0.0f)
 	{
-		valueScaled = (uint16_t)(value*((float)(max-neutral))) + neutral;
+		valueScaled = (int16_t)(value*((float)(max-neutral))) + neutral;
 	}
 	else
 	{
-		valueScaled = (uint16_t)(value*((float)(neutral-min))) + neutral;
+		valueScaled = (int16_t)(value*((float)(neutral-min))) + neutral;
 	}
 
 	if (max>min)

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -99,9 +99,9 @@ static void update_path_desired(ManualControlCommandData * cmd, bool flightModeC
 static void set_flight_mode();
 static void process_transmitter_events(ManualControlCommandData * cmd, ManualControlSettingsData * settings, float * scaled);
 static void set_manual_control_error(SystemAlarmsManualControlOptions errorCode);
-static float scaleChannel(uint16_t value, uint16_t max, uint16_t min, uint16_t neutral);
+static float scaleChannel(int16_t value, int16_t max, int16_t min, int16_t neutral);
 static uint32_t timeDifferenceMs(portTickType start_time, portTickType end_time);
-static bool validInputRange(uint16_t min, uint16_t max, uint16_t value, uint16_t offset);
+static bool validInputRange(int16_t min, int16_t max, uint16_t value, uint16_t offset);
 static void applyDeadband(float *value, float deadband);
 static void resetRcvrActivity(struct rcvr_activity_fsm * fsm);
 static bool updateRcvrActivity(struct rcvr_activity_fsm * fsm);
@@ -977,7 +977,7 @@ static void altitude_hold_desired(ManualControlCommandData * cmd, bool flightMod
 /**
  * Convert channel from servo pulse duration (microseconds) to scaled -1/+1 range.
  */
-static float scaleChannel(uint16_t value, uint16_t max, uint16_t min, uint16_t neutral)
+static float scaleChannel(int16_t value, int16_t max, int16_t min, int16_t neutral)
 {
 	float valueScaled;
 
@@ -1015,11 +1015,11 @@ static uint32_t timeDifferenceMs(portTickType start_time, portTickType end_time)
  * @brief Determine if the manual input value is within acceptable limits
  * @returns return TRUE if so, otherwise return FALSE
  */
-bool validInputRange(uint16_t min, uint16_t max, uint16_t value, uint16_t offset)
+bool validInputRange(int16_t min, int16_t max, uint16_t value, uint16_t offset)
 {
 	if (min > max)
 	{
-		uint16_t tmp = min;
+		int16_t tmp = min;
 		min = max;
 		max = tmp;
 	}

--- a/ground/gcs/src/plugins/config/outputchannelform.ui
+++ b/ground/gcs/src/plugins/config/outputchannelform.ui
@@ -192,7 +192,7 @@ margin:1px;</string>
       <string>Minimum PWM value, beware of not overdriving your servo.</string>
      </property>
      <property name="maximum">
-      <number>65535</number>
+      <number>9999</number>
      </property>
     </widget>
    </item>
@@ -442,7 +442,7 @@ p, li { white-space: pre-wrap; }
       <string>Maximum PWM value, beware of not overdriving your servo.</string>
      </property>
      <property name="maximum">
-      <number>65535</number>
+      <number>9999</number>
      </property>
     </widget>
    </item>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -2,9 +2,9 @@
     <object name="ActuatorSettings" singleinstance="true" settings="true">
         <description>Settings for the @ref ActuatorModule that controls the channel assignments for the mixer based on AircraftType</description>
         <field name="ChannelUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="50"/>
-        <field name="ChannelMax" units="us" type="uint16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelNeutral" units="us" type="uint16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelMin" units="us" type="uint16" elements="10" defaultvalue="1000"/>
+        <field name="ChannelMax" units="us" type="int16" elements="10" defaultvalue="1000"/>
+        <field name="ChannelNeutral" units="us" type="int16" elements="10" defaultvalue="1000"/>
+        <field name="ChannelMin" units="us" type="int16" elements="10" defaultvalue="1000"/>
         <field name="ChannelType" units="" type="enum" elements="10" options="PWM,MK,ASTEC4,PWM Alarm Buzzer,Arming led,Info led" defaultvalue="PWM"/>
         <field name="ChannelAddr" units="" type="uint8" elements="10" defaultvalue="0,1,2,3,4,5,6,7,8,9"/>
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>


### PR DESCRIPTION
After some discussion on irc it seems that its best to revert this commit for now.
There seems to be some inconsistencies at the representation of channel values regarding its signedness which need more attention.
