### PR TITLE
Autobaud delay fix

### DIFF
--- a/flight/Modules/GPS/ubx_cfg.c
+++ b/flight/Modules/GPS/ubx_cfg.c
@@ -419,8 +419,15 @@ void ubx_cfg_set_baudrate(uintptr_t gps_port, ModuleSettingsGPSSpeedOptions baud
     for (uint32_t i = 0; i < NELEMENTS(baud_rates); i++) {
         PIOS_COM_ChangeBaud(gps_port, baud_rates[i]);
         vTaskDelay(MS2TICKS(UBLOX_WAIT_MS));
+
+        // Send the baud rate change message
         PIOS_COM_SendString(gps_port, msg);
-        vTaskDelay(MS2TICKS(UBLOX_WAIT_MS));
+
+        // Wait until the message has been fully transmitted including all start+stop bits
+        // 34 bytes * 10bits/byte = 340 bits
+        // At 2400bps, that's (340 / 2400) = 142ms
+        // add some margin and we end up with 200ms
+        vTaskDelay(MS2TICKS(200));
     }
 
     // Set to proper baud rate


### PR DESCRIPTION
The GPS autobaud feature was failing to switch from low (<= 9600bps) baud rates.  This was due to not waiting long enough between queuing the message for Tx and then subsequently changing the baud rate to the next rate.

At low speeds, the message hadn't actually been fully sent before the baud rate changed.  This corrupted the tail of the baud-change messages at the lower rates.

This change has been verified all the way down to 2400bps and up to 230400bps with a Ublox 6 module.
