### PR TITLE
Remove "Max rate attitude (deg/s)" from GCS GUI

### DIFF
--- a/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
@@ -195,9 +195,6 @@ void ConfigStabilizationWidget::applyRateLimits()
     m_stabilization->fullStickRateRoll->setMaximum(maxRate);
     m_stabilization->fullStickRatePitch->setMaximum(maxRate);
     m_stabilization->fullStickRateYaw->setMaximum(maxRate);
-    m_stabilization->maxRateAttRoll->setMaximum(maxRate);
-    m_stabilization->maxRateAttPitch->setMaximum(maxRate);
-    m_stabilization->maxRateAttYaw->setMaximum(maxRate);
 }
 
 void ConfigStabilizationWidget::showMWRateConvertDialog()

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -615,8 +615,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>937</width>
-            <height>601</height>
+            <width>935</width>
+            <height>593</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12" stretch="0,0,0,0">
@@ -6997,8 +6997,8 @@ border-radius: 5;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>923</width>
-            <height>675</height>
+            <width>935</width>
+            <height>644</height>
            </rect>
           </property>
           <property name="autoFillBackground">
@@ -14027,7 +14027,7 @@ border-radius: 5;</string>
              <property name="alignment">
               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
              </property>
-             <layout class="QGridLayout" name="gridLayout_18">
+             <layout class="QGridLayout" name="gridLayout_18" columnstretch="0,0" columnminimumwidth="0,0">
               <property name="leftMargin">
                <number>12</number>
               </property>
@@ -14538,12 +14538,12 @@ border-radius: 5;</string>
                 <property name="flat">
                  <bool>true</bool>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_6" rowstretch="0,0,0,0" columnstretch="0,0,1,0,1,0,1,0">
+                <layout class="QGridLayout" name="gridLayout_6" rowstretch="0,0,0" columnstretch="0,0,1,0,1,0,1,0">
                  <property name="leftMargin">
                   <number>0</number>
                  </property>
                  <property name="verticalSpacing">
-                  <number>0</number>
+                  <number>-1</number>
                  </property>
                  <item row="1" column="4">
                   <widget class="QDoubleSpinBox" name="ratePitchKp_4">
@@ -14587,90 +14587,6 @@ border-radius: 5;</string>
                     <stringlist>
                      <string>objname:StabilizationSettings</string>
                      <string>fieldname:PitchMax</string>
-                     <string>haslimits:no</string>
-                     <string>scale:1</string>
-                     <string>buttongroup:6,20</string>
-                    </stringlist>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QLabel" name="label_22">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>128</width>
-                     <height>16</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="styleSheet">
-                    <string notr="true"/>
-                   </property>
-                   <property name="text">
-                    <string>Max rate attitude (deg/s)</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="2">
-                  <widget class="QDoubleSpinBox" name="maxRateAttRoll">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>22</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>22</height>
-                    </size>
-                   </property>
-                   <property name="focusPolicy">
-                    <enum>Qt::StrongFocus</enum>
-                   </property>
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="styleSheet">
-                    <string notr="true"/>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                   <property name="decimals">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="objrelation" stdset="0">
-                    <stringlist>
-                     <string>objname:StabilizationSettings</string>
-                     <string>fieldname:MaximumRate</string>
-                     <string>element:Roll</string>
                      <string>haslimits:no</string>
                      <string>scale:1</string>
                      <string>buttongroup:6,20</string>
@@ -14792,56 +14708,6 @@ border-radius: 5;</string>
                     <stringlist>
                      <string>objname:StabilizationSettings</string>
                      <string>fieldname:YawMax</string>
-                     <string>haslimits:no</string>
-                     <string>scale:1</string>
-                     <string>buttongroup:6,20</string>
-                    </stringlist>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="4">
-                  <widget class="QDoubleSpinBox" name="maxRateAttPitch">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>22</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>22</height>
-                    </size>
-                   </property>
-                   <property name="focusPolicy">
-                    <enum>Qt::StrongFocus</enum>
-                   </property>
-                   <property name="styleSheet">
-                    <string notr="true"/>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                   <property name="decimals">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="objrelation" stdset="0">
-                    <stringlist>
-                     <string>objname:StabilizationSettings</string>
-                     <string>fieldname:MaximumRate</string>
-                     <string>element:Pitch</string>
                      <string>haslimits:no</string>
                      <string>scale:1</string>
                      <string>buttongroup:6,20</string>
@@ -16730,59 +16596,6 @@ border-radius: 5;</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="3" column="6">
-                  <widget class="QDoubleSpinBox" name="maxRateAttYaw">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>22</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>22</height>
-                    </size>
-                   </property>
-                   <property name="focusPolicy">
-                    <enum>Qt::StrongFocus</enum>
-                   </property>
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="styleSheet">
-                    <string notr="true"/>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                   <property name="decimals">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="objrelation" stdset="0">
-                    <stringlist>
-                     <string>objname:StabilizationSettings</string>
-                     <string>fieldname:MaximumRate</string>
-                     <string>element:Yaw</string>
-                     <string>haslimits:no</string>
-                     <string>scale:1</string>
-                     <string>buttongroup:6,20</string>
-                    </stringlist>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="2" column="0">
                   <widget class="QLabel" name="label_40">
                    <property name="sizePolicy">
@@ -17434,11 +17247,20 @@ border-radius: 5;</string>
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_21">
+          <property name="leftMargin">
+           <number>12</number>
+          </property>
+          <property name="topMargin">
+           <number>12</number>
+          </property>
+          <property name="rightMargin">
+           <number>12</number>
+          </property>
+          <property name="bottomMargin">
+           <number>12</number>
+          </property>
           <property name="horizontalSpacing">
            <number>6</number>
-          </property>
-          <property name="margin">
-           <number>12</number>
           </property>
           <item row="2" column="0" colspan="3">
            <widget class="QGroupBox" name="MWRateStabilizationSettingsGroup">
@@ -20385,7 +20207,16 @@ value as the Kp.</string>
        <string>Expert</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -20471,8 +20302,8 @@ value as the Kp.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>798</width>
-            <height>468</height>
+            <width>935</width>
+            <height>593</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -27925,9 +27756,6 @@ Useful if you have accidentally changed some settings.</string>
   <tabstop>fullStickRateRoll</tabstop>
   <tabstop>fullStickRatePitch</tabstop>
   <tabstop>fullStickRateYaw</tabstop>
-  <tabstop>maxRateAttRoll</tabstop>
-  <tabstop>maxRateAttPitch</tabstop>
-  <tabstop>maxRateAttYaw</tabstop>
   <tabstop>checkBox_3</tabstop>
   <tabstop>checkBox_2</tabstop>
   <tabstop>WeakLevelingKp</tabstop>
@@ -27947,6 +27775,7 @@ Useful if you have accidentally changed some settings.</string>
   <tabstop>scrollArea_2</tabstop>
  </tabstops>
  <resources>
+  <include location="../coreplugin/core.qrc"/>
   <include location="../coreplugin/core.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
This variable is still available in the UAVObject browser.

Solves Issue #1496 .