### PR TITLE
Android: add serial support for FTDI_FT230X

### DIFF
--- a/androidgcs/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/androidgcs/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -512,6 +512,7 @@ public class FtdiSerialDriver extends CommonUsbSerialDriver {
         supportedDevices.put(Integer.valueOf(UsbId.VENDOR_FTDI),
                 new int[] {
                     UsbId.FTDI_FT232R,
+                    UsbId.FTDI_FT230X,
                 });
         return supportedDevices;
     }

--- a/androidgcs/src/com/hoho/android/usbserial/driver/UsbId.java
+++ b/androidgcs/src/com/hoho/android/usbserial/driver/UsbId.java
@@ -31,6 +31,7 @@ public final class UsbId {
 
     public static final int VENDOR_FTDI = 0x0403;
     public static final int FTDI_FT232R = 0x6001;
+    public static final int FTDI_FT230X = 0x6015;
 
     public static final int VENDOR_ATMEL = 0x03EB;
     public static final int ATMEL_LUFA_CDC_DEMO_APP = 0x2044;


### PR DESCRIPTION
This is the chipset used in the 3dr radio v2 and should
add support for that radio.
