### PR TITLE
AltitudeHold: increase stack size

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -58,7 +58,7 @@
 
 // Private constants
 #define MAX_QUEUE_SIZE 4
-#define STACK_SIZE_BYTES 540
+#define STACK_SIZE_BYTES 600
 #define TASK_PRIORITY PIOS_THREAD_PRIO_LOW
 
 // Private variables


### PR DESCRIPTION
Sometimes this module is getting down as low as
12 bytes free.