### PR TITLE
No disarm in autonomous mode

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -633,8 +633,20 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 	{
 		set_armed_if_changed(FLIGHTSTATUS_ARMED_ARMED);
 
-		// Check for arming timeout if transmitter invalid
-		if (!valid || cmd->Throttle < 0) {
+		// Determine whether to disarm when throttle is low
+		uint8_t flight_mode;
+		FlightStatusFlightModeGet(&flight_mode);
+		bool autonomous_mode = flight_mode == FLIGHTSTATUS_FLIGHTMODE_VELOCITYCONTROL ||
+		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_POSITIONHOLD ||
+		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_RETURNTOHOME ||
+		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_PATHPLANNER  ||
+		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_TABLETCONTROL;
+		bool check_throttle = settings->ArmTimeoutAutonomous == MANUALCONTROLSETTINGS_ARMTIMEOUTAUTONOMOUS_ENABLED ||
+			!autonomous_mode;
+		bool low_throttle = cmd->Throttle < 0;
+
+		// Check for arming timeout if transmitter invalid or throttle is low and checked
+		if (!valid || (low_throttle && check_throttle)) {
 			if ((settings->ArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->ArmedTimeout))
 				arm_state = ARM_STATE_DISARMED;
 		} else {

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -634,7 +634,7 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		set_armed_if_changed(FLIGHTSTATUS_ARMED_ARMED);
 
 		// Check for arming timeout if transmitter invalid
-		if (!valid) {
+		if (!valid || cmd->Throttle < 0) {
 			if ((settings->ArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->ArmedTimeout))
 				arm_state = ARM_STATE_DISARMED;
 		} else {

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -127,6 +127,9 @@
 		<field name="FlightModeNumber" units="" type="uint8" elements="1" defaultvalue="3"/>
 		<field name="FlightModePosition" units="" type="enum" elements="6" options="Manual,Acro,Leveling,VirtualBar,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,VelocityControl,PositionHold,ReturnToHome,PathPlanner,TabletControl" defaultvalue="Manual,Stabilized1,Stabilized2,Stabilized3,ReturnToHome,PositionHold" limits="%0401NE:AltitudeHold:VelocityControl;%0402NE:AltitudeHold:VelocityControl,%0401NE:AltitudeHold:VelocityControl;%0402NE:AltitudeHold:VelocityControl,%0401NE:AltitudeHold:VelocityControl;%0402NE:AltitudeHold:VelocityControl,%0401NE:AltitudeHold:VelocityControl;%0402NE:AltitudeHold:VelocityControl,%0401NE:AltitudeHold:VelocityControl;%0402NE:AltitudeHold:VelocityControl,%0401NE:AltitudeHold:VelocityControl;%0402NE:AltitudeHold:VelocityControl"/>
 
+		<!-- This option prevents timing out arming when disabled and in autonomous modes.
+                     It is enabled by default for additional safety to prevent flyaways -->
+		<field name="ArmTimeoutAutonomous" units="" type="enum" elements="1" options="DISABLED,ENABLED" defaultvalue="ENABLED"/>
 		<field name="ArmedTimeout" units="ms" type="uint16" elements="1" defaultvalue="30000"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
The default behavior of applying the disarm timeout in all modes
is nice and conservative. However, it is easy to leave the
throttle low while doing navigation and then have it disarm
while flying. This provides an option to avoid that.

Once this has been well validated, eventually we should drop this
option and never disarm while in autonomous modes unless the
user gives the disarm command.

This fixes the disarm timeout for low throttle which was dropped
with #1482 
