### PR TITLE
RevoMini: update RTC clock rate

### DIFF
--- a/flight/targets/revomini/board-info/board_hw_defs.c
+++ b/flight/targets/revomini/board-info/board_hw_defs.c
@@ -1030,9 +1030,7 @@ void PIOS_I2C_pressure_adapter_er_irq_handler(void);
 void PIOS_RTC_IRQ_Handler (void);
 void RTC_WKUP_IRQHandler() __attribute__ ((alias ("PIOS_RTC_IRQ_Handler")));
 static const struct pios_rtc_cfg pios_rtc_main_cfg = {
-	.clksrc = RCC_RTCCLKSource_HSE_Div16, // Divide 8 Mhz crystal down to 1
-	// For some reason it's acting like crystal is 16 Mhz.  This clock is then divided
-	// by another 16 to give a nominal 62.5 khz clock
+	.clksrc = RCC_RTCCLKSource_HSE_Div8, // Divide 8 Mhz crystal down to 1
 	.prescaler = 100, // Every 100 cycles gives 625 Hz
 	.irq = {
 		.init = {


### PR DESCRIPTION
It was running incorrectly which subsequently broke
the SBUS driver.

Thanks to @pug368 for lending me an SBUS TX/RX to
fix this.