### PR TITLE
Android: build UAVOs for HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ androidgcs_clean:
 #
 # Find the git hashes of each commit that changes uavobjects with:
 #   git log --format=%h -- shared/uavobjectdefinition/ | head -n 6 | tr '\n' ' '
-UAVO_GIT_VERSIONS := next 
+UAVO_GIT_VERSIONS := HEAD 
 
 # All versions includes a pseudo collection called "working" which represents
 # the UAVOs in the source tree


### PR DESCRIPTION
This will make jenkins produce .apk with valid UAVO
sets. Also, it will work better for people working
on branches.
