### PR TITLE
GCS: update wiki links

### DIFF
--- a/ground/gcs/src/plugins/boards_openpilot/config_cc_hw_widget.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/config_cc_hw_widget.cpp
@@ -143,7 +143,7 @@ void ConfigCCHWWidget::widgetsContentsChanged()
 
 void ConfigCCHWWidget::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Hardware-Settings", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Hardware-Settings", QUrl::StrictMode) );
 }
 
 /**

--- a/ground/gcs/src/plugins/boards_taulabs/sparkybgcconfiguration.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparkybgcconfiguration.cpp
@@ -76,5 +76,5 @@ void SparkyBgcConfiguration::widgetsContentsChanged()
 
 void SparkyBgcConfiguration::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Hardware-Settings", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Hardware-Settings", QUrl::StrictMode) );
 }

--- a/ground/gcs/src/plugins/boards_tbs/colibriconfiguration.cpp
+++ b/ground/gcs/src/plugins/boards_tbs/colibriconfiguration.cpp
@@ -137,5 +137,5 @@ void ColibriConfiguration::resizeEvent(QResizeEvent *event)
 
 void ColibriConfiguration::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Hardware-Settings", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Hardware-Settings", QUrl::StrictMode) );
 }

--- a/ground/gcs/src/plugins/config/configccattitudewidget.cpp
+++ b/ground/gcs/src/plugins/config/configccattitudewidget.cpp
@@ -122,7 +122,7 @@ ConfigCCAttitudeWidget::~ConfigCCAttitudeWidget()
 void ConfigCCAttitudeWidget::openHelp()
 {
 
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Vehicle-configuration", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Vehicle-configuration", QUrl::StrictMode) );
 }
 
 void ConfigCCAttitudeWidget::enableControls(bool enable)

--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -318,7 +318,7 @@ void ConfigInputWidget::resizeEvent(QResizeEvent *event)
 
 void ConfigInputWidget::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Input-Configuration", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Input-Configuration", QUrl::StrictMode) );
 }
 
 void ConfigInputWidget::goToWizard()

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -302,7 +302,7 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(picoCSettingsName, "ComSpeed", ui->cb_picocComSpeed);
 
     //Help button
-    addHelpButton(ui->inputHelp,"http://wiki.taulabs.org/OnlineHelp:-Modules");
+    addHelpButton(ui->inputHelp,"https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Modules");
 
     // Connect any remaining widgets
     connect(airspeedSettings, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(updateAirspeedUAVO(UAVObject *)));

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -471,7 +471,7 @@ void ConfigOutputWidget::updateObjectsFromWidgets()
 void ConfigOutputWidget::openHelp()
 {
 
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Output-Configuration", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Output-Configuration", QUrl::StrictMode) );
 }
 
 void ConfigOutputWidget::stopTests()

--- a/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
+++ b/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
@@ -771,7 +771,7 @@ void ConfigVehicleTypeWidget::updateObjectsFromWidgets()
 void ConfigVehicleTypeWidget::openHelp()
 {
 
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Vehicle-configuration", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Vehicle-configuration", QUrl::StrictMode) );
 }
 
 /**

--- a/ground/gcs/src/plugins/importexport/importexportgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/importexport/importexportgadgetwidget.cpp
@@ -200,7 +200,7 @@ void ImportExportGadgetWidget::importConfiguration(const QString& fileName)
 void ImportExportGadgetWidget::on_helpButton_clicked()
 {
     qDebug() << "Show Help";
-    QDesktopServices::openUrl(QUrl("http://wiki.taulabs.org/OnlineHelp:-Import-Export"));
+    QDesktopServices::openUrl(QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Import-Export"));
 }
 
 

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
@@ -61,7 +61,7 @@ ImportSummaryDialog::~ImportSummaryDialog()
   */
 void ImportSummaryDialog::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-UAV-Settings-import-export", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-UAV-Settings-import-export", QUrl::StrictMode) );
 }
 
 /*

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1503,5 +1503,5 @@ void UploaderGadgetWidget::onAutoUpdateCount(int i)
  */
 void UploaderGadgetWidget::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wiki.taulabs.org/OnlineHelp:-Uploader-Plugin", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Uploader-Plugin", QUrl::StrictMode) );
 }


### PR DESCRIPTION
The redirect of wiki.taulabs.org to https://github.com/TauLabs/TauLabs/wiki/
is no longer working. Update the help buttons to go to the github
site directly.