### PR TITLE
hardcode sensor rate value to 380hz

### DIFF
--- a/flight/PiOS/Common/pios_l3gd20.c
+++ b/flight/PiOS/Common/pios_l3gd20.c
@@ -163,7 +163,7 @@ int32_t PIOS_L3GD20_Init(uint32_t spi_id, uint32_t slave_num, const struct pios_
 static void PIOS_L3GD20_Config(const struct pios_l3gd20_cfg *cfg)
 {
 	// This register enables the channels and sets the bandwidth
-	while (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG1, PIOS_L3GD20_CTRL1_FASTEST |
+	while (PIOS_L3GD20_SetReg(PIOS_L3GD20_CTRL_REG1, PIOS_L3GD20_CTRL1_380HZ_100HZ |
 	                          PIOS_L3GD20_CTRL1_PD | PIOS_L3GD20_CTRL1_ZEN |
 	                          PIOS_L3GD20_CTRL1_YEN | PIOS_L3GD20_CTRL1_XEN) != 0);
 


### PR DESCRIPTION
That way the CPULoad go down to values around 50%. I didn't noticed any difference on quad behavior.
