### PR TITLE
gcs input widget: fix flightmode position calculation

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -1387,7 +1387,7 @@ quint8 ConfigInputWidget::scaleSwitchChannel(quint8 channelNumber, quint8 switch
 
     // Convert channel value into the switch position in the range [0..N-1]
     // This uses the same optimized computation as flight code to be consistent
-    quint8 pos = ((int16_t)(valueScaled * 256) + 256) * (switchPositions-1) >> 9;
+    quint8 pos = ((int16_t)(valueScaled * 256) + 256) * switchPositions >> 9;
     if (pos >= switchPositions)
         pos = switchPositions - 1;
     return pos;


### PR DESCRIPTION
Range was effectively being computed/split across 0..N-2 and
would only ever show N-1 (ie. the max flight mode) when
valueScaled was exactly 1.0f.  Even the slightest jitter on the
flightmode channel would result in the GUI drawing the flight mode
as N-2.

The code in the GCS now matches the code in the flight firmware.

Fixes: #1034 
