### PR TITLE
Qt5.3: update dll from 51 to 52

### DIFF
--- a/ground/gcs/copydata.pro
+++ b/ground/gcs/copydata.pro
@@ -25,9 +25,9 @@ equals(copydata, 1) {
             Qt5MultimediaWidgets.dll \
             Qt5Quick.dll \
             Qt5Qml.dll \
-            icuin51.dll \
-            icudt51.dll \
-            icuuc51.dll \
+            icuin52.dll \
+            icudt52.dll \
+            icuuc52.dll \
             libwinpthread-1.dll \
 	    libgcc_s_dw2-1.dll \
 	    libstdc++-6.dll \


### PR DESCRIPTION
This follows the changes with the MinGW packaged
with Qt5.3
