### PR TITLE
sparky: put pios_can_cfg in FLASH to save a few RAM bytes

### DIFF
--- a/flight/targets/sparky/board-info/board_hw_defs.c
+++ b/flight/targets/sparky/board-info/board_hw_defs.c
@@ -236,7 +236,7 @@ void PIOS_I2C_flexi_er_irq_handler(void)
 
 #if defined(PIOS_INCLUDE_CAN)
 #include "pios_can_priv.h"
-struct pios_can_cfg pios_can_cfg = {
+static const struct pios_can_cfg pios_can_cfg = {
 	.regs = CAN1,
 	.init = {
 		// To make it easy to use both F3 and F4 use the other APB1 bus rate


### PR DESCRIPTION
On Sparky, pios_can_cfg is currently in RAM. As there appears to be no need to modify this, the modifier static const has been added to move this to FLASH and save a few precious RAM bytes.