### PR TITLE
GCS/Input Wizard: allow skipping flight mode

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -690,6 +690,14 @@ void ConfigInputWidget::wizardTearDownStep(enum wizardSteps step)
         {
             manualSettingsData.ChannelNeutral[i] = manualCommandData.Channel[i];
         }
+
+        // If user skipped flight mode then force the number of flight modes to 1
+        // for valid connection
+        if (manualSettingsData.ChannelGroups[ManualControlSettings::CHANNELMIN_FLIGHTMODE] ==
+                ManualControlSettings::CHANNELGROUPS_NONE) {
+            manualSettingsData.FlightModeNumber = 1;
+        }
+
         manualSettingsObj->setData(manualSettingsData);
         setTxMovement(nothing);
         break;


### PR DESCRIPTION
The firmware supports not having a flight mode switch
and the wizard allows skipping it. However, because the
default number of flight modes is 3 this creates an
invalid ManualControlSetting and prevents the rest of
the calibration procedure.
