### PR TITLE
Erase flash

### DIFF
--- a/flight/targets/colibri/fw/Makefile
+++ b/flight/targets/colibri/fw/Makefile
@@ -30,6 +30,7 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # Set developer code and compile options
 # Set to YES for debugging
 DEBUG ?= NO
+ERASE_FLASH ?= NO
 
 # List of modules to include
 MODULES = Sensors
@@ -108,6 +109,10 @@ SRC += $(OPUAVOBJ)/eventdispatcher.c
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
+endif
+
+ifeq ($(ERASE_FLASH), YES)
+CDEFS += -DERASE_FLASH
 endif
 
 SRC += $(FLIGHTLIB)/paths.c

--- a/flight/targets/colibri/fw/pios_board.c
+++ b/flight/targets/colibri/fw/pios_board.c
@@ -414,6 +414,11 @@ void PIOS_Board_Init(void)
 	    (&pios_waypoints_settings_fs_id, &flashfs_waypoints_cfg,
 	     FLASH_PARTITION_LABEL_WAYPOINTS) != 0)
 		panic(1);
+
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
+
 #endif /* PIOS_INCLUDE_FLASH */
 
 	/* Initialize the task monitor library */

--- a/flight/targets/flyingf3/fw/Makefile
+++ b/flight/targets/flyingf3/fw/Makefile
@@ -31,7 +31,7 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # @groupbrief Set developer code and compile options
 # @optbrief Set to YES to compile for debugging
 DEBUG ?= NO
-
+ERASE_FLASH ?= NO
 
 # @endgroup Compile Options
 # List of modules to include
@@ -111,6 +111,10 @@ SRC += $(OPUAVOBJ)/eventdispatcher.c
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
+endif
+
+ifeq ($(ERASE_FLASH), YES)
+CDEFS += -DERASE_FLASH
 endif
 
 SRC += $(FLIGHTLIB)/paths.c

--- a/flight/targets/flyingf3/fw/pios_board.c
+++ b/flight/targets/flyingf3/fw/pios_board.c
@@ -382,6 +382,11 @@ void PIOS_Board_Init(void) {
 	/* Mount all filesystems */
 	PIOS_FLASHFS_Logfs_Init(&pios_uavo_settings_fs_id, &flashfs_internal_settings_cfg, FLASH_PARTITION_LABEL_SETTINGS);
 	PIOS_FLASHFS_Logfs_Init(&pios_waypoints_settings_fs_id, &flashfs_internal_waypoints_cfg, FLASH_PARTITION_LABEL_WAYPOINTS);
+
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
+
 #endif
 
 	/* Initialize the task monitor library */

--- a/flight/targets/flyingf4/fw/Makefile
+++ b/flight/targets/flyingf4/fw/Makefile
@@ -30,6 +30,7 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # Set developer code and compile options
 # Set to YES for debugging
 DEBUG ?= NO
+ERASE_FLASH ?= NO
 
 # List of modules to include
 MODULES = Sensors
@@ -108,6 +109,10 @@ SRC += $(OPUAVOBJ)/eventdispatcher.c
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
+endif
+
+ifeq ($(ERASE_FLASH), YES)
+CDEFS += -DERASE_FLASH
 endif
 
 SRC += $(FLIGHTLIB)/paths.c

--- a/flight/targets/flyingf4/fw/pios_board.c
+++ b/flight/targets/flyingf4/fw/pios_board.c
@@ -324,6 +324,10 @@ void PIOS_Board_Init(void) {
 		panic(1);
 #endif /* PIOS_INCLUDE_EXTERNAL_FLASH_WAYPOINTS */
 
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
+
 #endif	/* PIOS_INCLUDE_FLASH */
 
 	/* Initialize the task monitor library */

--- a/flight/targets/freedom/fw/Makefile
+++ b/flight/targets/freedom/fw/Makefile
@@ -31,7 +31,7 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # @groupbrief Set developer code and compile options
 # @optbrief Set to YES to compile for debugging
 DEBUG ?= NO
-
+ERASE_FLASH ?= NO
 
 # @endgroup Compile Options
 # List of modules to include
@@ -256,7 +256,9 @@ else
 CFLAGS += -Os
 endif
 
-
+ifeq ($(ERASE_FLASH), YES)
+CDEFS += -DERASE_FLASH
+endif
    
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/freedom/fw/pios_board.c
+++ b/flight/targets/freedom/fw/pios_board.c
@@ -360,6 +360,11 @@ void PIOS_Board_Init(void) {
 		panic(1);
 	if (PIOS_FLASHFS_Logfs_Init(&pios_waypoints_settings_fs_id, &flashfs_waypoints_cfg, FLASH_PARTITION_LABEL_WAYPOINTS) != 0)
 		panic(1);
+
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
+
 #endif	/* PIOS_INCLUDE_FLASH */
 
 	/* Initialize the task monitor library */

--- a/flight/targets/quanton/fw/Makefile
+++ b/flight/targets/quanton/fw/Makefile
@@ -30,6 +30,7 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # Set developer code and compile options
 # Set to YES for debugging
 DEBUG ?= NO
+ERASE_FLASH ?= NO
 
 # List of modules to include
 MODULES = Sensors
@@ -110,6 +111,10 @@ SRC += $(OPUAVOBJ)/eventdispatcher.c
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
+endif
+
+ifeq ($(ERASE_FLASH), YES)
+CDEFS += -DERASE_FLASH
 endif
 
 SRC += $(FLIGHTLIB)/paths.c

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -387,6 +387,11 @@ void PIOS_Board_Init(void) {
 		panic(1);
 	if (PIOS_FLASHFS_Logfs_Init(&pios_waypoints_settings_fs_id, &flashfs_waypoints_cfg, FLASH_PARTITION_LABEL_WAYPOINTS) != 0)
 		panic(1);
+
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
+
 #endif	/* PIOS_INCLUDE_FLASH */
 
 	/* Initialize the task monitor library */

--- a/flight/targets/revomini/fw/Makefile
+++ b/flight/targets/revomini/fw/Makefile
@@ -30,6 +30,7 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # Set developer code and compile options
 # Set to YES for debugging
 DEBUG ?= NO
+ERASE_FLASH ?= NO
 
 # List of modules to include
 MODULES = Sensors
@@ -249,7 +250,9 @@ else
 CFLAGS += -Os
 endif
 
-
+ifeq ($(ERASE_FLASH), YES)
+CDEFS += -DERASE_FLASH
+endif
    
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -339,6 +339,11 @@ void PIOS_Board_Init(void) {
 	/* Mount all filesystems */
 	PIOS_FLASHFS_Logfs_Init(&pios_uavo_settings_fs_id, &flashfs_settings_cfg, FLASH_PARTITION_LABEL_SETTINGS);
 	PIOS_FLASHFS_Logfs_Init(&pios_waypoints_settings_fs_id, &flashfs_waypoints_cfg, FLASH_PARTITION_LABEL_WAYPOINTS);
+
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
+
 #endif	/* PIOS_INCLUDE_FLASH */
 
 	/* Initialize the task monitor library */


### PR DESCRIPTION
Make it easy to compile an erase flash version of the firmware for targets. This was
already supported on Sparky.

Compile firmware with
```make fw_<board_name>```