### PR TITLE
AltitudeHold: make sure to get latest command when engaging

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -160,6 +160,13 @@ static void altitudeHoldTask(void *parameters)
 				StabilizationDesiredThrottleGet(&velocity_pid.iAccumulator);
 				velocity_pid.iAccumulator *= 1000.0f; // pid library scales up accumulator by 1000
 				engaged = true;
+
+				// Make sure this uses a valid AltitudeHoldDesired. No delay is really required here
+				// because ManualControl sets AltitudeHoldDesired first before the FlightStatus, but
+				// this is just to be conservative at 1ms when engaging will not bother the pilot.
+				PIOS_Thread_Sleep(1);
+				AltitudeHoldDesiredGet(&altitudeHoldDesired);
+
 			} else if (flight_mode != FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD)
 				engaged = false;
 


### PR DESCRIPTION
When switching to ChibiOS the order events were received changed
with regard to FlightStatus going to AH mode and then the update
for AltitudeHoldDesired. This meant the first pass was using all
zero for the AltitudeHoldDesired (or previous value) and was
causing the integral to hit the anti-windup saturation and go to
zero. The next update was correct but since the integral was
erased the aircraft would have a transient drop.

This can also be fixed by calling a continue in the FlightStatusHandle
processing block so the next loop catches the update (confirming
there is no event being dropped). However, this method is slightly
lower latency and it is reasonable to force a get of the AHD when
engaging it, anyway.