### PR TITLE
GCS/Input Config: directly set meta data during calibration

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -750,7 +750,6 @@ void ConfigInputWidget::fastMdata()
 
     // Iterate over list of UAVObjects, configuring all dynamic data metadata objects.
     UAVObjectManager *objManager = getObjectManager();
-    QMap<QString, UAVObject::Metadata> metaDataList;
     QVector< QVector<UAVDataObject*> > objList = objManager->getDataObjectsVector();
     foreach (QVector<UAVDataObject*> list, objList) {
         foreach (UAVDataObject* obj, list) {
@@ -779,14 +778,11 @@ void ConfigInputWidget::fastMdata()
                         break;
                 }
 
-                metaDataList.insert(obj->getName(), mdata);
+                // Set the metadata
+                obj->setMetadata(mdata);
             }
         }
     }
-
-    // Set new metadata
-    utilMngr->setAllNonSettingsMetadata(metaDataList);
-
 
 }
 
@@ -796,7 +792,10 @@ void ConfigInputWidget::fastMdata()
 void ConfigInputWidget::restoreMdata()
 {
     UAVObjectUtilManager* utilMngr = getObjectUtilManager();
-    utilMngr->setAllNonSettingsMetadata(originalMetaData);
+    foreach (QString objName, originalMetaData.keys()) {
+        UAVObject *obj = getObjectManager()->getObject(objName);
+        obj->setMetadata(originalMetaData.value(objName));
+    }
     originalMetaData.clear();
 }
 


### PR DESCRIPTION
Because the input wizard toggles the metadata a fair number of
times the latency of ack'ing all of them blocks the UI. This
changes the behavior to directly set and store the metadata.
While this might miss one or two settings, it works reliably
for configuring the wizard (and approximates the previous
behavior that has been working for a while).

It also fixes a confusing bug that was occuring at the end
of calibration where the save button was blocking due to
a series of metadata transactions taking up the transaction
queue.

Essentially this should restore the behavior we had before
#1269 where we just blast over the desired metadata

changes.

Fixes #1303 
