### PR TITLE
Bogus cableconnected() F4 USB function

### DIFF
--- a/flight/PiOS/STM32F4xx/pios_usb.c
+++ b/flight/PiOS/STM32F4xx/pios_usb.c
@@ -131,6 +131,10 @@ int32_t PIOS_USB_ChangeConnectionState(bool connected)
 	return 0;
 }
 
+bool PIOS_USB_CableConnected(uintptr_t id)
+{
+	return PIOS_USB_CheckAvailable(id);
+}
 /**
  * This function returns the connection status of the USB interface
  * \return true: interface available


### PR DESCRIPTION
This is a temporary work around function.
The bootloader should only check if cable is connected to figure if it needs to delay boot waiting for BL coms.
Checking for checkavailable fails on slower machines which take longer to enumerate.

This is a temporary workaround to allow using cable connected function on the bootloader without braking F4. Right now it only calls checkavailable but should be refactored to check cable connectivity only (on board with and without usb sense pin) 
