### PR TITLE
GCS/Uploader: set boot timeout to 3 seconds

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -113,7 +113,7 @@ UploaderGadgetWidget::UploaderGadgetWidget(QWidget *parent):QWidget(parent),
         }
     }
 
-    bootTimeoutTimer.setInterval(12000);
+    bootTimeoutTimer.setInterval(3000);
     bootTimeoutTimer.setSingleShot(true);
     connect(&bootTimeoutTimer, SIGNAL(timeout()), this, SLOT(onBootingTimout()));
 }


### PR DESCRIPTION
The chip doesn't take anywhere near 12 seconds to boot. This reduces
the timeout in the uploader to something more reasonable.
