### PR TITLE
FrSky PWM RSSI fix

### DIFF
--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -38,7 +38,7 @@
 		<field name="RssiChannelNumber" units="channel" type="uint8" elements="1" defaultvalue="0"/>
 		<field name="RssiMax" units="" type="int16" elements="1" defaultvalue="2000"/>
 		<field name="RssiMin" units="" type="int16" elements="1" defaultvalue="1000"/>
-		<field name="RssiPwmPeriod" units="us" type="int16" elements="1" defaultvalue="9.6"/>
+		<field name="RssiPwmPeriod" units="us" type="int16" elements="1" defaultvalue="260"/>
 		
 		<field name="ChannelNumber" units="channel" type="uint8" defaultvalue="0">
 			<elementnames>


### PR DESCRIPTION
There was an incompatibility between de default value and the field
type.
Also the value itself was wrong since the pwm driver doesnt return in
uS.

Tested with FliyingF3 using receiver port set as PPM + PWM, default RssiPwmPeriod of 260, RssiMax=240 and RssiMin=0.
