### PR TITLE
GCS Config: if no board then have default max rate

### DIFF
--- a/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
@@ -168,8 +168,11 @@ void ConfigStabilizationWidget::processLinkedWidgets(QWidget * widget)
 void ConfigStabilizationWidget::applyRateLimits()
 {
     Core::IBoardType *board = getObjectUtilManager()->getBoardType();
-    Q_ASSERT(board);
-    double maxRate = board->queryMaxGyroRate() * 0.85;
+
+    double maxRate = 500; // Default to slowest across boards
+    if (board)
+        maxRate = board->queryMaxGyroRate() * 0.85;
+
     m_stabilization->fullStickRateRoll->setMaximum(maxRate);
     m_stabilization->fullStickRatePitch->setMaximum(maxRate);
     m_stabilization->fullStickRateYaw->setMaximum(maxRate);


### PR DESCRIPTION
In the case of a flaky connection it is possible to connect to
the FC but not get an update of FirmwareIAPObj in which case no
valid board plugin is found. This was causing a crash but we
should handle this more gracefully.
