### PR TITLE
GCS Trimming: allow trimming in leveling mode

### DIFF
--- a/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
+++ b/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
@@ -911,7 +911,7 @@ void ConfigVehicleTypeWidget::bnLevelTrim_clicked()
     case VehicleTrim::AUTOPILOT_LEVEL_FAILED_DUE_TO_FLIGHTMODE:
     {
         QMessageBox msgBox(QMessageBox::Critical, tr("Vehicle not in Stabilized mode"),
-                           tr("The autopilot must be in Stabilized1, Stabilized2, or Stabilized3 mode."), QMessageBox::Ok, this);
+                           tr("The autopilot must be in Leveling, Stabilized1, Stabilized2, or Stabilized3 mode."), QMessageBox::Ok, this);
         msgBox.exec();
         break;
     }

--- a/ground/gcs/src/plugins/config/vehicletrim.cpp
+++ b/ground/gcs/src/plugins/config/vehicletrim.cpp
@@ -66,7 +66,8 @@ VehicleTrim::autopilotLevelBiasMessages VehicleTrim::setAutopilotBias()
     }
 
     // Check that vehicle is in stabilized{1,2,3} flight mode
-    if (flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED1 &&
+    if (flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_LEVELING &&
+            flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED1 &&
             flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED2 &&
             flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED3){
         return AUTOPILOT_LEVEL_FAILED_DUE_TO_FLIGHTMODE;


### PR DESCRIPTION
Using the tranmitter trim was never updated to handle
the case of using "Leveling' mode which largely replaces
the old Stabilized{1,2,3} naming.
