### PR TITLE
Battery monitoring fixes and improvements

### DIFF
--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -91,7 +91,6 @@ int32_t BatteryInitialize(void)
 	return 0;
 }
 MODULE_INITCALL(BatteryInitialize, BatteryStart)
-#define HAS_SENSOR(x) batterySettings.SensorType[x]==FLIGHTBATTERYSETTINGS_SENSORTYPE_ENABLED
 
 static bool battery_settings_updated;
 
@@ -119,50 +118,50 @@ static void batteryTask(void * parameters)
 			FlightBatterySettingsGet(&batterySettings);
 
 			voltageADCPin = batterySettings.VoltagePin;
-			if (!HAS_SENSOR(FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYVOLTAGE) || (voltageADCPin == FLIGHTBATTERYSETTINGS_VOLTAGEPIN_NONE))
+			if (voltageADCPin == FLIGHTBATTERYSETTINGS_VOLTAGEPIN_NONE)
 				voltageADCPin = -1;
 
 			currentADCPin = batterySettings.CurrentPin;
-			if (!HAS_SENSOR(FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYCURRENT) || (currentADCPin == FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE))
+			if (currentADCPin == FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE)
 				currentADCPin = -1;
 		}
 
-		//calculate the battery parameters
+		// handle voltage
 		if (voltageADCPin >= 0) {
 			flightBatteryData.Voltage = ((float) PIOS_ADC_GetChannelVolt(voltageADCPin)) / batterySettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_VOLTAGE] * 1000.0f +
 							batterySettings.SensorCalibrationOffset[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONOFFSET_VOLTAGE]; //in Volts
+
+			// generate alarms and warnings
+			if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM])
+				AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_CRITICAL);
+			else if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING])
+				AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_WARNING);
+			else
+				AlarmsClear(SYSTEMALARMS_ALARM_BATTERY);
 		} else {
-			flightBatteryData.Voltage = 0; //Dummy placeholder value. This is in case we get another source of battery current which is not from the ADC
+			flightBatteryData.Voltage = 0;
 		}
 
+		// handle current
 		if (currentADCPin >= 0) {
 			flightBatteryData.Current = ((float) PIOS_ADC_GetChannelVolt(currentADCPin)) / batterySettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_CURRENT] * 1000.0f +
 							batterySettings.SensorCalibrationOffset[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONOFFSET_CURRENT]; //in Amps
 			if (flightBatteryData.Current > flightBatteryData.PeakCurrent)
 				flightBatteryData.PeakCurrent = flightBatteryData.Current; //in Amps
-		} else { //If there's no current measurement, we still need to assign one. Make it negative, so it can never trigger an alarm
-			flightBatteryData.Current = -1; //Dummy placeholder value. This is in case we get another source of battery current which is not from the ADC
-		}
 
-		flightBatteryData.ConsumedEnergy += (flightBatteryData.Current * dT * 1000.0f / 3600.0f); //in mAh
+			flightBatteryData.ConsumedEnergy += (flightBatteryData.Current * dT * 1000.0f / 3600.0f); //in mAh
 
-		//Apply a 2 second rise time low-pass filter to average the current
-		float alpha = 1.0f - dT / (dT + 2.0f);
-		flightBatteryData.AvgCurrent = alpha * flightBatteryData.AvgCurrent + (1 - alpha) * flightBatteryData.Current; //in Amps
+			//Apply a 2 second rise time low-pass filter to average the current
+			float alpha = 1.0f - dT / (dT + 2.0f);
+			flightBatteryData.AvgCurrent = alpha * flightBatteryData.AvgCurrent + (1 - alpha) * flightBatteryData.Current; //in Amps
 
-		energyRemaining = batterySettings.Capacity - flightBatteryData.ConsumedEnergy; // in mAh
-		if (flightBatteryData.AvgCurrent > 0)
-			flightBatteryData.EstimatedFlightTime = (energyRemaining / (flightBatteryData.AvgCurrent * 1000.0f)) * 3600.0f; //in Sec
-		else
-			flightBatteryData.EstimatedFlightTime = 9999;
+			energyRemaining = batterySettings.Capacity - flightBatteryData.ConsumedEnergy; // in mAh
+			if (flightBatteryData.AvgCurrent > 0)
+				flightBatteryData.EstimatedFlightTime = (energyRemaining / (flightBatteryData.AvgCurrent * 1000.0f)) * 3600.0f; //in Sec
+			else
+				flightBatteryData.EstimatedFlightTime = 9999;
 
-		//generate alarms where needed...
-		if (((voltageADCPin >= 0) && (flightBatteryData.Voltage <= 0)) || ((currentADCPin >=0) && (flightBatteryData.Current <= 0))) {
-			//FIXME: There's no guarantee that a floating ADC will give 0. So this
-			// check might fail, even when there's nothing attached.
-			AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_ERROR);
-			AlarmsSet(SYSTEMALARMS_ALARM_FLIGHTTIME, SYSTEMALARMS_ALARM_ERROR);
-		} else {
+			// generate alarms and warnings
 			if ((batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_ALARM] > 0)
 				&& (flightBatteryData.EstimatedFlightTime < batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_ALARM]))
 				AlarmsSet(SYSTEMALARMS_ALARM_FLIGHTTIME, SYSTEMALARMS_ALARM_CRITICAL);
@@ -171,17 +170,8 @@ static void batteryTask(void * parameters)
 				AlarmsSet(SYSTEMALARMS_ALARM_FLIGHTTIME, SYSTEMALARMS_ALARM_WARNING);
 			else
 				AlarmsClear(SYSTEMALARMS_ALARM_FLIGHTTIME);
-
-			// FIXME: should make the battery voltage detection dependent on battery type.
-			/*Not so sure. Some users will want to run their batteries harder than others, so it should be the user's choice. [KDS]*/
-			if (voltageADCPin >= 0) {
-				if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM])
-					AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_CRITICAL);
-				else if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING])
-					AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_WARNING);
-				else
-					AlarmsClear(SYSTEMALARMS_ALARM_BATTERY);
-			}
+		} else {
+			flightBatteryData.Current = 0;
 		}
 
 		FlightBatteryStateSet(&flightBatteryData);

--- a/flight/Modules/UAVOFrSKYSPortBridge/UAVOFrSKYSPortBridge.c
+++ b/flight/Modules/UAVOFrSKYSPortBridge/UAVOFrSKYSPortBridge.c
@@ -742,10 +742,9 @@ static int32_t uavoFrSKYSPortBridgeStart(void)
 
 	if (FlightBatterySettingsHandle() != NULL
 			&& FlightBatteryStateHandle() != NULL) {
-		uint8_t sensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_NUMELEM];
-		FlightBatterySettingsSensorTypeGet(sensorType);
-		if (sensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYCURRENT]
-				== FLIGHTBATTERYSETTINGS_SENSORTYPE_ENABLED)
+		uint8_t currentPin;
+		FlightBatterySettingsCurrentPinGet(&currentPin);
+		if (currentPin != FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE)
 			frsky->use_current_sensor = true;
 		FlightBatterySettingsGet(&frsky->battery_settings);
 		frsky->batt_cell_count = frsky->battery_settings.NbCells;

--- a/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
+++ b/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
@@ -255,14 +255,13 @@ static void uavoFrSKYSensorHubBridgeTask(void *parameters)
 		FlightBatterySettingsGet(&batSettings);
 	else {
 		batSettings.Capacity = 0;
-		batSettings.NbCells = 0;
 		batSettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_CURRENT] = 0;
 		batSettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_VOLTAGE] = 0;
-		batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYCURRENT] = FLIGHTBATTERYSETTINGS_SENSORTYPE_DISABLED;
-		batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYVOLTAGE] = FLIGHTBATTERYSETTINGS_SENSORTYPE_DISABLED;
-		batSettings.Type = FLIGHTBATTERYSETTINGS_TYPE_NONE;
 		batSettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING] = 0;
 		batSettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM] = 0;
+		batSettings.NbCells = 0;
+		batSettings.VoltagePin = FLIGHTBATTERYSETTINGS_VOLTAGEPIN_NONE;
+		batSettings.CurrentPin = FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE;
 	}
 
 	if (GPSPositionHandle() == NULL ) {
@@ -361,11 +360,11 @@ static void uavoFrSKYSensorHubBridgeTask(void *parameters)
 				FlightBatteryStateGet(&batState);
 
 			float voltage = 0.0f;
-			if (batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYVOLTAGE] == FLIGHTBATTERYSETTINGS_SENSORTYPE_ENABLED)
+			if (batSettings.VoltagePin != FLIGHTBATTERYSETTINGS_VOLTAGEPIN_NONE)
 				voltage = batState.Voltage;
 
 			float current = 0.0f;
-			if (batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYCURRENT] == FLIGHTBATTERYSETTINGS_SENSORTYPE_ENABLED)
+			if (batSettings.CurrentPin != FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE)
 				current = batState.Current;
 
 			// As long as there is no voltage for each cell

--- a/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
+++ b/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
@@ -156,14 +156,12 @@ static void uavoMavlinkBridgeTask(void *parameters) {
 		FlightBatterySettingsGet(&batSettings);
 	else {
 		batSettings.Capacity = 0;
-		batSettings.NbCells = 0;
 		batSettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_CURRENT] = 0;
 		batSettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_VOLTAGE] = 0;
-		batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYCURRENT] = FLIGHTBATTERYSETTINGS_SENSORTYPE_DISABLED;
-		batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYVOLTAGE] = FLIGHTBATTERYSETTINGS_SENSORTYPE_DISABLED;
-		batSettings.Type = FLIGHTBATTERYSETTINGS_TYPE_NONE;
 		batSettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING] = 0;
 		batSettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM] = 0;
+		batSettings.VoltagePin = FLIGHTBATTERYSETTINGS_VOLTAGEPIN_NONE;
+		batSettings.CurrentPin = FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE;
 	}
 
 	if (GPSPositionHandle() == NULL ){
@@ -230,11 +228,11 @@ static void uavoMavlinkBridgeTask(void *parameters) {
 			}
 
 			uint16_t voltage = 0;
-			if (batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYVOLTAGE] == FLIGHTBATTERYSETTINGS_SENSORTYPE_ENABLED)
+			if (batSettings.VoltagePin != FLIGHTBATTERYSETTINGS_VOLTAGEPIN_NONE)
 				voltage = lroundf(batState.Voltage * 1000);
 
 			uint16_t current = 0;
-			if (batSettings.SensorType[FLIGHTBATTERYSETTINGS_SENSORTYPE_BATTERYCURRENT] == FLIGHTBATTERYSETTINGS_SENSORTYPE_ENABLED)
+			if (batSettings.CurrentPin != FLIGHTBATTERYSETTINGS_CURRENTPIN_NONE)
 				current = lroundf(batState.Current * 100);
 
 			mavlink_msg_sys_status_pack(0, 200, &mavMsg,

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -112,9 +112,14 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationFactor", ui->sb_currentFactor, FlightBatterySettings::SENSORCALIBRATIONFACTOR_CURRENT);
     addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationOffset", ui->sb_voltageOffSet, FlightBatterySettings::SENSORCALIBRATIONOFFSET_VOLTAGE);
     addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationOffset", ui->sb_currentOffSet, FlightBatterySettings::SENSORCALIBRATIONOFFSET_CURRENT);
+    addUAVObjectToWidgetRelation(batterySettingsName, "FlightTimeThresholds", ui->sb_flightTimeAlarm, FlightBatterySettings::FLIGHTTIMETHRESHOLDS_ALARM);
+    addUAVObjectToWidgetRelation(batterySettingsName, "FlightTimeThresholds", ui->sb_flightTimeWarning, FlightBatterySettings::FLIGHTTIMETHRESHOLDS_WARNING);
 
     addUAVObjectToWidgetRelation(batteryStateName, "Voltage", ui->le_liveVoltageReading);
     addUAVObjectToWidgetRelation(batteryStateName, "Current", ui->le_liveCurrentReading);
+
+    addUAVObjectToWidgetRelation(batteryStateName, "ConsumedEnergy", ui->le_liveConsumedEnergy);
+    addUAVObjectToWidgetRelation(batteryStateName, "EstimatedFlightTime", ui->le_liveEstimatedFlightTime);
 
     addUAVObjectToWidgetRelation(vibrationAnalysisSettingsName, "SampleRate", ui->sb_sampleRate);
     addUAVObjectToWidgetRelation(vibrationAnalysisSettingsName, "FFTWindowSize", ui->cb_windowSize);
@@ -552,6 +557,7 @@ void ConfigModuleWidget::toggleVibrationTest()
     vibrationAnalysisSettings->setData(vibrationAnalysisSettingsData);
     vibrationAnalysisSettings->updated();
 }
+
 
 void ConfigModuleWidget::updateAirspeedUAVO(UAVObject *obj)
 {

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -92,8 +92,11 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbUAVOFrSkySPortBridge, ModuleSettings::ADMINSTATE_UAVOFRSKYSPORTBRIDGE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbGeofence, ModuleSettings::ADMINSTATE_GEOFENCE);
 
-    addUAVObjectToWidgetRelation(batterySettingsName, "SensorType", ui->gb_measureVoltage, FlightBatterySettings::SENSORTYPE_BATTERYVOLTAGE);
-    addUAVObjectToWidgetRelation(batterySettingsName, "SensorType", ui->gb_measureCurrent, FlightBatterySettings::SENSORTYPE_BATTERYCURRENT);
+    // Connect the voltage and current checkboxes, such that the ADC pins are toggled and vice versa
+    connect(ui->gb_measureVoltage, SIGNAL(toggled(bool)), this, SLOT(toggleBatteryMonitoringPin()));
+    connect(ui->gb_measureCurrent, SIGNAL(toggled(bool)), this, SLOT(toggleBatteryMonitoringPin()));
+    connect(ui->cbVoltagePin, SIGNAL(currentIndexChanged(int)), this, SLOT(toggleBatteryMonitoringGb()));
+    connect(ui->cbCurrentPin, SIGNAL(currentIndexChanged(int)), this, SLOT(toggleBatteryMonitoringGb()));
 
     // Link the fields
     addUAVObjectToWidgetRelation(airspeedSettingsName, "GPSSamplePeriod_ms", ui->sb_gpsUpdateRate);
@@ -101,7 +104,6 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(airspeedSettingsName, "ZeroPoint", ui->sb_pitotZeroPoint);
     addUAVObjectToWidgetRelation(airspeedSettingsName, "AnalogPin", ui->cbAirspeedAnalog);
 
-    addUAVObjectToWidgetRelation(batterySettingsName, "Type", ui->cb_batteryType);
     addUAVObjectToWidgetRelation(batterySettingsName, "NbCells", ui->sb_numBatteryCells);
     addUAVObjectToWidgetRelation(batterySettingsName, "Capacity", ui->sb_batteryCapacity);
     addUAVObjectToWidgetRelation(batterySettingsName, "VoltagePin", ui->cbVoltagePin);
@@ -558,6 +560,33 @@ void ConfigModuleWidget::toggleVibrationTest()
     vibrationAnalysisSettings->updated();
 }
 
+/**
+ * @brief Toggle voltage and current pins depending on battery monitoring checkboxes
+ */
+void ConfigModuleWidget::toggleBatteryMonitoringPin()
+{
+    if (!ui->gb_measureVoltage->isChecked())
+        ui->cbVoltagePin->setCurrentIndex(ui->cbVoltagePin->findText("NONE"));
+
+    if (!ui->gb_measureCurrent->isChecked())
+        ui->cbCurrentPin->setCurrentIndex(ui->cbCurrentPin->findText("NONE"));
+}
+
+/**
+ * @brief Toggle battery monitoring checkboxes depending on voltage and current pins
+ */
+void ConfigModuleWidget::toggleBatteryMonitoringGb()
+{
+    if (ui->cbVoltagePin->currentText().compare("NONE") != 0)
+        ui->gb_measureVoltage->setChecked(true);
+    else
+        ui->gb_measureVoltage->setChecked(false);
+
+    if (ui->cbCurrentPin->currentText().compare("NONE") != 0)
+        ui->gb_measureCurrent->setChecked(true);
+    else
+        ui->gb_measureCurrent->setChecked(false);
+}
 
 void ConfigModuleWidget::updateAirspeedUAVO(UAVObject *obj)
 {

--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -49,6 +49,8 @@ private slots:
     void updateAirspeedUAVO(UAVObject *);
     void updateAirspeedGroupbox(UAVObject *);
     void toggleVibrationTest();
+    void toggleBatteryMonitoringPin();
+    void toggleBatteryMonitoringGb();
 
     void recheckTabs();
     void objectUpdated(UAVObject * obj, bool success);

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -189,7 +189,7 @@
          <property name="text">
           <string>Geofence</string>
          </property>
-        </widget>        
+        </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="cbUAVOFrSkySPortBridge">
@@ -417,35 +417,6 @@
         </layout>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string>ADC Pins</string>
-         </property>
-         <layout class="QFormLayout" name="formLayout_9">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_23">
-            <property name="text">
-             <string>Voltage Pin:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_24">
-            <property name="text">
-             <string>Current Pin:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="cbVoltagePin"/>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="cbCurrentPin"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <widget class="QGroupBox" name="gb_measureVoltage">
          <property name="title">
           <string>Measure voltage</string>
@@ -463,7 +434,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_14">
             <property name="text">
-             <string>Live reading:</string>
+             <string>Live reading (V):</string>
             </property>
            </widget>
           </item>
@@ -474,14 +445,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_13">
             <property name="text">
              <string>Calibration factor:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="sb_voltageFactor">
             <property name="suffix">
              <string> mV/V</string>
@@ -497,14 +468,14 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_11">
             <property name="text">
              <string>Low voltage alarm:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QDoubleSpinBox" name="sb_lowVoltageAlarm">
             <property name="suffix">
              <string>V</string>
@@ -517,14 +488,14 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="label_12">
             <property name="text">
              <string>Low voltage warning:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="sb_lowVoltageWarning">
             <property name="suffix">
              <string>V</string>
@@ -537,14 +508,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_31">
             <property name="text">
-             <string>Calibration offset</string>
+             <string>Calibration offset:</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QDoubleSpinBox" name="sb_voltageOffSet">
             <property name="suffix">
              <string>V</string>
@@ -562,6 +533,16 @@
              <double>0.100000000000000</double>
             </property>
            </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_23">
+            <property name="text">
+             <string>Voltage Pin:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="cbVoltagePin"/>
           </item>
          </layout>
         </widget>
@@ -584,18 +565,18 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
-             <string>Live reading:</string>
+             <string>Live reading (A):</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>Calibration factor:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="sb_currentFactor">
             <property name="suffix">
              <string> mV/A</string>
@@ -618,14 +599,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_32">
             <property name="text">
-             <string>Calibration offset</string>
+             <string>Calibration offset:</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="6" column="1">
            <widget class="QDoubleSpinBox" name="sb_currentOffSet">
             <property name="suffix">
              <string>A</string>
@@ -641,6 +622,84 @@
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_24">
+            <property name="text">
+             <string>Current Pin:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="cbCurrentPin"/>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_33">
+            <property name="text">
+             <string>Flight time alarm:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_35">
+            <property name="text">
+             <string>Flight time warning:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="sb_flightTimeAlarm">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Raise an alarm when the remaining flight time (calculated based on battery capacity and current consumed) is below this threshold. Set to 0s to disable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="suffix">
+             <string>s</string>
+            </property>
+            <property name="maximum">
+             <number>255</number>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QSpinBox" name="sb_flightTimeWarning">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Issue a warning when the remaining flight time (calculated based on battery capacity and current consumed) is below this threshold. Set to 0s to disable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="suffix">
+             <string>s</string>
+            </property>
+            <property name="maximum">
+             <number>255</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_36">
+            <property name="text">
+             <string>Consumed capacity (mAh):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_37">
+            <property name="text">
+             <string>Remaining flight time (s):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="le_liveConsumedEnergy">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="le_liveEstimatedFlightTime">
+            <property name="readOnly">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -839,7 +898,6 @@
        </item>
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabGeofence">
       <attribute name="title">
        <string>Geofence</string>
@@ -926,7 +984,6 @@
        </item>
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabHoTTTelemetry">
       <attribute name="title">
        <string>HoTT Telemetry</string>
@@ -981,8 +1038,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>392</width>
-            <height>674</height>
+            <width>403</width>
+            <height>589</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">
@@ -3010,6 +3067,7 @@ Apply or Save button afterwards.</string>
   </layout>
  </widget>
  <resources>
+  <include location="../coreplugin/core.qrc"/>
   <include location="../coreplugin/core.qrc"/>
  </resources>
  <connections/>

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -358,17 +358,10 @@
       <layout class="QVBoxLayout" name="verticalLayout_7">
        <item>
         <layout class="QFormLayout" name="formLayout_6">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::ExpandingFieldsGrow</enum>
+         </property>
          <item row="0" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Battery type:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cb_batteryType"/>
-         </item>
-         <item row="1" column="0">
           <widget class="QLabel" name="label_6">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -381,21 +374,21 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="0" column="1">
           <widget class="QSpinBox" name="sb_numBatteryCells">
            <property name="minimum">
             <number>1</number>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
           <widget class="QLabel" name="label_2">
            <property name="text">
             <string>Capacity:</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="1" column="1">
           <widget class="QSpinBox" name="sb_batteryCapacity">
            <property name="suffix">
             <string>mAhr</string>
@@ -1038,7 +1031,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>403</width>
+            <width>328</width>
             <height>589</height>
            </rect>
           </property>

--- a/shared/uavobjectdefinition/flightbatterysettings.xml
+++ b/shared/uavobjectdefinition/flightbatterysettings.xml
@@ -5,17 +5,15 @@
         <field name="CurrentPin" units="" type="enum" elements="1" options="ADC0,ADC1,ADC2,ADC3,ADC4,ADC5,ADC6,ADC7,ADC8,NONE" defaultvalue="ADC0"/>
         <field name="VoltagePin" units="" type="enum" elements="1" options="ADC0,ADC1,ADC2,ADC3,ADC4,ADC5,ADC6,ADC7,ADC8,NONE" defaultvalue="ADC1"/>
 
-        <field name="Type" units="" type="enum" elements="1" options="LiPo,A123,LiCo,LiFeSO4,None" defaultvalue="LiPo"/>
         <field name="NbCells" units=""  type="uint8"  elements="1" defaultvalue="3"/>
         <field name="Capacity" units="mAh"  type="uint32"  elements="1" defaultvalue="2200"/>
 
         <field name="VoltageThresholds" units="V"  type="float" elementnames="Warning, Alarm" defaultvalue="9.8, 9.2"/>
           
-        <field name="SensorType" units="" type="enum" elementnames="BatteryCurrent,BatteryVoltage" options="Disabled,Enabled" defaultvalue="Enabled,Enabled"/>
         <field name="SensorCalibrationFactor" units="mV/U" type="float" elementnames="Voltage, Current" defaultvalue="63.69, 36.60"/>
         <field name="SensorCalibrationOffset" units="" type="float" elementnames="Voltage, Current" defaultvalue="0, 0"/>
 
-	<field name="FlightTimeThresholds" units="s"  type="uint8" elementnames="Warning, Alarm" defaultvalue="120, 30"/>
+        <field name="FlightTimeThresholds" units="s"  type="uint8" elementnames="Warning, Alarm" defaultvalue="120, 30"/>
 
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/flightbatterysettings.xml
+++ b/shared/uavobjectdefinition/flightbatterysettings.xml
@@ -15,6 +15,8 @@
         <field name="SensorCalibrationFactor" units="mV/U" type="float" elementnames="Voltage, Current" defaultvalue="63.69, 36.60"/>
         <field name="SensorCalibrationOffset" units="" type="float" elementnames="Voltage, Current" defaultvalue="0, 0"/>
 
+	<field name="FlightTimeThresholds" units="s"  type="uint8" elementnames="Warning, Alarm" defaultvalue="120, 30"/>
+
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>
         <telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Improvements to the battery monitoring module:

- Unchecking the voltage/current monitoring checkbox now actually disables voltage/current measurements. Before, it was necessary to set the ADC pin to `NONE` for this. Which is unintuitive and can lead to the problem that current monitoring remains enabled even when there is no sensor attached.

- Makes the flight time thresholds configurable

-  Shows consumed capacity and remaining flight time in battery monitoring config

- Moves ADC pin selection to the voltage / current config groups in the GCS