### PR TITLE
Fix make problem "reference to `clock_gettime' collect2: ld returned 1 e...

### DIFF
--- a/ground/gcs/src/plugins/rawhid/rawhid.pro
+++ b/ground/gcs/src/plugins/rawhid/rawhid.pro
@@ -37,10 +37,10 @@ macx {
 linux-g++ {
     SOURCES += hidapi/hidapi_linux.c \
             usbmonitor_linux.cpp
-    LIBS += -lusb-1.0 -ludev
+    LIBS += -lusb-1.0 -ludev -lrt
 }
 linux-g++-64 {
     SOURCES += hidapi/hidapi_linux.c \
             usbmonitor_linux.cpp
-    LIBS += -lusb-1.0 -ludev
+    LIBS += -lusb-1.0 -ludev -lrt
 }


### PR DESCRIPTION
on linux 32 and 64 bit by adding -lrt to libs list of the rawhid project file.
See also https://github.com/TauLabs/TauLabs/issues/1439.
