### PR TITLE
Fix Android SDK installer

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -378,7 +378,7 @@ android_sdk_clean:
 .PHONY: android_sdk_update
 android_sdk_update:
 	$(V0) @echo " UPDATE       $(ANDROID_SDK_DIR)"
-	$(ANDROID_SDK_DIR)/tools/android update sdk --no-ui -t platform-tools,build-tools-20.0.0,android-14,addon-google_apis-google-14
+	$(ANDROID_SDK_DIR)/tools/android update sdk --no-ui --all -t platform-tools,build-tools-20.0.0,android-14,addon-google_apis-google-14
 
 # Set up Google Test (gtest) tools
 GTEST_DIR       := $(TOOLS_DIR)/gtest-1.6.0


### PR DESCRIPTION
This aims to download the right SDK file for each OS and setup the SDK correctly with the make android_sdk_update routine
