### PR TITLE
quanton: enable internal pull-up on usb vsense line

### DIFF
--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2157,7 +2157,7 @@ static const struct pios_usb_cfg pios_usb_main_cfg = {
 			.GPIO_Speed = GPIO_Speed_25MHz,
 			.GPIO_Mode  = GPIO_Mode_IN,
 			.GPIO_OType = GPIO_OType_OD,
-			.GPIO_PuPd  = GPIO_PuPd_NOPULL,
+			.GPIO_PuPd  = GPIO_PuPd_UP,
 		},
 	}
 };


### PR DESCRIPTION
The impedance of the voltage divider is too high and could lead to
random failure of the usb connection.
In practice this has not ever been observed on any original quanton board
as of yet but enabling the internal pull up raises the line voltage by
0.2 V and thus gives a higher error margin.
