### PR TITLE
Alarms: set alarm when gyro bias is high

### DIFF
--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -320,6 +320,15 @@ static void update_gyros(struct pios_sensor_gyro_data *gyros)
 		gyrosData.x -= gyrosBias.x;
 		gyrosData.y -= gyrosBias.y;
 		gyrosData.z -= gyrosBias.z;
+
+		const float GYRO_BIAS_WARN = 10.0f;
+		if (fabsf(gyrosBias.x) > GYRO_BIAS_WARN ||
+			fabsf(gyrosBias.y) > GYRO_BIAS_WARN ||
+			fabsf(gyrosBias.z) > GYRO_BIAS_WARN) {
+			AlarmsSet(SYSTEMALARMS_ALARM_GYROBIAS, SYSTEMALARMS_ALARM_WARNING);
+		} else {
+			AlarmsClear(SYSTEMALARMS_ALARM_GYROBIAS);
+		}
 	}
 
 	GyrosSet(&gyrosData);

--- a/shared/uavobjectdefinition/systemalarms.xml
+++ b/shared/uavobjectdefinition/systemalarms.xml
@@ -24,6 +24,7 @@
                 		<elementname>AltitudeHold</elementname>
 				<elementname>BootFault</elementname>
 				<elementname>TempBaro</elementname>
+				<elementname>GyroBias</elementname>
 			</elementnames>
 		</field>
 		<field name="ConfigError" units="" type="enum" elements="1" defaultvalue="None">


### PR DESCRIPTION
A gyro bias of more than 10 deg/s is indicative of a potentially 
bad sensor. Throw a warning up to alert the user. This is a 
problem if after leveling and power cycling, the board does 
not hit level again.

fixes #1503 