### PR TITLE
Conditionalize SIGFPE handling in posix simulator.

### DIFF
--- a/flight/PiOS.osx/inc/pios_sys.h
+++ b/flight/PiOS.osx/inc/pios_sys.h
@@ -42,6 +42,8 @@ extern uint32_t PIOS_SYS_getCPUFlashSize(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
 
+extern void PIOS_SYS_Args(int argc, char *argv[]);
+
 #endif /* PIOS_SYS_H */
 
 /**

--- a/flight/PiOS.osx/osx/pios_sys.c
+++ b/flight/PiOS.osx/osx/pios_sys.c
@@ -34,6 +34,9 @@
 
 #if defined(PIOS_INCLUDE_SYS)
 
+void PIOS_SYS_Args(int argc, char *argv[]) {
+	(void) argc; (void) argv;
+}
 
 /**
 * Initialises all system peripherals

--- a/flight/PiOS.posix/inc/pios_sys.h
+++ b/flight/PiOS.posix/inc/pios_sys.h
@@ -42,6 +42,8 @@ extern uint32_t PIOS_SYS_getCPUFlashSize(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
 
+extern void PIOS_SYS_Args(int argc, char *argv[]);
+
 #endif /* PIOS_SYS_H */
 
 /**

--- a/flight/PiOS.posix/posix/pios_sys.c
+++ b/flight/PiOS.posix/posix/pios_sys.c
@@ -35,6 +35,35 @@
 
 #if defined(PIOS_INCLUDE_SYS)
 
+static bool debug_fpe=false;
+
+static void Usage(char *cmdName) {
+	printf( "usage: %s [-f]\n"
+		"\n"
+		"\t-f\tEnables floating point exception trapping mode\n",
+		cmdName);
+
+	exit(1);
+}
+
+void PIOS_SYS_Args(int argc, char *argv[]) {
+	int opt;
+
+	while ((opt = getopt(argc, argv, "f")) != -1) {
+		switch (opt) {
+			case 'f':
+				debug_fpe=true;
+				break;
+			default:
+				Usage(argv[0]);
+				break;
+		}
+	}
+
+	if (optind < argc) {
+		Usage(argv[0]);
+	}
+}
 
 /**
 * Initialises all system peripherals
@@ -65,15 +94,20 @@ void PIOS_SYS_Init(void)
 	int rc = sigaction(SIGINT, &sa_int, NULL);
 	assert(rc == 0);
 
-	struct sigaction sa_fpe = {
-		.sa_sigaction = sigfpe_handler,
-		.sa_flags = SA_SIGINFO,
-	};
+	if (debug_fpe) {
+		struct sigaction sa_fpe = {
+			.sa_sigaction = sigfpe_handler,
+			.sa_flags = SA_SIGINFO,
+		};
 
-	rc = sigaction(SIGFPE, &sa_fpe, NULL);
-	assert(rc == 0);
+		rc = sigaction(SIGFPE, &sa_fpe, NULL);
+		assert(rc == 0);
 
-	feenableexcept(FE_DIVBYZERO | FE_UNDERFLOW | FE_OVERFLOW | FE_INVALID);
+		// Underflow is fairly harmless, do we even care in debug
+		// mode?
+		feenableexcept(FE_DIVBYZERO | FE_UNDERFLOW | FE_OVERFLOW |
+			FE_INVALID);
+	}
 }
 
 /**

--- a/flight/targets/revolution/fw/main.c
+++ b/flight/targets/revolution/fw/main.c
@@ -64,8 +64,13 @@ extern void InitModules(void);
  * If something goes wrong, blink LED1 and LED2 every 100ms
  *
  */
+#if defined(SIM_OSX) || defined(SIM_POSIX)
+int main(int argc, char *argv[]) {
+	PIOS_SYS_Args(argc, argv);
+#else
 int main()
 {
+#endif
 	/* NOTE: Do NOT modify the following start-up sequence */
 	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();


### PR DESCRIPTION
Add functionality to use getopt appropriately inside the posix simulator.
Floating point exceptions are now disabled by default.  Passing -f to the
simulator will give you exceptions.

This was necessary because navigation and IMU code throws a lot of SIGFPE's
and won't make it through initialization in the posix simulator (this is a
separate issue I hope to hunt).

Also plumb args into the OSX simulator even though they're presently unused.
Need a Mac user to confirm this still compiles.