### PR TITLE
Battery: make sure to load battery value

### DIFF
--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -113,6 +113,8 @@ static void batteryTask(void * parameters)
 		FlightBatterySettingsData batterySettings;
 		float energyRemaining;
 
+		FlightBatteryStateGet(&flightBatteryData);
+
 		if (battery_settings_updated) {
 			battery_settings_updated = false;
 			FlightBatterySettingsGet(&batterySettings);

--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -38,7 +38,7 @@
 
 // ****************
 // Private constants
-#define STACK_SIZE_BYTES            468
+#define STACK_SIZE_BYTES            496
 #define TASK_PRIORITY               PIOS_THREAD_PRIO_LOW
 #define SAMPLE_PERIOD_MS            500
 // Private types


### PR DESCRIPTION
The module was using an uninitialized variable which
was causing the energy consumed to start at a random
value and the flight time to go to error state.

We could afford to only load this variable once before
the loop, but by doing it each loop it allows GCS to
push changes if desired. This is our more common
practice of making changes in place.