### PR TITLE
F4 Targets: enable WDG if it was not enabled

### DIFF
--- a/flight/targets/freedom/fw/pios_board.c
+++ b/flight/targets/freedom/fw/pios_board.c
@@ -379,6 +379,15 @@ void PIOS_Board_Init(void) {
 	PIOS_RTC_Init(&pios_rtc_main_cfg);
 #endif
 
+#ifndef ERASE_FLASH
+	/* Initialize watchdog as early as possible to catch faults during init
+	 * but do it only if there is no debugger connected
+	 */
+	if ((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0) {
+		PIOS_WDG_Init();
+	}
+#endif
+
 	// /* Set up pulse timers */
 	PIOS_TIM_InitClock(&tim_1_cfg);
 	PIOS_TIM_InitClock(&tim_2_cfg);

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -358,6 +358,15 @@ void PIOS_Board_Init(void) {
 	PIOS_RTC_Init(&pios_rtc_main_cfg);
 #endif
 
+#ifndef ERASE_FLASH
+	/* Initialize watchdog as early as possible to catch faults during init
+	 * but do it only if there is no debugger connected
+	 */
+	if ((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0) {
+		PIOS_WDG_Init();
+	}
+#endif
+
 	/* Set up pulse timers */
 	PIOS_TIM_InitClock(&tim_1_cfg);
 	PIOS_TIM_InitClock(&tim_3_cfg);


### PR DESCRIPTION
This was the case for
- freedom
- revomini

Not having the watchdog enabled is definitely risky.
