### PR TITLE
Replace QtDeclarative with QtQuick

### DIFF
--- a/ground/gcs/src/libs/utils/svgimageprovider.cpp
+++ b/ground/gcs/src/libs/utils/svgimageprovider.cpp
@@ -32,7 +32,7 @@
 
 SvgImageProvider::SvgImageProvider(const QString &basePath):
     QObject(),
-    QDeclarativeImageProvider(QDeclarativeImageProvider::Image),
+    QQuickImageProvider(QQuickImageProvider::Image),
     m_basePath(basePath)
 {
 }

--- a/ground/gcs/src/libs/utils/svgimageprovider.h
+++ b/ground/gcs/src/libs/utils/svgimageprovider.h
@@ -29,13 +29,13 @@
 #define SVGIMAGEPROVIDER_H_
 
 #include <QObject>
-#include <QtDeclarative/qdeclarativeimageprovider.h>
+#include <QtQuick/qquickimageprovider.h>
 #include <QSvgRenderer>
 #include <QMap>
 
 #include "utils_global.h"
 
-class QTCREATOR_UTILS_EXPORT SvgImageProvider : public QObject, public QDeclarativeImageProvider
+class QTCREATOR_UTILS_EXPORT SvgImageProvider : public QObject, public QQuickImageProvider
 {
     Q_OBJECT
 public:

--- a/ground/gcs/src/libs/utils/utils.pro
+++ b/ground/gcs/src/libs/utils/utils.pro
@@ -7,7 +7,8 @@ QT += gui \
     xml \
     svg \
     opengl \
-    declarative \
+    qml \
+    quick \
     widgets
 
 DEFINES += QTCREATOR_UTILS_LIB

--- a/ground/gcs/src/plugins/pfdqml/osgearth.cpp
+++ b/ground/gcs/src/plugins/pfdqml/osgearth.cpp
@@ -18,9 +18,9 @@
 
 #include <QtCore/qfileinfo.h>
 #include <QtCore/qthread.h>
-#include <QtDeclarative/qdeclarative.h>
-#include <QtDeclarative/qdeclarativeview.h>
-#include <QtDeclarative/qdeclarativeengine.h>
+#include <QtQml/qqml.h>
+#include <QtQuick/QQuickView>
+#include <QtQml/qqmlengine.h>
 #include <qpainter.h>
 #include <qvector3d.h>
 #include <QtOpenGL/qglframebufferobject.h>
@@ -41,8 +41,8 @@
 
 #include "utils/pathutils.h"
 
-OsgEarthItem::OsgEarthItem(QDeclarativeItem *parent):
-    QDeclarativeItem(parent),
+OsgEarthItem::OsgEarthItem(QQuickItem *parent):
+    QQuickItem(parent),
     m_renderer(0),
     m_rendererThread(0),
     m_currentSize(640, 480),
@@ -77,7 +77,7 @@ QString OsgEarthItem::resolvedSceneFile() const
 
     //try to resolve the relative scene file name:
     if (!QFileInfo(sceneFile).exists()) {
-        QDeclarativeView *view = qobject_cast<QDeclarativeView*>(scene()->views().first());
+        QQuickView *view = qobject_cast<QtQuick/QQuickView*>(scene()->views().first());
 
         if (view) {
             QUrl baseUrl = view->engine()->baseUrl();

--- a/ground/gcs/src/plugins/pfdqml/osgearth.h
+++ b/ground/gcs/src/plugins/pfdqml/osgearth.h
@@ -19,14 +19,14 @@
 
 #include <osgViewer/Viewer>
 
-#include <QtDeclarative/QDeclarativeItem>
+#include <QtQuick/QQuickItem>
 #include <osgQt/GraphicsWindowQt>
 
 class QGLFramebufferObject;
 class QGLWidget;
 class OsgEarthItemRenderer;
 
-class OsgEarthItem : public QDeclarativeItem
+class OsgEarthItem : public QQuickItem
 {
     Q_OBJECT
     Q_DISABLE_COPY(OsgEarthItem)
@@ -43,7 +43,7 @@ class OsgEarthItem : public QDeclarativeItem
     Q_PROPERTY(double altitude READ altitude WRITE setAltitude NOTIFY altitudeChanged)
 
 public:
-    OsgEarthItem(QDeclarativeItem *parent = 0);
+    OsgEarthItem(QQuickItem *parent = 0);
     ~OsgEarthItem();
 
     QString sceneFile() const { return m_sceneFile; }

--- a/ground/gcs/src/plugins/pfdqml/pfdqml.pro
+++ b/ground/gcs/src/plugins/pfdqml/pfdqml.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = PfdQml
 QT += svg
 QT += opengl
-QT += declarative
+QT += qml
 OSG {
     DEFINES += USE_OSG
 }

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
@@ -28,14 +28,14 @@
 #include <QtCore/qfileinfo.h>
 #include <QtCore/qdir.h>
 
-#include <QtDeclarative/qdeclarativeengine.h>
-#include <QtDeclarative/qdeclarativecontext.h>
-#include <QtDeclarative/qdeclarative.h>
+#include <QtQml/qqmlengine.h>
+#include <QtQml/qqmlcontext.h>
+#include <QtQml/qqml.h>
 #include "lowpassfilter.h"
 #include "stabilizationdesired.h"
 
 PfdQmlGadgetWidget::PfdQmlGadgetWidget(QWidget *parent) :
-    QDeclarativeView(parent),
+    QQuickView(parent),
     m_openGLEnabled(false),
     m_terrainEnabled(false),
     m_actualPositionUsed(false),
@@ -141,7 +141,7 @@ void PfdQmlGadgetWidget::setQmlFile(QString fn)
     qDebug() << Q_FUNC_INFO << fn;
     setSource(QUrl::fromLocalFile(fn));
 
-    foreach(const QDeclarativeError &error, errors()) {
+    foreach(const QQmlError &error, errors()) {
         qDebug() << error.description();
     }
 }

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.h
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.h
@@ -18,11 +18,11 @@
 #define PFDQMLGADGETWIDGET_H_
 
 #include "pfdqmlgadgetconfiguration.h"
-#include <QtDeclarative/qdeclarativeview.h>
+#include <QtQml/qdeclarativeview.h>
 
 class UAVObjectManager;
 
-class PfdQmlGadgetWidget : public QDeclarativeView
+class PfdQmlGadgetWidget : public QQuickView
 {
     Q_OBJECT
     Q_PROPERTY(QString earthFile READ earthFile WRITE setEarthFile NOTIFY earthFileChanged)

--- a/ground/gcs/src/plugins/qmlview/qmlview.pro
+++ b/ground/gcs/src/plugins/qmlview/qmlview.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = QMLView
 QT += svg
 QT += opengl
-QT += declarative
+QT += qml
 
 include(../../taulabsgcsplugin.pri)
 include(../../plugins/coreplugin/coreplugin.pri)

--- a/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.cpp
@@ -38,11 +38,11 @@
 #include <QtCore/qfileinfo.h>
 #include <QtCore/qdir.h>
 
-#include <QtDeclarative/qdeclarativeengine.h>
-#include <QtDeclarative/qdeclarativecontext.h>
+#include <QtQml/qqmlengine.h>
+#include <QtQml/qqmlcontext.h>
 
 QmlViewGadgetWidget::QmlViewGadgetWidget(QWidget *parent) :
-    QDeclarativeView(parent)
+    QQuickView(parent)
 {
     setMinimumSize(64,64);
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -89,7 +89,7 @@ void QmlViewGadgetWidget::setQmlFile(QString fn)
     qDebug() << Q_FUNC_INFO << fn;
     setSource(QUrl::fromLocalFile(fn));
 
-    foreach(const QDeclarativeError &error, errors()) {
+    foreach(const QQmlError &error, errors()) {
         qDebug() << error.description();
     }
 }

--- a/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.h
+++ b/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.h
@@ -30,7 +30,7 @@
 
 #include "qmlviewgadgetconfiguration.h"
 
-#include <QtDeclarative/qdeclarativeview.h>
+#include <QtQml/qdeclarativeview.h>
 
 #include <QtSvg/QSvgRenderer>
 #include <QtSvg/QGraphicsSvgItem>
@@ -40,7 +40,7 @@
 
 class UAVObject;
 
-class QmlViewGadgetWidget : public QDeclarativeView
+class QmlViewGadgetWidget : public QQuickView
 {
     Q_OBJECT
 

--- a/ground/gcs/src/plugins/welcome/welcome.pro
+++ b/ground/gcs/src/plugins/welcome/welcome.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 TARGET = Welcome
-QT += network declarative
+QT += network qml
 CONFIG += plugin
 
 include(../../taulabsgcsplugin.pri)

--- a/ground/gcs/src/plugins/welcome/welcomemode.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomemode.cpp
@@ -45,10 +45,10 @@
 #include <QtCore/QUrl>
 #include <QtCore/QDebug>
 
-#include <QtDeclarative/qdeclarative.h>
-#include <QtDeclarative/qdeclarativeview.h>
-#include <QtDeclarative/qdeclarativeengine.h>
-#include <QtDeclarative/qdeclarativecontext.h>
+#include <QtQml/qqml.h>
+#include <QtQuick/QQuickView>
+#include <QtQml/qqmlengine.h>
+#include <QtQml/qqmlcontext.h>
 
 #include <cstdlib>
 
@@ -61,7 +61,7 @@ struct WelcomeModePrivate
 {
     WelcomeModePrivate();
 
-    QDeclarativeView *declarativeView;
+    QQuickView *declarativeView;
 };
 
 WelcomeModePrivate::WelcomeModePrivate()
@@ -73,8 +73,8 @@ WelcomeMode::WelcomeMode() :
     m_d(new WelcomeModePrivate),
     m_priority(Core::Constants::P_MODE_WELCOME)
 {
-    m_d->declarativeView = new QDeclarativeView;
-    m_d->declarativeView->setResizeMode(QDeclarativeView::SizeRootObjectToView);
+    m_d->declarativeView = new QQuickView;
+    m_d->declarativeView->setResizeMode(QQuickView::SizeRootObjectToView);
     m_d->declarativeView->engine()->rootContext()->setContextProperty("welcomePlugin", this);
     m_d->declarativeView->setSource(QUrl("qrc:/welcome/qml/main.qml"));
 }


### PR DESCRIPTION
This is needed when building against minimal Qt5 setups.

This was done by running rename-qtdeclarative-symbols.sh from
qtdeclarative 5.1.1 over the source tree.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
