### PR TITLE
GCS: remove Qt5.2ism

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/generalsettings.cpp
+++ b/ground/gcs/src/plugins/coreplugin/generalsettings.cpp
@@ -156,7 +156,7 @@ void GeneralSettings::apply()
     m_useExpertMode=m_page->cbExpertMode->isChecked();
     m_autoConnect = m_page->checkAutoConnect->isChecked();
     m_autoSelect = m_page->checkAutoSelect->isChecked();
-    m_proxyType = m_page->proxyTypeCB->currentData().toInt();
+    m_proxyType = m_page->proxyTypeCB->itemData(m_page->proxyTypeCB->currentIndex()).toInt();
     m_proxyPort = m_page->portLE->text().toInt();
     m_proxyHostname = m_page->hostNameLE->text();
     m_proxyUser = m_page->userLE->text();


### PR DESCRIPTION
QComboBox::currentData was introduced in Qt 5.2 and all the other
comboboxes in the gcs code use the old

```
comboBox->itemData(comboBox->currentIndex());
```

form anyway. .

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
