### PR TITLE
CopterControl: OneShot and HSUM support

### DIFF
--- a/flight/PiOS/STM32F10x/pios_servo.c
+++ b/flight/PiOS/STM32F10x/pios_servo.c
@@ -202,3 +202,81 @@ void PIOS_Servo_Set(uint8_t servo, uint16_t position)
 			break;
 	}
 }
+
+#if defined(PIOS_INCLUDE_ONESHOT)
+#define OneShotFrequency 12000000
+
+/**
+* Set servo position for OneShot
+* \param[in] Servo Servo number (0-num_channels)
+* \param[in] Position Servo position in 1/12 microseconds based on OneShotFrequency
+*/
+void PIOS_Servo_OneShot_Set(uint8_t servo, uint16_t position)
+{
+	/* Make sure servo exists */
+	if (!servo_cfg || servo >= servo_cfg->num_channels) {
+		return;
+	}
+
+	const struct pios_tim_channel * chan = &servo_cfg->channels[servo];
+
+	/* stop the timer */
+	TIM_Cmd(chan->timer, DISABLE);
+
+	/* Update the position */
+	switch(chan->timer_chan) {
+		case TIM_Channel_1:
+			TIM_SetCompare1(chan->timer, position);
+			break;
+		case TIM_Channel_2:
+			TIM_SetCompare2(chan->timer, position);
+			break;
+		case TIM_Channel_3:
+			TIM_SetCompare3(chan->timer, position);
+			break;
+		case TIM_Channel_4:
+			TIM_SetCompare4(chan->timer, position);
+			break;
+	}
+}
+
+/**
+* Update the timer for OneShot
+*/
+void PIOS_Servo_OneShot_Update()
+{
+	if (!servo_cfg) {
+		return;
+	}
+
+	TIM_TimeBaseInitTypeDef TIM_TimeBaseStructure;
+	TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
+
+	for (uint8_t i = 0; i < servo_cfg->num_channels; i++) {
+		const struct pios_tim_channel * chan = &servo_cfg->channels[i];
+
+		/* Look for a disabled timer which is probably used by OneShot */
+		if (!(chan->timer->CR1 & TIM_CR1_CEN)) {
+			/* Choose the correct prescaler value for the APB the timer is attached */
+			if (chan->timer==TIM6 || chan->timer==TIM7) {
+				// These timers cannot be used here.
+				continue;
+			} else if (chan->timer==TIM1 || chan->timer==TIM8) {
+				if (PIOS_PERIPHERAL_APB2_CLOCK == PIOS_SYSCLK)
+					TIM_TimeBaseStructure.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / OneShotFrequency) - 1;
+				else
+					TIM_TimeBaseStructure.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK*2 / OneShotFrequency) - 1;
+			} else {
+				if (PIOS_PERIPHERAL_APB1_CLOCK == PIOS_SYSCLK)
+					TIM_TimeBaseStructure.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / OneShotFrequency) - 1;
+				else
+					TIM_TimeBaseStructure.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK*2 / OneShotFrequency) - 1;
+			}
+
+			/* enable it again and reinitialize it */
+			TIM_Cmd(chan->timer, ENABLE);
+			TIM_TimeBaseInit(chan->timer, &TIM_TimeBaseStructure);
+		}
+	}
+}
+#endif

--- a/flight/targets/coptercontrol/board-info/board_hw_defs.c
+++ b/flight/targets/coptercontrol/board-info/board_hw_defs.c
@@ -1065,7 +1065,44 @@ static const struct pios_usart_cfg pios_usart_generic_flexi_cfg = {
  */
 #include <pios_dsm_priv.h>
 
-static const struct pios_usart_cfg pios_usart_dsm_main_cfg = {
+static const struct pios_dsm_cfg pios_dsm_main_cfg = {
+	.bind = {
+		.gpio = GPIOA,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_10,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_Out_PP,
+		},
+	},
+};
+
+static const struct pios_dsm_cfg pios_dsm_flexi_cfg = {
+	.bind = {
+		.gpio = GPIOB,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_11,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_Out_PP,
+		},
+	},
+};
+
+#endif	/* PIOS_INCLUDE_DSM */
+
+#if defined(PIOS_INCLUDE_HSUM)
+/*
+ * Graupner HoTT SUMD/SUMH USART
+ */
+#include <pios_hsum_priv.h>
+
+#endif	/* PIOS_INCLUDE_HSUM */
+
+#if (defined(PIOS_INCLUDE_DSM) || defined(PIOS_INCLUDE_HSUM))
+/*
+ * Spektrum/JR DSM or Graupner HoTT SUMD/SUMH USART
+ */
+
+static const struct pios_usart_cfg pios_usart_dsm_hsum_main_cfg = {
 	.regs = USART1,
 	.init = {
 		.USART_BaudRate            = 115200,
@@ -1101,18 +1138,7 @@ static const struct pios_usart_cfg pios_usart_dsm_main_cfg = {
 	},
 };
 
-static const struct pios_dsm_cfg pios_dsm_main_cfg = {
-	.bind = {
-		.gpio = GPIOA,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_10,
-			.GPIO_Speed = GPIO_Speed_2MHz,
-			.GPIO_Mode  = GPIO_Mode_Out_PP,
-		},
-	},
-};
-
-static const struct pios_usart_cfg pios_usart_dsm_flexi_cfg = {
+static const struct pios_usart_cfg pios_usart_dsm_hsum_flexi_cfg = {
 	.regs = USART3,
 	.init = {
 		.USART_BaudRate            = 115200,
@@ -1148,18 +1174,7 @@ static const struct pios_usart_cfg pios_usart_dsm_flexi_cfg = {
 	},
 };
 
-static const struct pios_dsm_cfg pios_dsm_flexi_cfg = {
-	.bind = {
-		.gpio = GPIOB,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_11,
-			.GPIO_Speed = GPIO_Speed_2MHz,
-			.GPIO_Mode  = GPIO_Mode_Out_PP,
-		},
-	},
-};
-
-#endif	/* PIOS_INCLUDE_DSM */
+#endif	/* PIOS_INCLUDE_DSM || PIOS_INCLUDE_HSUM */
 
 
 #if defined(PIOS_INCLUDE_SBUS)

--- a/flight/targets/coptercontrol/board-info/pios_board.h
+++ b/flight/targets/coptercontrol/board-info/pios_board.h
@@ -240,6 +240,12 @@ extern uintptr_t pios_com_lighttelemetry_id;
 #define PIOS_DSM_NUM_INPUTS			12
 
 //-------------------------
+// Receiver HSUM input
+//-------------------------
+#define PIOS_HSUM_MAX_DEVS				2
+#define PIOS_HSUM_NUM_INPUTS			32
+
+//-------------------------
 // Receiver S.Bus input
 //-------------------------
 #define PIOS_SBUS_NUM_INPUTS			(16+2)

--- a/flight/targets/coptercontrol/fw/Makefile
+++ b/flight/targets/coptercontrol/fw/Makefile
@@ -284,6 +284,7 @@ SRC += $(PIOSCOMMON)/pios_mpu6000.c
 SRC += $(PIOSCOMMON)/pios_com.c
 SRC += $(PIOSCOMMON)/pios_rcvr.c
 SRC += $(PIOSCOMMON)/pios_sbus.c
+SRC += $(PIOSCOMMON)/pios_hsum.c
 SRC += $(PIOSCOMMON)/pios_sensors.c
 SRC += $(PIOSCOMMON)/pios_gcsrcvr.c
 SRC += $(PIOSCOMMON)/printf-stdarg.c

--- a/flight/targets/coptercontrol/fw/pios_board.c
+++ b/flight/targets/coptercontrol/fw/pios_board.c
@@ -469,7 +469,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			uintptr_t pios_usart_dsm_id;
-			if (PIOS_USART_Init(&pios_usart_dsm_id, &pios_usart_dsm_main_cfg)) {
+			if (PIOS_USART_Init(&pios_usart_dsm_id, &pios_usart_dsm_hsum_main_cfg)) {
 				PIOS_Assert(0);
 			}
 
@@ -488,6 +488,32 @@ void PIOS_Board_Init(void) {
 			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_DSMMAINPORT] = pios_dsm_rcvr_id;
 		}
 #endif	/* PIOS_INCLUDE_DSM */
+		break;
+	case HWCOPTERCONTROL_MAINPORT_HOTTSUMD:
+	case HWCOPTERCONTROL_MAINPORT_HOTTSUMH:
+#if defined(PIOS_INCLUDE_HSUM)
+		{
+			enum pios_hsum_proto proto;
+			proto = (hw_mainport == HWCOPTERCONTROL_MAINPORT_HOTTSUMD) ? PIOS_HSUM_PROTO_SUMD : PIOS_HSUM_PROTO_SUMH;
+
+			uintptr_t pios_usart_hsum_id;
+			if (PIOS_USART_Init(&pios_usart_hsum_id, &pios_usart_dsm_hsum_main_cfg)) {
+				PIOS_Assert(0);
+			}
+
+			uintptr_t pios_hsum_id;
+			if (PIOS_HSUM_Init(&pios_hsum_id, &pios_usart_com_driver, pios_usart_hsum_id, proto)) {
+				PIOS_Assert(0);
+			}
+
+			uintptr_t pios_hsum_rcvr_id;
+			if (PIOS_RCVR_Init(&pios_hsum_rcvr_id, &pios_hsum_rcvr_driver, pios_hsum_id)) {
+				PIOS_Assert(0);
+			}
+			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_HOTTSUM] = pios_hsum_rcvr_id;
+
+		}
+#endif	/* PIOS_INCLUDE_HSUM */
 		break;
 	case HWCOPTERCONTROL_MAINPORT_DEBUGCONSOLE:
 #if defined(PIOS_INCLUDE_COM)
@@ -670,7 +696,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			uintptr_t pios_usart_dsm_id;
-			if (PIOS_USART_Init(&pios_usart_dsm_id, &pios_usart_dsm_flexi_cfg)) {
+			if (PIOS_USART_Init(&pios_usart_dsm_id, &pios_usart_dsm_hsum_flexi_cfg)) {
 				PIOS_Assert(0);
 			}
 
@@ -689,6 +715,32 @@ void PIOS_Board_Init(void) {
 			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_DSMFLEXIPORT] = pios_dsm_rcvr_id;
 		}
 #endif	/* PIOS_INCLUDE_DSM */
+		break;
+	case HWCOPTERCONTROL_FLEXIPORT_HOTTSUMD:
+	case HWCOPTERCONTROL_FLEXIPORT_HOTTSUMH:
+#if defined(PIOS_INCLUDE_HSUM)
+		{
+			enum pios_hsum_proto proto;
+			proto = (hw_flexiport == HWCOPTERCONTROL_FLEXIPORT_HOTTSUMD) ? PIOS_HSUM_PROTO_SUMD : PIOS_HSUM_PROTO_SUMH;
+
+			uintptr_t pios_usart_hsum_id;
+			if (PIOS_USART_Init(&pios_usart_hsum_id, &pios_usart_dsm_hsum_flexi_cfg)) {
+				PIOS_Assert(0);
+			}
+
+			uintptr_t pios_hsum_id;
+			if (PIOS_HSUM_Init(&pios_hsum_id, &pios_usart_com_driver, pios_usart_hsum_id, proto)) {
+				PIOS_Assert(0);
+			}
+
+			uintptr_t pios_hsum_rcvr_id;
+			if (PIOS_RCVR_Init(&pios_hsum_rcvr_id, &pios_hsum_rcvr_driver, pios_hsum_id)) {
+				PIOS_Assert(0);
+			}
+			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_HOTTSUM] = pios_hsum_rcvr_id;
+
+		}
+#endif	/* PIOS_INCLUDE_HSUM */
 		break;
 	case HWCOPTERCONTROL_FLEXIPORT_DEBUGCONSOLE:
 #if defined(PIOS_INCLUDE_COM)

--- a/flight/targets/coptercontrol/fw/pios_config.h
+++ b/flight/targets/coptercontrol/fw/pios_config.h
@@ -45,11 +45,13 @@
 #define PIOS_INCLUDE_LED
 #define PIOS_INCLUDE_IAP
 #define PIOS_INCLUDE_TIM
+#define PIOS_INCLUDE_ONESHOT
 
 #define PIOS_INCLUDE_RCVR
 
 /* Supported receiver interfaces */
 #define PIOS_INCLUDE_DSM
+#define PIOS_INCLUDE_HSUM
 #define PIOS_INCLUDE_SBUS
 #define PIOS_INCLUDE_PPM
 #define PIOS_INCLUDE_PWM

--- a/shared/uavobjectdefinition/hwcoptercontrol.xml
+++ b/shared/uavobjectdefinition/hwcoptercontrol.xml
@@ -3,8 +3,8 @@
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Outputs,Outputs" defaultvalue="PWM"/>
-		<field name="MainPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,S.Bus,DSM,DebugConsole,ComBridge, MavLinkTX, MavLinkTX_GPS_RX, FrSKY Sensor Hub, LighttelemetryTx" defaultvalue="Telemetry"/>
-		<field name="FlexiPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,I2C,DSM,DebugConsole,ComBridge, MavLinkTX, FrSKY Sensor Hub, LighttelemetryTx" defaultvalue="Disabled"/>
+		<field name="MainPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,S.Bus,DSM,DebugConsole,ComBridge, MavLinkTX, MavLinkTX_GPS_RX, FrSKY Sensor Hub, LighttelemetryTx,HoTT SUMD,HoTT SUMH " defaultvalue="Telemetry"/>
+		<field name="FlexiPort" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,I2C,DSM,DebugConsole,ComBridge, MavLinkTX, FrSKY Sensor Hub, LighttelemetryTx,HoTT SUMD,HoTT SUMH" defaultvalue="Disabled"/>
 
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" options="USBTelemetry,RCTransmitter,Disabled" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" options="USBTelemetry,ComBridge,DebugConsole,Disabled" defaultvalue="Disabled"/>


### PR DESCRIPTION
Add PIOS functions for OneShot on F1 targets. Enable OneShot on
CopterControl. Add HoTT receiver support for CopterControl.