### PR TITLE
OneShot: inital commit

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -526,7 +526,7 @@ static int16_t scaleChannel(float value, int16_t max, int16_t min, int16_t neutr
 static void setFailsafe(const ActuatorSettingsData * actuatorSettings, const MixerSettingsData * mixerSettings)
 {
 	/* grab only the parts that we are going to use */
-	int16_t Channel[ACTUATORCOMMAND_CHANNEL_NUMELEM];
+	uint16_t Channel[ACTUATORCOMMAND_CHANNEL_NUMELEM];
 	ActuatorCommandChannelGet(Channel);
 
 	const Mixer_t * mixers = (Mixer_t *)&mixerSettings->Mixer1Type; //pointer to array of mixers in UAVObjects

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -379,6 +379,9 @@ static void actuatorTask(void* parameters)
 		{
 			success &= set_channel(n, command.Channel[n], &actuatorSettings);
 		}
+#if defined(PIOS_INCLUDE_ONESHOT)
+		PIOS_Servo_OneShot_Update();
+#endif
 
 		if(!success) {
 			command.NumFailedUpdates++;
@@ -556,6 +559,9 @@ static void setFailsafe(const ActuatorSettingsData * actuatorSettings, const Mix
 	{
 		set_channel(n, Channel[n], actuatorSettings);
 	}
+#if defined(PIOS_INCLUDE_ONESHOT)
+	PIOS_Servo_OneShot_Update();
+#endif
 
 	// Update output object's parts that we changed
 	ActuatorCommandChannelSet(Channel);
@@ -686,6 +692,11 @@ static bool set_channel(uint8_t mixer_channel, uint16_t value, const ActuatorSet
 		case ACTUATORSETTINGS_CHANNELTYPE_PWM:
 			PIOS_Servo_Set(actuatorSettings->ChannelAddr[mixer_channel], value);
 			return true;
+#if defined(PIOS_INCLUDE_ONESHOT)
+		case ACTUATORSETTINGS_CHANNELTYPE_ONESHOT:
+			PIOS_Servo_OneShot_Set(actuatorSettings->ChannelAddr[mixer_channel], value);
+			return true;
+#endif
 #if defined(PIOS_INCLUDE_I2C_ESC)
 		case ACTUATORSETTINGS_CHANNELTYPE_MK:
 			return PIOS_SetMKSpeed(actuatorSettings->ChannelAddr[mixer_channel],value);

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -12,7 +12,7 @@
  *
  * @file       actuator.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
  * @brief      Actuator module. Drives the actuators (servos, motors etc).
  *
  * @see        The GNU Public License (GPL) Version 3

--- a/flight/PiOS/STM32F30x/pios_servo.c
+++ b/flight/PiOS/STM32F30x/pios_servo.c
@@ -8,7 +8,7 @@
  *
  * @file       pios_servo.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      RC Servo routines (STM32 dependent)
  * @see        The GNU Public License (GPL) Version 3
  *

--- a/flight/PiOS/STM32F4xx/pios_servo.c
+++ b/flight/PiOS/STM32F4xx/pios_servo.c
@@ -194,3 +194,75 @@ void PIOS_Servo_Set(uint8_t servo, uint16_t position)
 			break;
 	}
 }
+
+#if defined(PIOS_INCLUDE_ONESHOT)
+#define OneShotFrequency 12000000
+
+/**
+* Set servo position for OneShot
+* \param[in] Servo Servo number (0-num_channels)
+* \param[in] Position Servo position in 1/12 microseconds based on OneShotFrequency
+*/
+void PIOS_Servo_OneShot_Set(uint8_t servo, uint16_t position)
+{
+	/* Make sure servo exists */
+	if (!servo_cfg || servo >= servo_cfg->num_channels) {
+		return;
+	}
+
+	const struct pios_tim_channel * chan = &servo_cfg->channels[servo];
+
+	/* stop the timer */
+	TIM_Cmd(chan->timer, DISABLE);
+
+	/* Update the position */
+	switch(chan->timer_chan) {
+		case TIM_Channel_1:
+			TIM_SetCompare1(chan->timer, position);
+			break;
+		case TIM_Channel_2:
+			TIM_SetCompare2(chan->timer, position);
+			break;
+		case TIM_Channel_3:
+			TIM_SetCompare3(chan->timer, position);
+			break;
+		case TIM_Channel_4:
+			TIM_SetCompare4(chan->timer, position);
+			break;
+	}
+}
+
+/**
+* Update the timer for OneShot
+*/
+void PIOS_Servo_OneShot_Update()
+{
+	if (!servo_cfg) {
+		return;
+	}
+
+	TIM_TimeBaseInitTypeDef TIM_TimeBaseStructure;
+	TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
+
+	for (uint8_t i = 0; i < servo_cfg->num_channels; i++) {
+		const struct pios_tim_channel * chan = &servo_cfg->channels[i];
+
+		/* Look for a disabled timer which is probably used by OneShot */
+		if (!(chan->timer->CR1 & TIM_CR1_CEN)) {
+			/* Choose the correct prescaler value for the APB the timer is attached */
+			if (chan->timer==TIM6 || chan->timer==TIM7) {
+				// These timers cannot be used here.
+				continue;
+			} else if (chan->timer==TIM1 || chan->timer==TIM8 || chan->timer==TIM9 || chan->timer==TIM10 || chan->timer==TIM11 ) {
+				TIM_TimeBaseStructure.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / OneShotFrequency) - 1;
+			} else {
+				TIM_TimeBaseStructure.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / OneShotFrequency) - 1;
+			}
+
+			/* enable it again and reinitialize it */
+			TIM_Cmd(chan->timer, ENABLE);
+			TIM_TimeBaseInit(chan->timer, &TIM_TimeBaseStructure);
+		}
+	}
+}
+#endif

--- a/flight/PiOS/STM32F4xx/pios_servo.c
+++ b/flight/PiOS/STM32F4xx/pios_servo.c
@@ -8,7 +8,7 @@
  *
  * @file       pios_servo.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014-2015
  * @brief      RC Servo routines (STM32 dependent)
  * @see        The GNU Public License (GPL) Version 3
  *

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -33,6 +33,8 @@
 /* Public Functions */
 extern void PIOS_Servo_SetHz(const uint16_t * update_rates, uint8_t banks);
 extern void PIOS_Servo_Set(uint8_t Servo, uint16_t Position);
+extern void PIOS_Servo_OneShot_Set(uint8_t servo, uint16_t position);
+extern void PIOS_Servo_OneShot_Update();
 
 #endif /* PIOS_SERVO_H */
 

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -7,6 +7,7 @@
  *
  * @file       pios_servo.h  
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
  * @brief      RC Servo functions header.
  * @see        The GNU Public License (GPL) Version 3
  *

--- a/flight/targets/colibri/fw/pios_config.h
+++ b/flight/targets/colibri/fw/pios_config.h
@@ -55,6 +55,7 @@
 #define PIOS_INCLUDE_RTC
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_FASTHEAP
+#define PIOS_INCLUDE_ONESHOT
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_HMC5883

--- a/flight/targets/colibri/fw/pios_config.h
+++ b/flight/targets/colibri/fw/pios_config.h
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       pios_config.h 
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
  * @see        The GNU Public License (GPL) Version 3
  * 

--- a/flight/targets/flyingf3/fw/pios_config.h
+++ b/flight/targets/flyingf3/fw/pios_config.h
@@ -59,6 +59,7 @@
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_ADC
 #define PIOS_INCLUDE_FASTHEAP
+#define PIOS_INCLUDE_ONESHOT
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_L3GD20

--- a/flight/targets/flyingf3/fw/pios_config.h
+++ b/flight/targets/flyingf3/fw/pios_config.h
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       pios_config.h 
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
  * @see        The GNU Public License (GPL) Version 3
  * 

--- a/flight/targets/flyingf4/fw/pios_config.h
+++ b/flight/targets/flyingf4/fw/pios_config.h
@@ -55,6 +55,7 @@
 #define PIOS_INCLUDE_RTC
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_FASTHEAP
+#define PIOS_INCLUDE_ONESHOT
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_HMC5883

--- a/flight/targets/flyingf4/fw/pios_config.h
+++ b/flight/targets/flyingf4/fw/pios_config.h
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       pios_config.h 
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
  * @see        The GNU Public License (GPL) Version 3
  * 

--- a/flight/targets/quanton/fw/pios_config.h
+++ b/flight/targets/quanton/fw/pios_config.h
@@ -55,6 +55,7 @@
 #define PIOS_INCLUDE_RTC
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_FASTHEAP
+#define PIOS_INCLUDE_ONESHOT
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_HMC5883

--- a/flight/targets/quanton/fw/pios_config.h
+++ b/flight/targets/quanton/fw/pios_config.h
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       pios_config.h 
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
  * @see        The GNU Public License (GPL) Version 3
  * 

--- a/flight/targets/revomini/fw/pios_config.h
+++ b/flight/targets/revomini/fw/pios_config.h
@@ -56,6 +56,7 @@
 #define PIOS_INCLUDE_RTC
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_FASTHEAP
+#define PIOS_INCLUDE_ONESHOT
 
 /* Variables related to the RFM22B functionality */
 #define PIOS_INCLUDE_RFM22B

--- a/flight/targets/revomini/fw/pios_config.h
+++ b/flight/targets/revomini/fw/pios_config.h
@@ -7,7 +7,7 @@
  *
  * @file       pios_config.h 
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
  * @see        The GNU Public License (GPL) Version 3
  * 

--- a/flight/targets/sparky/fw/pios_config.h
+++ b/flight/targets/sparky/fw/pios_config.h
@@ -56,6 +56,7 @@
 #define PIOS_INCLUDE_EXTI
 #define PIOS_INCLUDE_RTC
 #define PIOS_INCLUDE_WDG
+#define PIOS_INCLUDE_ONESHOT
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_MS5611

--- a/flight/targets/sparky/fw/pios_config.h
+++ b/flight/targets/sparky/fw/pios_config.h
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       pios_config.h 
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
  * @see        The GNU Public License (GPL) Version 3
  * 

--- a/shared/uavobjectdefinition/actuatorcommand.xml
+++ b/shared/uavobjectdefinition/actuatorcommand.xml
@@ -1,7 +1,7 @@
 <xml>
     <object name="ActuatorCommand" singleinstance="true" settings="false">
         <description>Contains the pulse duration sent to each of the channels.  Set by @ref ActuatorModule</description>
-        <field name="Channel" units="us" type="int16" elements="10"/>
+        <field name="Channel" units="us,us/12" type="uint16" elements="10"/>
         <field name="UpdateTime" units="ms" type="uint8" elements="1"/>
         <field name="MaxUpdateTime" units="ms" type="uint16" elements="1"/>
         <field name="NumFailedUpdates" units="" type="uint8" elements="1"/>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -2,9 +2,9 @@
     <object name="ActuatorSettings" singleinstance="true" settings="true">
         <description>Settings for the @ref ActuatorModule that controls the channel assignments for the mixer based on AircraftType</description>
         <field name="ChannelUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="50"/>
-        <field name="ChannelMax" units="us" type="int16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelNeutral" units="us" type="int16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelMin" units="us" type="int16" elements="10" defaultvalue="1000"/>
+        <field name="ChannelMax" units="us,us/12" type="uint16" elements="10" defaultvalue="2000"/>
+        <field name="ChannelNeutral" units="us,us/12" type="uint16" elements="10" defaultvalue="1000"/>
+        <field name="ChannelMin" units="us,us/12" type="uint16" elements="10" defaultvalue="1000"/>
         <field name="ChannelType" units="" type="enum" elements="10" options="PWM,OneShot,MK,ASTEC4,PWM Alarm Buzzer,Arming led,Info led" defaultvalue="PWM"/>
         <field name="ChannelAddr" units="" type="uint8" elements="10" defaultvalue="0,1,2,3,4,5,6,7,8,9"/>
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -5,7 +5,7 @@
         <field name="ChannelMax" units="us" type="int16" elements="10" defaultvalue="1000"/>
         <field name="ChannelNeutral" units="us" type="int16" elements="10" defaultvalue="1000"/>
         <field name="ChannelMin" units="us" type="int16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelType" units="" type="enum" elements="10" options="PWM,MK,ASTEC4,PWM Alarm Buzzer,Arming led,Info led" defaultvalue="PWM"/>
+        <field name="ChannelType" units="" type="enum" elements="10" options="PWM,OneShot,MK,ASTEC4,PWM Alarm Buzzer,Arming led,Info led" defaultvalue="PWM"/>
         <field name="ChannelAddr" units="" type="uint8" elements="10" defaultvalue="0,1,2,3,4,5,6,7,8,9"/>
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
This adds support for the new OneShot125 servo mode. Normal ESCs use 1000..2000µs @ max. 400Hz for signal transfer. The new Ultra- and KISS-ESC use OneShot125 without a fixed rate. This implementation generates the wanted 125..250µs with 1500 steps based on an internal 12MHz clock. The OneShot is coupled with the PID update rate. The benefit is: There is no jitter between servo rate and sensor rate. The update rate can be up to 2kHz in OneShot according to the ESC description. I've tested it up to 3,9kHz without flying.