### PR TITLE
Autotune: reduce module stack size

### DIFF
--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -46,7 +46,7 @@
 #include "pios_thread.h"
 
 // Private constants
-#define STACK_SIZE_BYTES 2000
+#define STACK_SIZE_BYTES 1500
 #define TASK_PRIORITY PIOS_THREAD_PRIO_NORMAL
 
 #define AF_NUMX 13

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -46,7 +46,7 @@
 #include "pios_thread.h"
 
 // Private constants
-#define STACK_SIZE_BYTES 1500
+#define STACK_SIZE_BYTES 1700
 #define TASK_PRIORITY PIOS_THREAD_PRIO_NORMAL
 
 #define AF_NUMX 13


### PR DESCRIPTION
This reduces the stack size from 2000 to 1500 in autotune module. It
frees some memory and autotune can be enabled on coptercontrol again.
Tested on CC3D and works.