### PR TITLE
Welcome crash and broken button

### DIFF
--- a/ground/gcs/src/plugins/welcome/welcome.pro
+++ b/ground/gcs/src/plugins/welcome/welcome.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 TARGET = Welcome
-QT += network qml quick
+QT += network qml quick quickwidgets
 CONFIG += plugin
 
 include(../../taulabsgcsplugin.pri)

--- a/ground/gcs/src/plugins/welcome/welcomemode.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomemode.cpp
@@ -88,7 +88,7 @@ QWidget* WelcomeMode::widget()
     if (!m_widget) {
         QQuickWidget *qWidget = new QQuickWidget(QUrl("qrc:/welcome/qml/main.qml"));
         qWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
-        qWidget->engine()->rootContext()->setContextProperty("welcomPlugin", this);
+        qWidget->engine()->rootContext()->setContextProperty("welcomePlugin", this);
         m_widget = qWidget;
     }
     return m_widget;

--- a/ground/gcs/src/plugins/welcome/welcomemode.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomemode.cpp
@@ -46,7 +46,7 @@
 #include <QtCore/QDebug>
 
 #include <QtQuick>
-#include <QQuickView>
+#include <QtQuickWidgets/QQuickWidget>
 #include <QQmlEngine>
 #include <QQmlContext>
 
@@ -57,33 +57,15 @@ using namespace Utils;
 
 namespace Welcome {
 
-struct WelcomeModePrivate
-{
-    WelcomeModePrivate();
-
-    QQuickView *quickView;
-};
-
-WelcomeModePrivate::WelcomeModePrivate()
-{
-}
-
 // ---  WelcomeMode
 WelcomeMode::WelcomeMode() :
-    m_d(new WelcomeModePrivate),
+    m_widget(NULL),
     m_priority(Core::Constants::P_MODE_WELCOME)
 {
-    m_d->quickView = new QQuickView;
-    m_d->quickView->setResizeMode(QQuickView::SizeRootObjectToView);
-    m_d->quickView->engine()->rootContext()->setContextProperty("welcomePlugin", this);
-    m_d->quickView->setSource(QUrl("qrc:/welcome/qml/main.qml"));
-    m_container = NULL;
 }
 
 WelcomeMode::~WelcomeMode()
 {
-    delete m_d->quickView;
-    delete m_d;
 }
 
 QString WelcomeMode::name() const
@@ -103,12 +85,13 @@ int WelcomeMode::priority() const
 
 QWidget* WelcomeMode::widget()
 {
-    if (!m_container) {
-        m_container = QWidget::createWindowContainer(m_d->quickView);
-        m_container->setMinimumSize(64, 64);
-        m_container->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+    if (!m_widget) {
+        QQuickWidget *qWidget = new QQuickWidget(QUrl("qrc:/welcome/qml/main.qml"));
+        qWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+        qWidget->engine()->rootContext()->setContextProperty("welcomPlugin", this);
+        m_widget = qWidget;
     }
-    return m_container;
+    return m_widget;
 }
 
 const char* WelcomeMode::uniqueModeName() const

--- a/ground/gcs/src/plugins/welcome/welcomemode.h
+++ b/ground/gcs/src/plugins/welcome/welcomemode.h
@@ -68,8 +68,7 @@ public slots:
     void triggerAction(const QString &actionId);
 
 private:
-    WelcomeModePrivate *m_d;
-    QWidget *m_container;
+    QWidget *m_widget;
     int m_priority;
 };
 

--- a/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
@@ -55,7 +55,7 @@ WelcomePlugin::~WelcomePlugin()
 {
     if (m_welcomeMode) {
         removeObject(m_welcomeMode);
-        m_welcomeMode->deleteLater();
+        delete m_welcomeMode;
     }
 }
 


### PR DESCRIPTION
This reverts a previous fix that introduced a crash on exit for windows due to the
welcome gadget. It also properly fixes a bug that I introduced previously with a
typo of a QML variable definition.

 - [x] test jenkins output on windows
 - [x] test jenkins output on linux
 - [x] test manual packaging on OSX
