### PR TITLE
SanityCheck: prevent unsafe forms of arming

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -171,6 +171,8 @@ static void systemTask(void *parameters)
 		SystemSettingsConnectCallback(configurationUpdatedCb);
 	if (ManualControlSettingsHandle())
 		ManualControlSettingsConnectCallback(configurationUpdatedCb);
+	if (FlightStatusHandle())
+		FlightStatusConnectCallback(configurationUpdatedCb);
 #endif
 
 	// Main system loop

--- a/shared/uavobjectdefinition/systemalarms.xml
+++ b/shared/uavobjectdefinition/systemalarms.xml
@@ -33,6 +33,7 @@
 				<option>VelocityControl</option>
 				<option>PositionHold</option>
 				<option>PathPlanner</option>
+				<option>UnsafeToArm</option>
 				<option>Undefined</option>
 				<option>None</option>
 			</options>


### PR DESCRIPTION
This prevents a problem that caused an unsafe start of his
system.

Arming while in autonomous modes (e.g. RTH, PH, AH) can
allow unexpected behavior and is certainly an untested
path. This patch creates an error condition when in those
modes and disarmed or arming to prevent arming. In this
case one should switch to a traditional manual mode, arm,
and then engage the AP functionality.
