### PR TITLE
Make: create PHONY for standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -996,6 +996,7 @@ endif
 package:
 	$(V1) cd $@ && $(MAKE) --no-print-directory $@
 	
+.PHONY: standalone
 standalone:
 	$(V1) cd package && $(MAKE) --no-print-directory $@
 


### PR DESCRIPTION
This is good practice for targets that do not create
particular files.
