### PR TITLE
Added ESC calibration procedure.

### DIFF
--- a/ground/gcs/src/plugins/config/configoutputwidget.h
+++ b/ground/gcs/src/plugins/config/configoutputwidget.h
@@ -70,6 +70,7 @@ private slots:
     void updateObjectsFromWidgets();
     void runChannelTests(bool state);
     void sendChannelTest(int index, int value);
+    void startESCCalibration();
     void openHelp();
     void do_SetDirty();
     void assignOutputChannels(UAVObject *obj);

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -14,7 +14,16 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>12</number>
+   </property>
+   <property name="topMargin">
+    <number>12</number>
+   </property>
+   <property name="rightMargin">
+    <number>12</number>
+   </property>
+   <property name="bottomMargin">
     <number>12</number>
    </property>
    <item>
@@ -36,7 +45,16 @@
        <property name="spacing">
         <number>0</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -116,15 +134,24 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>668</width>
-            <height>654</height>
+            <width>670</width>
+            <height>664</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <property name="spacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
-           <property name="margin">
+           <property name="leftMargin">
+            <number>12</number>
+           </property>
+           <property name="topMargin">
+            <number>12</number>
+           </property>
+           <property name="rightMargin">
+            <number>12</number>
+           </property>
+           <property name="bottomMargin">
             <number>12</number>
            </property>
            <item>
@@ -145,11 +172,20 @@
               <string>Output Update Speed</string>
              </property>
              <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0,0,0,0,0">
+              <property name="leftMargin">
+               <number>12</number>
+              </property>
+              <property name="topMargin">
+               <number>12</number>
+              </property>
+              <property name="rightMargin">
+               <number>12</number>
+              </property>
+              <property name="bottomMargin">
+               <number>12</number>
+              </property>
               <property name="horizontalSpacing">
                <number>6</number>
-              </property>
-              <property name="margin">
-               <number>12</number>
               </property>
               <item row="0" column="7">
                <widget class="QLabel" name="chBank6">
@@ -678,7 +714,16 @@ Leave at 50Hz for fixed wing.</string>
               </item>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_2">
-                <property name="margin">
+                <property name="leftMargin">
+                 <number>12</number>
+                </property>
+                <property name="topMargin">
+                 <number>12</number>
+                </property>
+                <property name="rightMargin">
+                 <number>12</number>
+                </property>
+                <property name="bottomMargin">
                  <number>12</number>
                 </property>
                 <item>
@@ -737,29 +782,62 @@ Leave at 50Hz for fixed wing.</string>
               <string/>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_6">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>12</number>
+              </property>
+              <property name="topMargin">
+               <number>12</number>
+              </property>
+              <property name="rightMargin">
+               <number>12</number>
+              </property>
+              <property name="bottomMargin">
                <number>12</number>
               </property>
               <item>
-               <widget class="QCheckBox" name="channelOutTest">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>105</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string>Move the servos using the sliders. Two important things:
+               <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <item>
+                 <widget class="QCheckBox" name="channelOutTest">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>105</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Move the servos using the sliders. Two important things:
 - Take extra care if the output is connected to an motor controller!
 - Will only work if the RC receiver is working (failsafe)</string>
-                </property>
-                <property name="text">
-                 <string>Test outputs</string>
-                </property>
-               </widget>
+                  </property>
+                  <property name="text">
+                   <string>Test outputs</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="calibrateESC">
+                  <property name="text">
+                   <string>Calibrate ESCs</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>


### PR DESCRIPTION
The button for ESC calibration was added to Output page next
to "Test outputs" checkbox. It walks user through the whole
process of calibration, beggining with channel selection that
allow to select specific outputs.

This feature was requested and can be closed here:
https://github.com/TauLabs/TauLabs/issues/1177

Reported-by: cGiesen Signed-off-by: Ivan Sevcik ivan-sevcik@hotmail.com
