### PR TITLE
Revert "Merge pull request #971 from metropt/update_gyro_rate_ff3"

### DIFF
--- a/flight/PiOS/Common/pios_l3gd20.c
+++ b/flight/PiOS/Common/pios_l3gd20.c
@@ -69,7 +69,7 @@ static struct l3gd20_dev *pios_l3gd20_dev;
 //! Private functions
 static struct l3gd20_dev *PIOS_L3GD20_alloc(void);
 static int32_t PIOS_L3GD20_Validate(struct l3gd20_dev *dev);
-static int32_t PIOS_L3GD20_Config(const struct pios_l3gd20_cfg *cfg);
+static void PIOS_L3GD20_Config(const struct pios_l3gd20_cfg *cfg);
 static int32_t PIOS_L3GD20_SetReg(uint8_t address, uint8_t buffer);
 static int32_t PIOS_L3GD20_GetReg(uint8_t address);
 static int32_t PIOS_L3GD20_GetRegIsr(uint8_t address, bool *woken);
@@ -156,19 +156,16 @@ int32_t PIOS_L3GD20_Init(uint32_t spi_id, uint32_t slave_num, const struct pios_
 
 /**
  * @brief Initialize the L3GD20 3-axis gyro sensor
- * \return 0 for successful configuration or -1 otherwise
+ * \return none
  * \param[in] PIOS_L3GD20_ConfigTypeDef struct to be used to configure sensor.
 *
 */
-static int32_t PIOS_L3GD20_Config(const struct pios_l3gd20_cfg *cfg)
+static void PIOS_L3GD20_Config(const struct pios_l3gd20_cfg *cfg)
 {
-	// This register enables the channels
-	while (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG1, PIOS_L3GD20_CTRL1_PD | PIOS_L3GD20_CTRL1_ZEN |
+	// This register enables the channels and sets the bandwidth
+	while (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG1, PIOS_L3GD20_CTRL1_FASTEST |
+	                          PIOS_L3GD20_CTRL1_PD | PIOS_L3GD20_CTRL1_ZEN |
 	                          PIOS_L3GD20_CTRL1_YEN | PIOS_L3GD20_CTRL1_XEN) != 0);
-
-	// Set the sample rate
-	if(PIOS_L3GD20_SetSampleRate(PIOS_L3GD20_RATE_380HZ_100HZ) != 0)
-		return -1;
 
 	// Disable the high pass filters
 	while (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG2, 0) != 0);
@@ -183,8 +180,6 @@ static int32_t PIOS_L3GD20_Config(const struct pios_l3gd20_cfg *cfg)
 	while (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG5, 0x00) != 0);
 
 	pios_l3gd20_dev->configured = true;
-
-	return 0;
 }
 
 /**
@@ -212,27 +207,6 @@ int32_t PIOS_L3GD20_SetRange(enum pios_l3gd20_range range)
 		PIOS_SENSORS_SetMaxGyro(2000);
 		break;
 	}
-	return 0;
-}
-
-/**
- * @brief Set the sample rate, 780 or 360
- * @param[in] enum pios_l3gd20_rate
- * @return 0 if successful, -1 for invalid device, -2 if unable to get register, -3 if unable to set register
- */
-int32_t PIOS_L3GD20_SetSampleRate(enum pios_l3gd20_rate rate)
-{
-	if (PIOS_L3GD20_Validate(pios_l3gd20_dev) != 0)
-		return -1;
-
-	int32_t l3gd20_reg1 = PIOS_L3GD20_GetReg(PIOS_L3GD20_CTRL_REG1);
-
-	if (l3gd20_reg1 == -1)
-		return -2;
-
-	if (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG1, rate | l3gd20_reg1) != 0)
-		return -3;
-
 	return 0;
 }
 

--- a/flight/PiOS/inc/pios_l3gd20.h
+++ b/flight/PiOS/inc/pios_l3gd20.h
@@ -63,6 +63,8 @@
 #define PIOS_L3GD20_INT1_DURATION        0x38
 
 /* Ctrl1 flags */
+#define PIOS_L3GD20_CTRL1_FASTEST        0xF0
+#define PIOS_L3GD20_CTRL1_380HZ_100HZ    0xB0
 #define PIOS_L3GD20_CTRL1_PD             0x08
 #define PIOS_L3GD20_CTRL1_ZEN            0x04
 #define PIOS_L3GD20_CTRL1_YEN            0x02
@@ -108,11 +110,6 @@ enum pios_l3gd20_range {
 	PIOS_L3GD20_SCALE_2000_DEG = 0x3
 };
 
-enum pios_l3gd20_rate {
-	PIOS_L3GD20_RATE_760HZ_100HZ = 0xF0,
-	PIOS_L3GD20_RATE_380HZ_100HZ = 0xB0
-};
-
 enum pios_l3gd20_filter {
 	PIOS_L3GD20_LOWPASS_256_HZ = 0x00,
 	PIOS_L3GD20_LOWPASS_188_HZ = 0x01,
@@ -133,7 +130,6 @@ struct pios_l3gd20_cfg {
 /* Public Functions */
 extern int32_t PIOS_L3GD20_Init(uint32_t spi_id, uint32_t slave_num, const struct pios_l3gd20_cfg * cfg);
 extern int32_t PIOS_L3GD20_SetRange(enum pios_l3gd20_range range);
-extern int32_t PIOS_L3GD20_SetSampleRate(enum pios_l3gd20_rate rate);
 extern int32_t PIOS_L3GD20_ReadID();
 extern uint8_t PIOS_L3GD20_Test();
 extern bool PIOS_L3GD20_IRQHandler();

--- a/flight/targets/flyingf3/fw/pios_board.c
+++ b/flight/targets/flyingf3/fw/pios_board.c
@@ -1217,19 +1217,6 @@ void PIOS_Board_Init(void) {
 	if (PIOS_L3GD20_Test() != 0)
 		panic(1);
 
-	uint8_t hw_l3gd20_samplerate;
-	HwFlyingF3L3GD20RateGet(&hw_l3gd20_samplerate);
-	enum pios_l3gd20_rate l3gd20_samplerate = PIOS_L3GD20_RATE_380HZ_100HZ;
-	switch(hw_l3gd20_samplerate) {
-		case HWFLYINGF3_L3GD20RATE_380:
-			l3gd20_samplerate = PIOS_L3GD20_RATE_380HZ_100HZ;
-			break;
-		case HWFLYINGF3_L3GD20RATE_760:
-			l3gd20_samplerate = PIOS_L3GD20_RATE_760HZ_100HZ;
-			break;
-	}
-	PIOS_Assert(PIOS_L3GD20_SetSampleRate(l3gd20_samplerate) == 0);
-
 	// To be safe map from UAVO enum to driver enum
 	/*
 	 * FIXME: add support for this to l3gd20 driver

--- a/shared/uavobjectdefinition/hwflyingf3.xml
+++ b/shared/uavobjectdefinition/hwflyingf3.xml
@@ -104,14 +104,6 @@
 		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
-		
-		<field name="L3GD20Rate" units="" type="enum" elements="1" defaultvalue="380">
-			<options>
-				<option>380</option>
-				<option>760</option>
-			</options>
-		</field>
-
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
 
 		<field name="Shield" units="" type="enum" elements="1" defaultvalue="None">


### PR DESCRIPTION
This reverts commit 4dc6538daf0888144f992889f3895278e75f1abd, reversing
changes made to 1a58f65ea6f9100d0726f0b0e71311618cf09dab.

This merge introduced the bug #1073 which results in a sensor error condition. I'm not sure under
what conditions it works and doesn't work so I'm ammenable to a proper fix. However, pending that
we should simply revert it and fix the FlyingF3 target.
