### PR TITLE
MS5611: memory was not correctly cleared

### DIFF
--- a/flight/PiOS/Common/pios_ms5611.c
+++ b/flight/PiOS/Common/pios_ms5611.c
@@ -108,7 +108,7 @@ static struct ms5611_dev * PIOS_MS5611_alloc(void)
 		return NULL;
 	}
 
-	memset(ms5611_dev, 0, sizeof(ms5611_dev));
+	memset(ms5611_dev, 0, sizeof(*ms5611_dev));
 
 	ms5611_dev->magic = PIOS_MS5611_DEV_MAGIC;
 

--- a/flight/PiOS/Common/pios_ms5611_spi.c
+++ b/flight/PiOS/Common/pios_ms5611_spi.c
@@ -108,7 +108,7 @@ static struct ms5611_dev * PIOS_MS5611_alloc(void)
 		return NULL;
 	}
 
-	memset(ms5611_dev, 0, sizeof(ms5611_dev));
+	memset(ms5611_dev, 0, sizeof(*ms5611_dev));
 
 	ms5611_dev->magic = PIOS_MS5611_DEV_MAGIC;
 


### PR DESCRIPTION
Used the wrong size to clear it. This error was caught
by someone using gcc 4.8.
