### PR TITLE
Remove requirement of NMEA talker ID equaling 'GP'

### DIFF
--- a/flight/Modules/GPS/NMEA.c
+++ b/flight/Modules/GPS/NMEA.c
@@ -80,28 +80,28 @@ static bool nmeaProcessGPGSA(GPSPositionData * GpsData, bool* gpsDataUpdated, ch
 
 const static struct nmea_parser nmea_parsers[] = {
 	{
-		.prefix = "GPGGA",
+		.prefix = "GGA",
 		.handler = nmeaProcessGPGGA,
 	},
 	{
-		.prefix = "GPVTG",
+		.prefix = "VTG",
 		.handler = nmeaProcessGPVTG,
 	},
 	{
-		.prefix = "GPGSA",
+		.prefix = "GSA",
 		.handler = nmeaProcessGPGSA,
 	},
 	{
-		.prefix = "GPRMC",
+		.prefix = "RMC",
 		.handler = nmeaProcessGPRMC,
 	},
 #if !defined(PIOS_GPS_MINIMAL)
 	{
-		.prefix = "GPZDA",
+		.prefix = "ZDA",
 		.handler = nmeaProcessGPZDA,
 	},
 	{
-		.prefix = "GPGSV",
+		.prefix = "GSV",
 		.handler = nmeaProcessGPGSV,
 	},
 #endif //PIOS_GPS_MINIMAL
@@ -381,7 +381,8 @@ bool NMEA_update_position(char *nmea_sentence, GPSPositionData *GpsData)
 	// Sample NMEA message: "GPRMC,000131.736,V,,,,,0.00,0.00,060180,,,N*43"
 
 	// The first parameter starts at the beginning of the message
-	params[0] = p;
+	p += 2; // Skip the first two characters (e.g., GP, GN) which is the talker ID
+	params[0] = p; 
 	nbParams = 1;
 	while (*p != 0) {
 		if (*p == '*') {


### PR DESCRIPTION
Since some GNSS receivers sends NMEA data that use a talker ID other than 'GP' by default, they are not accepted by the TauLabs NMEA parser. This patch allows those streams to be parsed using the current functions.

From http://gpsd.berlios.de/NMEA.txt:
"NMEA sentences do [...] include a "talker ID" a two-characterprefix that identifies the type of the transmitting unit.  By far the most common talker ID is "GP", identifying a generic GPS"
