### PR TITLE
Feedforward: Remove remaining feedforward code in flight side.

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -514,12 +514,6 @@ void VehicleConfigurationHelper::resetVehicleConfig()
     // Reset all vehicle data
     MixerSettings *mSettings = MixerSettings::GetInstance(m_uavoManager);
 
-    // Reset feed forward, accel times etc
-    mSettings->setFeedForward(0.0f);
-    mSettings->setMaxAccel(1000.0f);
-    mSettings->setAccelTime(0.0f);
-    mSettings->setDecelTime(0.0f);
-
     // Reset throttle curves
     QString throttlePattern = "ThrottleCurve%1";
     for (int i = 1; i <= 2; i++) {

--- a/shared/uavobjectdefinition/mixersettings.xml
+++ b/shared/uavobjectdefinition/mixersettings.xml
@@ -1,10 +1,6 @@
 <xml>
     <object name="MixerSettings" singleinstance="true" settings="true">
         <description>Settings for the @ref ActuatorModule that controls the channel assignments for the mixer based on AircraftType</description>
-        <field name="MaxAccel" units="units/sec" type="float" elements="1" defaultvalue="1000"/>
-        <field name="FeedForward" units="" type="float" elements="1" defaultvalue="0"/>
-        <field name="AccelTime" units="ms" type="float" elements="1" defaultvalue="0"/>
-        <field name="DecelTime" units="ms" type="float" elements="1" defaultvalue="0"/>
 	<field name="ThrottleCurve1" units="percent" type="float" elementnames="0,25,50,75,100" defaultvalue="0,0,0,0,0"/>
         <field name="Curve2Source" units="" type="enum" elements="1" defaultvalue="Throttle">
 		<options>


### PR DESCRIPTION
And also remove leftover feedforward reference in Ground side wizard.
Remove feedforward for Mixer UAVObject.

Flight tested on Sparky. Need independent review since this touches core flight code in actuator.c.
Solves Issue #1471 