### PR TITLE
Trimming: allow trimming level in AH mode

### DIFF
--- a/ground/gcs/src/plugins/config/vehicletrim.cpp
+++ b/ground/gcs/src/plugins/config/vehicletrim.cpp
@@ -67,6 +67,7 @@ VehicleTrim::autopilotLevelBiasMessages VehicleTrim::setAutopilotBias()
 
     // Check that vehicle is in stabilized{1,2,3} flight mode
     if (flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_LEVELING &&
+            flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_ALTITUDEHOLD &&
             flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED1 &&
             flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED2 &&
             flightStatus->getFlightMode() != FlightStatus::FLIGHTMODE_STABILIZED3){


### PR DESCRIPTION
Previously only a few modes used the vehicle trim,
but since now all of them do, it should be possible
to trim in altitude hold mode.