### PR TITLE
Logging plugin fix log corruption

### DIFF
--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -82,8 +82,9 @@ QIODevice* LoggingConnection::openDevice(IDevice *deviceName)
     QString fileName = QFileDialog::getOpenFileName(NULL, tr("Open file"), QString(""), tr("Tau Labs Log (*.tll)"));
     if (!fileName.isNull()) {
         startReplay(fileName);
+        return &logFile;
     }
-    return &logFile;
+    return NULL;
 }
 
 void LoggingConnection::startReplay(QString file)


### PR DESCRIPTION
The corruption used to happen if the user pressed connect and then cancelled during an already ongoing logging replay.
