### PR TITLE
system-health: add AltitudeHold to system health svg file

### DIFF
--- a/ground/gcs/share/taulabs/diagrams/default/system-health-linear.svg
+++ b/ground/gcs/share/taulabs/diagrams/default/system-health-linear.svg
@@ -794,17 +794,17 @@
      borderopacity="1"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.393877"
-     inkscape:cx="325.92275"
-     inkscape:cy="14.025333"
-     inkscape:current-layer="g11118"
+     inkscape:zoom="3.707287"
+     inkscape:cx="193.36968"
+     inkscape:cy="4.777166"
+     inkscape:current-layer="foreground"
      id="namedview3608"
      showgrid="true"
-     inkscape:window-width="2558"
-     inkscape:window-height="974"
+     inkscape:window-width="1600"
+     inkscape:window-height="850"
      inkscape:window-x="0"
      inkscape:window-y="0"
-     inkscape:window-maximized="0"
+     inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
      units="mm"
@@ -815,7 +815,7 @@
      inkscape:snap-bbox="true"
      inkscape:bbox-paths="true"
      inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:snap-bbox-edge-midpoints="true"
      inkscape:snap-bbox-midpoints="true"
      inkscape:snap-object-midpoints="true"
      inkscape:snap-center="true"
@@ -827,7 +827,7 @@
      inkscape:snap-page="false"
      inkscape:snap-nodes="false"
      inkscape:snap-grids="false"
-     inkscape:snap-to-guides="true"
+     inkscape:snap-to-guides="false"
      showborder="true"
      inkscape:showpageshadow="false">
     <sodipodi:guide
@@ -880,7 +880,7 @@
        id="guide4597" />
     <sodipodi:guide
        orientation="1,0"
-       position="365.1776,-1.1942919"
+       position="364.21513,12.441586"
        id="guide4599" />
     <sodipodi:guide
        orientation="1,0"
@@ -942,8 +942,8 @@
      transform="translate(-405.17146,-343.74826)"
      style="display:inline">
     <path
-       style="fill:#453e3e;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.7573427;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 411.88129,344.12693 351.75797,0 c 3.50745,0 6.33113,0.10735 6.33113,0.2407 l 0,11.20284 c 0,0.13335 -2.82368,0.2407 -6.33113,0.2407 l -351.75797,0 c -3.50748,0 -6.33116,-0.10735 -6.33116,-0.2407 l 0,-11.20284 c 0,-0.13335 2.82368,-0.2407 6.33116,-0.2407 z"
+       style="fill:#453e3e;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.77728355;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 412.24045,344.1369 371.15887,0 c 3.7009,0 6.68031,0.10717 6.68031,0.24029 l 0,11.18372 c 0,0.13312 -2.97941,0.24029 -6.68031,0.24029 l -371.15887,0 c -3.70093,0 -6.68035,-0.10717 -6.68035,-0.24029 l 0,-11.18372 c 0,-0.13312 2.97942,-0.24029 6.68035,-0.24029 z"
        id="Background"
        inkscape:connector-curvature="0" />
     <path
@@ -1053,6 +1053,12 @@
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline"
        d="m 749.59426,345.90824 18.15321,0 0,8.12162 -18.15321,0 z"
        id="PathFollower"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:label="#path26879"
+       style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53219783;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline"
+       d="m 769.65269,345.90859 18.20274,0 0,8.12092 -18.20274,0 z"
+       id="AltitudeHold"
        inkscape:connector-curvature="0" />
   </g>
   <g
@@ -1205,6 +1211,14 @@
        width="18.153212"
        id="PathFollower-OK"
        style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    <rect
+       inkscape:label="#rect8374"
+       y="1.6278722"
+       x="271.98669"
+       height="8.1216154"
+       width="18.153212"
+       id="AltitudeHold-OK"
+       style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
   </g>
   <g
      style="display:none"
@@ -1356,6 +1370,14 @@
        height="8.1216154"
        x="251.92862"
        y="1.6278714" />
+    <rect
+       inkscape:label="#rect4073"
+       style="fill:#f1b907;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="AltitudeHold-Warning"
+       width="18.153212"
+       height="8.1216154"
+       x="272.01181"
+       y="1.6278691" />
   </g>
   <g
      style="display:none"
@@ -1784,6 +1806,14 @@
        width="18.153212"
        id="PathFollower-Critical"
        style="fill:#cf0e0e;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    <rect
+       inkscape:label="#rect4080"
+       y="1.6278722"
+       x="272.01181"
+       height="8.1216154"
+       width="18.153212"
+       id="AltitudeHold-Critical"
+       style="fill:#cf0e0e;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
   </g>
   <g
      inkscape:groupmode="layer"
@@ -1940,9 +1970,18 @@
        x="251.92862"
        y="-9.7494869"
        transform="scale(1,-1)" />
+    <rect
+       inkscape:label="#rect4000-7-6-7-1"
+       style="fill:#808080;fill-opacity:0.89019608;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="AltitudeHold-Uninitialised"
+       width="18.153212"
+       height="8.1216154"
+       x="271.98669"
+       y="-9.7494841"
+       transform="scale(1,-1)" />
   </g>
   <g
-     style="display:inline"
+     style="display:none"
      inkscape:label="FlightTime-Uninitialised"
      id="g11138"
      inkscape:groupmode="layer"
@@ -2684,8 +2723,8 @@
     <path
        inkscape:connector-curvature="0"
        id="path29775"
-       d="m -85.784342,-0.15344051 351.757962,0 c 3.50745,0 6.33114,0.1073513 6.33114,0.2406969 l 0,11.20284761 c 0,0.133345 -2.82369,0.240696 -6.33114,0.240696 l -351.757962,0 c -3.50748,0 -6.331158,-0.107351 -6.331158,-0.240696 l 0,-11.20284761 c 0,-0.1333456 2.823678,-0.2406969 6.331158,-0.2406969 z"
-       style="fill:none;stroke:#000000;stroke-width:0.7573427;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
+       d="m -85.425182,-0.14347009 371.158852,0 c 3.7009,0 6.68033,0.10716809 6.68033,0.24028612 l 0,11.18372797 c 0,0.133118 -2.97943,0.240286 -6.68033,0.240286 l -371.158852,0 c -3.700932,0 -6.680348,-0.107168 -6.680348,-0.240286 l 0,-11.18372797 c 0,-0.13311803 2.979416,-0.24028612 6.680348,-0.24028612 z"
+       style="fill:none;stroke:#000000;stroke-width:0.77728355;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
     <text
        xml:space="preserve"
        style="font-size:2.87697005px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ffffff;fill-opacity:1;stroke:none;font-family:DejaVu Sans Mono;-inkscape-font-specification:DejaVu Sans Mono"
@@ -2726,6 +2765,26 @@
          id="tspan5683"
          x="254.72736"
          y="8.013648">Follower</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.885602px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:DejaVu Sans Mono;-inkscape-font-specification:DejaVu Sans Mono"
+       x="274.19766"
+       y="4.7037296"
+       id="text4868-5-0"><tspan
+         sodipodi:role="line"
+         x="274.19766"
+         y="4.7037296"
+         id="tspan4657">Altitude</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.94651628px;font-style:normal;font-weight:normal;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Bitstream Vera Sans"
+       x="277.37976"
+       y="8.2200718"
+       id="text5681-0"><tspan
+         sodipodi:role="line"
+         id="tspan5683-4"
+         x="277.37976"
+         y="8.2200718">Hold</tspan></text>
   </g>
   <g
      style="display:none"
@@ -2736,7 +2795,7 @@
     <g
        id="nolink"
        inkscape:label="#g26918"
-       transform="matrix(1.0571052,0,0,1,-23.086592,0)">
+       transform="matrix(1.1127398,0,0,1.0054496,-44.731371,-1.5405607)">
       <rect
          style="fill:#453e3e;fill-opacity:0.86363639;fill-rule:evenodd;stroke:#000000;stroke-width:0.73494369;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
          id="rect3370"

--- a/ground/gcs/share/taulabs/diagrams/default/system-health.svg
+++ b/ground/gcs/share/taulabs/diagrams/default/system-health.svg
@@ -14,7 +14,7 @@
    height="79.57505"
    id="svg3604"
    version="1.1"
-   inkscape:version="0.48.2 r9819"
+   inkscape:version="0.48.4 r9939"
    sodipodi:docname="system-health.svg"
    inkscape:export-filename="C:\NoBackup\OpenPilot\mainboard-health.png"
    inkscape:export-xdpi="269.53"
@@ -689,14 +689,14 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="6.6150934"
-     inkscape:cx="43.08329"
-     inkscape:cy="43.747536"
-     inkscape:current-layer="background"
+     inkscape:zoom="10.247587"
+     inkscape:cx="36.437167"
+     inkscape:cy="31.153742"
+     inkscape:current-layer="foreground"
      id="namedview3608"
      showgrid="false"
-     inkscape:window-width="1440"
-     inkscape:window-height="803"
+     inkscape:window-width="1600"
+     inkscape:window-height="850"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -740,125 +740,154 @@
     <path
        style="fill:#453e3e;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 499.55004,344.5361 90.48958,0 c 0.90229,0 1.62868,0.7264 1.62868,1.62869 l 0,75.80623 c 0,0.90229 -0.72639,1.62868 -1.62868,1.62868 l -90.48958,0 c -0.90229,0 -1.62868,-0.72639 -1.62868,-1.62868 l 0,-75.80623 c 0,-0.90229 0.72639,-1.62869 1.62868,-1.62869 z"
-       id="Background" />
+       id="Background"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 499.10913,365.44907 13.89318,0 0,56.63723 -13.89318,0 z"
-       id="Actuator" />
+       id="Actuator"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 576.71594,365.44907 13.89318,0 0,56.63723 -13.89318,0 z"
-       id="ManualControl" />
+       id="ManualControl"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 569.32855,406.95688 5.31119,0 0,15.00702 -5.31119,0 z"
-       id="SDCard" />
+       id="AltitudeHold"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 501.80048,345.98773 18.02354,0 0,8.28467 -18.02354,0 z"
-       id="Power" />
+       id="Power"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 556.2887,345.96741 9.74145,0 0,20.20886 -9.74145,0 z"
-       id="Sensors" />
+       id="Sensors"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 569.6358,346.10165 18.02355,0 0,8.0568 -18.02355,0 z"
-       id="I2C" />
+       id="I2C"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.51991701;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 569.63025,355.2207 18.03638,0 0,8.06906 -18.03638,0 z"
-       id="Temp-Baro" />
+       id="Temp-Baro"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 552.6358,407.05673 5.3112,0 0,15.00703 -5.3112,0 z"
-       id="USB" />
+       id="USB"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 560.98218,407.05673 5.31119,0 0,15.00703 -5.31119,0 z"
-       id="JTAG" />
+       id="JTAG"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 544.28949,407.05673 5.31119,0 0,15.00703 -5.31119,0 z"
-       id="GPIO" />
+       id="GPIO"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53369814;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 514.80487,407.0524 9.94268,0 0,14.93898 -9.94268,0 z"
-       id="Pwr-Sense" />
+       id="Pwr-Sense"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53585184;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 526.39636,406.95688 16.17991,0 0,15.0345 -16.17991,0 z"
-       id="ADC" />
+       id="ADC"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 515.23181,387.64853 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="CPUOverload" />
+       id="CPUOverload"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 535.7182,387.64853 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="StackOverflow" />
+       id="StackOverflow"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 556.20465,387.64853 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="OutOfMemory" />
+       id="OutOfMemory"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 515.23181,397.55762 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="EventSystem" />
+       id="EventSystem"
+       inkscape:connector-curvature="0" />
     <path
        transform="translate(497.66563,344.28037)"
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.55302167;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline"
        d="m 25.010578,1.9175365 30.08411,0 0,20.0405945 -30.08411,0 z"
-       id="USARTs" />
+       id="USARTs"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#ffffff;stroke-width:0.29055119;stroke-miterlimit:4;stroke-opacity:1;display:inline"
        d="m 523.76398,347.41809 23.3471,0 0,5.60024 -23.3471,0 z"
-       id="Telemetry" />
+       id="Telemetry"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 535.7182,397.55762 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="Stabilization" />
+       id="Stabilization"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline"
        d="m 556.20465,397.55762 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="FlightTime" />
+       id="FlightTime"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#ffffff;stroke-width:0.29055119;stroke-miterlimit:4;stroke-opacity:1;display:inline"
        d="m 523.76398,353.41809 23.3471,0 0,5.60024 -23.3471,0 z"
-       id="GPS" />
+       id="GPS"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 556.20465,377.73944 18.15321,0 0,8.12162 -18.15321,0 z"
-       id="Attitude" />
+       id="Attitude"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 535.7182,377.73944 18.15321,0 0,8.12162 -18.15321,0 z"
        id="PathFollower"
-       inkscape:label="#PathFollower" />
+       inkscape:label="#PathFollower"
+       inkscape:connector-curvature="0" />
     <path
        transform="scale(1,-1)"
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 515.23181,-385.86105 18.15321,0 0,8.12161 -18.15321,0 z"
-       id="BootFault" />
+       id="BootFault"
+       inkscape:connector-curvature="0" />
     <path
        transform="scale(1,-1)"
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 501.73566,-363.52982 18.15321,0 0,8.12162 -18.15321,0 z"
-       id="Battery" />
+       id="Battery"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 556.20465,367.83035 18.15321,0 0,8.12162 -18.15321,0 z"
        id="PathPlanner"
-       inkscape:label="#rect8563" />
+       inkscape:label="#rect8563"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 535.7182,367.83035 18.15321,0 0,8.12162 -18.15321,0 z"
-       id="SystemConfiguration" />
+       id="SystemConfiguration"
+       inkscape:connector-curvature="0" />
     <path
        transform="scale(1,-1)"
        style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 515.23181,-375.95197 18.15321,0 0,8.12162 -18.15321,0 z"
-       id="rect8567" />
+       id="rect8567"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      inkscape:groupmode="layer"
@@ -1268,6 +1297,70 @@
        height="56.637238"
        x="499.10913"
        y="365.44907" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="AltitudeHold-OK"
+     id="g5479"
+     inkscape:groupmode="layer">
+    <rect
+       inkscape:label="#rect4000-7-6-7-1"
+       style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.40042669;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="AltitudeHold-OK"
+       width="5.490716"
+       height="15.240981"
+       x="71.550316"
+       y="62.571053" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="AltitudeHold-Warning"
+     id="g6148"
+     inkscape:groupmode="layer">
+    <rect
+       y="62.480896"
+       x="71.56086"
+       height="15.281312"
+       width="5.4057837"
+       id="AltitudeHold-Warning"
+       style="fill:#f1b907;fill-opacity:1;stroke:#ffffff;stroke-width:0.39784303;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       inkscape:label="#rect4000-7-6-7-1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="AltitudeHold-Error"
+     id="g6152"
+     inkscape:groupmode="layer">
+    <g
+       transform="matrix(0.34283823,0,0,2.0450571,58.06391,-6.5492124)"
+       id="AltitudeHold-Error"
+       style="stroke:#cf0e0e;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       inkscape:label="#g4040-1">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6156"
+         d="M 38.076545,33.292974 56.14311,41.28257"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6158"
+         d="m 38.220502,41.354548 17.85063,-8.061574"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="AltitudeHold-Critical"
+     id="g6160"
+     inkscape:groupmode="layer">
+    <rect
+       style="fill:#cf0e0e;fill-opacity:1;stroke:#ffffff;stroke-width:0.39905104;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="AltitudeHold-Critical"
+       width="5.4045758"
+       height="15.377688"
+       x="71.561462"
+       y="62.383915"
+       inkscape:label="#rect8365" />
   </g>
   <g
      inkscape:groupmode="layer"
@@ -3518,6 +3611,26 @@
          x="38.682404"
          y="38.476322"
          style="fill:#ffffff">PathFollower</tspan></text>
+    <g
+       style="font-size:4px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;letter-spacing:-1.20000005px;word-spacing:0px;writing-mode:tb-rl;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Verdana;-inkscape-font-specification:Verdana"
+       id="text3682">
+      <path
+         d="m 75.540604,66.013485 -0.41211,0 -0.285156,-0.810547 -1.257812,0 -0.285157,0.810547 -0.392578,0 1.058594,-2.908203 0.515625,0 1.058594,2.908203 m -0.816407,-1.142578 -0.509765,-1.427735 -0.511719,1.427735 1.021484,0"
+         style="line-height:100%;fill:#ffffff"
+         id="path4440" />
+      <path
+         d="m 75.423416,69.674813 -1.839844,0 0,-2.908203 0.386719,0 0,2.564453 1.453125,0 0,0.34375"
+         style="line-height:100%;fill:#ffffff"
+         id="path4442" />
+      <path
+         d="m 75.536697,70.607626 -1.039062,0 0,2.564453 -0.386719,0 0,-2.564453 -1.039062,0 0,-0.34375 2.464843,0 0,0.34375"
+         style="line-height:100%;fill:#ffffff"
+         id="path4444" />
+      <path
+         d="m 75.335526,76.997469 -0.386719,0 0,-1.423828 -1.451172,0 0,1.423828 -0.386719,0 0,-2.908203 0.386719,0 0,1.140625 1.451172,0 0,-1.140625 0.386719,0 0,2.908203"
+         style="line-height:100%;fill:#ffffff"
+         id="path4446" />
+    </g>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -3701,6 +3814,21 @@
        x="17.566181"
        y="-61.398865"
        transform="scale(1,-1)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g3660"
+     inkscape:label="AltitudeHold-Uninitialised"
+     style="display:none">
+    <rect
+       transform="scale(1,-1)"
+       y="-77.762215"
+       x="71.56086"
+       height="15.281313"
+       width="5.4057837"
+       id="AltitudeHold-Uninitialised"
+       style="fill:#808080;fill-opacity:0.89019608;stroke:#ffffff;stroke-width:0.39784303;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       inkscape:label="#rect4000-7-6-7-1" />
   </g>
   <g
      style="display:none"


### PR DESCRIPTION
This fixes the console warnings:

```
[SystemHealth] Warning: The SystemHealth SVG does not contain a graphical element for the  "AltitudeHold"  alarm.
```
