### PR TITLE
Minor fix to TelemetrySchedulerWidget

### DIFF
--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryschedulergadgetwidget.h
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryschedulergadgetwidget.h
@@ -116,7 +116,7 @@ public:
     Qt::ItemFlags flags (const QModelIndex & index) const
     {
         if (index.column() == 0 || index.column() == 1)
-            return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+            return 0;
         else
             return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
     }


### PR DESCRIPTION
Makes the first two columns in telemetrySchedulerGadget inactive as proposed in #939.

fixes #939
