### PR TITLE
Fix android crash on MIUI

### DIFF
--- a/androidgcs/src/org/taulabs/androidgcs/MainActivity.java
+++ b/androidgcs/src/org/taulabs/androidgcs/MainActivity.java
@@ -40,20 +40,27 @@ public class MainActivity extends ObjectManagerActivity {
 		// Only do this when null as the default on create will restore
 		// the existing fragment after rotation
 		if ( savedInstanceState == null ) {
-			Fragment contentFrag;
+			Fragment contentFrag = null;
+			boolean newPFD = false;
 			Bundle b = getIntent().getExtras();
 			if (b == null) {
-				contentFrag = new PFD();
-				setTitle("PFD");
+				newPFD = true;
 			} else {
 				int id = b.getInt("ContentFrag");
 				contentFrag = getFragmentById(id);
-
-				String title = b.getString("ContentName");
-				if (title != null)
-					setTitle(title);
+				if (contentFrag == null)
+					newPFD = true;
+				else {
+					String title = b.getString("ContentName");
+					if (title != null)
+						setTitle(title);
+				}
 			}
-
+			if (newPFD) {
+				contentFrag = new PFD();
+				setTitle("PFD");
+			}
+			
 			FragmentTransaction fragmentTransaction = getFragmentManager()
 					.beginTransaction();
 			fragmentTransaction.add(R.id.content_frame, contentFrag);


### PR DESCRIPTION
Phone: Cubot S208 running MIUI rom.

Install androidgcs from market or from self built apk. If run immediately from installer or market it runs without issues.
If run from the home screen (where all the apps are, the screen I get after pressing home) both apps crash.
Running from the recent apps drawer both apps crash.
Running the market version from the icon it creates on the desktop (?) it runs ok.
Creating a similar icon with the self built apk and using it it crashes.

Some googling gave different app sleeping methods as possible culprit with some more or less complicated workarounds. 
This changeset seems to fix the issue, and I don't think it breaks anything. 
