### PR TITLE
QQuickWidget not ready for linux

### DIFF
--- a/ground/gcs/src/plugins/pfdqml/pfdqml.pro
+++ b/ground/gcs/src/plugins/pfdqml/pfdqml.pro
@@ -4,7 +4,6 @@ QT += svg
 QT += opengl
 QT += qml
 QT += quick
-QT += quickwidgets
 OSG {
     DEFINES += USE_OSG
 }

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadget.cpp
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadget.cpp
@@ -31,6 +31,8 @@ PfdQmlGadget::PfdQmlGadget(QString classId, PfdQmlGadgetWidget *widget, QWidget 
         IUAVGadget(classId, parent),
         m_widget(widget)
 {
+    m_container = NULL;
+    m_parent = parent;
 }
 
 PfdQmlGadget::~PfdQmlGadget()

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadget.h
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadget.h
@@ -34,11 +34,20 @@ public:
     PfdQmlGadget(QString classId, PfdQmlGadgetWidget *widget, QWidget *parent = 0);
     ~PfdQmlGadget();
 
-    QWidget *widget() { return m_widget; }
+    QWidget *widget() {
+        if(!m_container){
+            m_container = QWidget::createWindowContainer(m_widget, m_parent);
+            m_container->setMinimumSize(64, 64);
+            m_container->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+        }
+        return m_container;
+    }
 
     void loadConfiguration(IUAVGadgetConfiguration* config);
 
 private:
+    QWidget *m_container;
+    QWidget *m_parent;
     PfdQmlGadgetWidget *m_widget;
 };
 

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
@@ -34,8 +34,8 @@
 #include "lowpassfilter.h"
 #include "stabilizationdesired.h"
 
-PfdQmlGadgetWidget::PfdQmlGadgetWidget(QWidget *parent) :
-    QQuickWidget(parent),
+PfdQmlGadgetWidget::PfdQmlGadgetWidget(QWindow *parent) :
+    QQuickView(parent),
     m_openGLEnabled(false),
     m_terrainEnabled(false),
     m_actualPositionUsed(false),
@@ -179,7 +179,7 @@ void PfdQmlGadgetWidget::mouseReleaseEvent(QMouseEvent *event)
         setQmlFile(m_qmlFileName);
     }
 
-    QQuickWidget::mouseReleaseEvent(event);
+    QQuickView::mouseReleaseEvent(event);
 }
 
 void PfdQmlGadgetWidget::setLatitude(double arg)

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.h
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.h
@@ -18,11 +18,11 @@
 #define PFDQMLGADGETWIDGET_H_
 
 #include "pfdqmlgadgetconfiguration.h"
-#include <QtQuickWidgets/QQuickWidget>
+#include <QtQuick/QQuickView>
 
 class UAVObjectManager;
 
-class PfdQmlGadgetWidget : public QQuickWidget
+class PfdQmlGadgetWidget : public QQuickView
 {
     Q_OBJECT
     Q_PROPERTY(QString earthFile READ earthFile WRITE setEarthFile NOTIFY earthFileChanged)
@@ -36,7 +36,7 @@ class PfdQmlGadgetWidget : public QQuickWidget
     Q_PROPERTY(double altitude READ altitude WRITE setAltitude NOTIFY altitudeChanged)
 
 public:
-    PfdQmlGadgetWidget(QWidget *parent = 0);
+    PfdQmlGadgetWidget(QWindow *parent = 0);
    ~PfdQmlGadgetWidget();
     void setQmlFile(QString fn);
 

--- a/ground/gcs/src/plugins/welcome/welcome.pro
+++ b/ground/gcs/src/plugins/welcome/welcome.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 TARGET = Welcome
-QT += network qml quick quickwidgets
+QT += network qml quick
 CONFIG += plugin
 
 include(../../taulabsgcsplugin.pri)

--- a/ground/gcs/src/plugins/welcome/welcomemode.h
+++ b/ground/gcs/src/plugins/welcome/welcomemode.h
@@ -68,7 +68,8 @@ public slots:
     void triggerAction(const QString &actionId);
 
 private:
-    QWidget *m_widget;
+    WelcomeModePrivate *m_d;
+    QWidget *m_container;
     int m_priority;
 };
 


### PR DESCRIPTION
So this has been going back and forth, partly due to me. The QQuickWidget
is not ready to be used as of Qt 5.4 for linux. I can't explain the report that it
worked for someone, but #1447 caused a regression in this that results in the
welcome screen being black. It also causes the QML PFD to be black if that
is what people are using.

The underlying issue is https://bugreports.qt.io/browse/QTBUG-40765

Hopefully if this is fixed we can revert this once we update to Qt 5.4.1

fixes #1463
fixes #1427

We also need to verify that this doesn't reintroduce the crash on exit in windows that
was caused by #1427. I think this was caused by  c881c3d which was supposed to
fix a crash on linux, so we also need to make sure this doesn't crash on exit for
linux *sigh*.

 - [x] test welcome shows up on mac with package
 - [x] test qml pfd shows up on mac with package
 - [x] test welcome shows up on windows with package
 - [x] test qml pfd shows up on windows with package
 - [x] test welcome shows up on linux with package
 - [x] test qml pfd shows up on linux with package
 - [x] test there is no crash on exit with windows
 - [x] test there is no crash on exit with linux