### PR TITLE
logview.py: do not attempt to append null objects

### DIFF
--- a/python/logview.py
+++ b/python/logview.py
@@ -140,7 +140,8 @@ def main():
                             u  = parser.getLastReceivedObject(timestamp=log_hdr.time)
                         else:
                             u  = parser.getLastReceivedObject()
-                        uavo_parsed.append(u)
+                        if u is not None:
+                            uavo_parsed.append(u)
 
                 except TypeError:
                     print "End of file"


### PR DESCRIPTION
If an object UAVO is not known, then it is appended as a null
which breaks hte iteration through the tuples.
