### PR TITLE
Specifies a color of SystemHealth text

### DIFF
--- a/ground/gcs/src/plugins/systemhealth/html/Actuator-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Actuator-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Servo Output: Critical</h1>
     <p>
     One of the following conditions may be present:

--- a/ground/gcs/src/plugins/systemhealth/html/AlarmOK.html
+++ b/ground/gcs/src/plugins/systemhealth/html/AlarmOK.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Alarm: OK</h1>
     <p>
     There are no problems with this alarm.

--- a/ground/gcs/src/plugins/systemhealth/html/Attitude-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Attitude-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: Critical</h1>
     <p>
     This alarm will remain set until data is received from the accelerometer.

--- a/ground/gcs/src/plugins/systemhealth/html/Attitude-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Attitude-Error.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: Error</h1>
     <p>
     Failed to get an update from the accelerometer or gyros.

--- a/ground/gcs/src/plugins/systemhealth/html/Battery-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Battery-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Battery: Critical</h1>
     <p>
     Battery voltage has fallen below the <b>alarm</b> threshold.

--- a/ground/gcs/src/plugins/systemhealth/html/Battery-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Battery-Error.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Battery: Error</h1>
     <p>
     Both battery current and voltage are at or below zero.

--- a/ground/gcs/src/plugins/systemhealth/html/Battery-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Battery-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Battery: Warning</h1>
     <p>
     Battery voltage has fallen below the <b>warning</b> threshold.

--- a/ground/gcs/src/plugins/systemhealth/html/BootFault-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/BootFault-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Boot Fault: Critical</h1>
     <p>
     System has failed to boot more than three times: system defaults have been set.

--- a/ground/gcs/src/plugins/systemhealth/html/CPU-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/CPU-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>CPU: Critical</h1>
     <p>
     CPU load has exceeded 95%

--- a/ground/gcs/src/plugins/systemhealth/html/CPU-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/CPU-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>CPU: Warning</h1>
     <p>
     CPU load has exceeded 80%

--- a/ground/gcs/src/plugins/systemhealth/html/EventSystem-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/EventSystem-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Event System: Warning</h1>
     <p>
     There were problems with UAVObject events or callbacks

--- a/ground/gcs/src/plugins/systemhealth/html/FlightTime-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/FlightTime-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Flight Time: Critical</h1>
     <p>
     Estimated flight time based on battery usage is less than 30s.

--- a/ground/gcs/src/plugins/systemhealth/html/FlightTime-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/FlightTime-Error.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Flight Time: Error</h1>
     <p>
     Estimated flight time cannot be determined as battery voltage and current are at or below 0.

--- a/ground/gcs/src/plugins/systemhealth/html/FlightTime-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/FlightTime-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Flight Time: Warning</h1>
     <p>
     Estimated flight time based on battery usage is less than 60s.

--- a/ground/gcs/src/plugins/systemhealth/html/GPS-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/GPS-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>GPS: Critical</h1>
     <p>
     The GPS is receiving data but there is no position fix.

--- a/ground/gcs/src/plugins/systemhealth/html/GPS-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/GPS-Error.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>GPS: Error</h1>
     <p>
     The GPS has timed out; either there is no GPS plugged in, the GPS has locked up or there is some other hardware fault.

--- a/ground/gcs/src/plugins/systemhealth/html/GPS-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/GPS-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>GPS: Warning</h1>
     <p>
     The GPS has a fix and navigation can be used. However, the position quality is very low (the indication is &lt;7 satellites)

--- a/ground/gcs/src/plugins/systemhealth/html/ManualControl-Critical-PathFollower.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ManualControl-Critical-PathFollower.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>RC Input: Critical</h1>
     <h2>Error Code: Path Follower</h2>
     <p>The PathFollower module is not running. This module must first be enabled in the Modules tab.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/ManualControl-Critical-Settings.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ManualControl-Critical-Settings.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>RC Input: Critical</h1>
     <h2>Error Code: Settings</h2>
     <p>Have you configured your transmitter on the Input configuration page? One of the following conditions may be present:</p>

--- a/ground/gcs/src/plugins/systemhealth/html/ManualControl-Error-AltitudeHold.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ManualControl-Error-AltitudeHold.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>RC Input: Error</h1>
     <h2>Error Code: Altitude Hold</h2>
     <p>AltitudeHold module is not running. This module must first be configured on the Modules tab.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/ManualControl-Undefined.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ManualControl-Undefined.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>RC Input: </h1>
     <h2>Error Code: Undefined</h2>
     <p>This should not happen</p>

--- a/ground/gcs/src/plugins/systemhealth/html/ManualControl-Warning-Accessory.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ManualControl-Warning-Accessory.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>RC Input: Warning</h1>
     <h2>Error Code: Accessory</h2>
     <p>Failed to update one or more of the accessory channels.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/ManualControl-Warning-NoRx.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ManualControl-Warning-NoRx.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>RC Input: Warning</h1>
     <h2>Error Code: No Rx</h2>
     <p>No R/C receiver detected. The system has been put in failsafe mode.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/OutOfMemory-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/OutOfMemory-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Memory: Critical</h1>
     <p>
     Either the remaining heap space or the IRQ stack has fallen below the <b>critical</b> limit (1000 bytes heap, 80 entries IRQ stack).

--- a/ground/gcs/src/plugins/systemhealth/html/OutOfMemory-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/OutOfMemory-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Memory: Warning</h1>
     <p>
     Either the remaining heap space or the IRQ stack has fallen below the <b>warning</b> limit (4000 bytes heap, 150 entries IRQ stack).

--- a/ground/gcs/src/plugins/systemhealth/html/PathFollower-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/PathFollower-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Path Follower: Warning</h1>
     <p>
     Timed out waiting for an attitude update.

--- a/ground/gcs/src/plugins/systemhealth/html/PathPlanner-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/PathPlanner-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Path Planner: Critical</h1>
     <p>
     Attempting to run path planner without a path follower running.

--- a/ground/gcs/src/plugins/systemhealth/html/PathPlanner-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/PathPlanner-Error.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Path Planner: Error</h1>
     <p>
     Serious error attempting to follow specified path.

--- a/ground/gcs/src/plugins/systemhealth/html/Sensors-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Sensors-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Sensors: Critical</h1>
     <p>
     One of the following conditions may be present:

--- a/ground/gcs/src/plugins/systemhealth/html/Stabilization-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Stabilization-Warning.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Stabilization: Warning</h1>
     <p>
     Timed out waiting for an attitude update.

--- a/ground/gcs/src/plugins/systemhealth/html/Stack-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Stack-Critical.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Stack: Critical</h1>
     <p>
     Stack overflow

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Accelerometer-Queue-Not-Updating.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Accelerometer-Queue-Not-Updating.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: Accelerometer Queue not updating</h2>
     <p>Accelerometer data is not being received by the system, or is being received at too slow a rate.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Gyro-Queue-Not-Updating.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Gyro-Queue-Not-Updating.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: Gyro Queue not updating</h2>
     <p>Gyroscope data is not being received by the system, or is being received at too slow a rate.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-No-Barometer.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-No-Barometer.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: No Barometer</h2>
     <p>One or more of the following conditions has occurred:

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-No-GPS.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-No-GPS.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: No GPS</h2>
     <p>No GPS data is being received. Please check that the GPS is correctly wired, is receiving power, and has been configured to send all necessary messages in the uBlox binary protocol.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-No-Magnetometer.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-No-Magnetometer.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: No Magnetometer</h2>
     <p>One or more of the following conditions has occurred:

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-PDOP-Too-High.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-PDOP-Too-High.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: PDOP too high</h2>
     <p>

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Too-Few-Satellites.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Too-Few-Satellites.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: Too Few Satellites</h2>
     <p>The GPS isn't using enough satellites, please either wait or move the model so the GPS has a better view of the sky.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Undefined.html
+++ b/ground/gcs/src/plugins/systemhealth/html/StateEstimation-Undefined.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Attitude: </h1>
     <h2>Error Code: Undefined</h2>
     <p>This should not happen</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-AltitudeHold.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-AltitudeHold.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Altitude Hold</h2>
     <p>Altitude hold flight mode available without the altitude hold module running.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-AutoTune.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-AutoTune.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Auto Tune</h2>
     <p>Autotune flight mode or stabilization mode selected without enabling the module.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-Multirotor.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-Multirotor.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Multirotor</h2>
     <p>Roll, pitch, and/or yaw axes not set to stabilized modes. Check Input-->Flight Mode Switch Settings page.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-PathPlanner.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-PathPlanner.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Path Planner</h2>
     <p>Path planner flight mode available without a path planner running.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-PositionHold.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-PositionHold.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Position Hold</h2>
     <p>Position hold flight mode available without a path follower running.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-Stabilization.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-Stabilization.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Stabilization</h2>
     <p>Inappropriate stabilization mode selected, such as:</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-VelocityControl.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-VelocityControl.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: Error</h1>
     <h2>Error Code: Velocity Control</h2>
     <p>This is ConfigError.VelocityControl</p>

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Undefined.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Undefined.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>System Configuration: </h1>
     <h2>Error Code: Undefined</h2>
     <p>This should not happen.</p>

--- a/ground/gcs/src/plugins/systemhealth/html/Telemetry-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Telemetry-Error.html
@@ -4,7 +4,7 @@
     <meta content="">
     <style></style>
   </head>
-  <body>
+  <body style="color: black">
     <h1>Telemetry: Error</h1>
     <p>
     Telemetry system is disconnected.


### PR DESCRIPTION
The standard palette seems to not be defined, which causes the text in some instances to be white. This adds a style parameter in the html code. See Issue #1093.
