### PR TITLE
GCS: keep browser buttons working regardless of state

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -506,9 +506,6 @@ void UAVObjectBrowserWidget::toggleUAVOButtons(const QModelIndex &currentIndex, 
     if (category)
         enableState = false;
 
-    if(!item->getIsPresentOnHardware())
-        enableState = false;
-
     enableUAVOBrowserButtons(enableState);
 }
 


### PR DESCRIPTION
This is a workaround for the fact the modem doens't trigger
a correctly opened state. It also doesn't even start handshaking
by itself, so the session management never even fails.

In general it's useful to keep the browser buttons working for
debugging purposes even if a valid session hasn't been established.
