### PR TITLE
Removed expression which caused Make-error on !Windows

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -539,8 +539,6 @@ openssl_install: openssl_clean
         # download the instalatopn file only if it's newer than what we already have
 	$(V1) wget -N -P "$(DL_DIR)" "$(OPENSSL_URL)"
 	$(V1) ./downloads/$(OPENSSL_FILE) /DIR=$(OPENSSL_DIR) /silent
-else
-	$(V1) echo "THIS IS A WINDOWS ONLY TARGET"
 endif
 
 .PHONY: openssl_clean


### PR DESCRIPTION
Functions cannot be executed outside a method, so it being there caused an error on non-Windows environments.

Error encountered using make 4.0-2 (x86_64-linux).
