### PR TITLE
makefile: filter ARCHFLAGS env var from user environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ endef
 # These specific variables can influence gcc in unexpected (and undesirable) ways
 SANITIZE_GCC_VARS := TMPDIR GCC_EXEC_PREFIX COMPILER_PATH LIBRARY_PATH
 SANITIZE_GCC_VARS += CFLAGS CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH OBJC_INCLUDE_PATH DEPENDENCIES_OUTPUT
+SANITIZE_GCC_VARS += ARCHFLAGS
 $(foreach var, $(SANITIZE_GCC_VARS), $(eval $(call SANITIZE_VAR,$(var),disallowed)))
 
 # These specific variables used to be valid but now they make no sense


### PR DESCRIPTION
Unexpected values in this variable can cause strange compile
failures.
