### PR TITLE
Set SO_REUSEADDR and TCP_NODELAY on sockets in gcs and sim.

### DIFF
--- a/flight/PiOS.osx/inc/pios_tcp_priv.h
+++ b/flight/PiOS.osx/inc/pios_tcp_priv.h
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include "fifo_buffer.h"
 
 struct pios_tcp_cfg {

--- a/flight/PiOS.osx/osx/pios_tcp.c
+++ b/flight/PiOS.osx/osx/pios_tcp.c
@@ -172,6 +172,15 @@ int32_t PIOS_TCP_Init(uintptr_t *tcp_id, const struct pios_tcp_cfg * cfg)
 	
 	/* assign socket */
 	tcp_dev->socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+	int optval=1;
+
+        /* Allow reuse of address if you restart. */
+        setsockopt(tcp_dev->socket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+        /* Also request low-latency (don't store up data to conserve packets */
+        setsockopt(tcp_dev->socket, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+
 	memset(&tcp_dev->server,0,sizeof(tcp_dev->server));
 	memset(&tcp_dev->client,0,sizeof(tcp_dev->client));
 	tcp_dev->server.sin_family = AF_INET;

--- a/flight/PiOS.posix/inc/pios_tcp_priv.h
+++ b/flight/PiOS.posix/inc/pios_tcp_priv.h
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include "fifo_buffer.h"
 
 struct pios_tcp_cfg {

--- a/flight/PiOS.posix/posix/pios_tcp.c
+++ b/flight/PiOS.posix/posix/pios_tcp.c
@@ -172,6 +172,15 @@ int32_t PIOS_TCP_Init(uintptr_t *tcp_id, const struct pios_tcp_cfg * cfg)
 	
 	/* assign socket */
 	tcp_dev->socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+	int optval=1;
+
+	/* Allow reuse of address if you restart. */
+	setsockopt(tcp_dev->socket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+	/* Also request low-latency (don't store up data to conserve packets */
+	setsockopt(tcp_dev->socket, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+
 	memset(&tcp_dev->server,0,sizeof(tcp_dev->server));
 	memset(&tcp_dev->client,0,sizeof(tcp_dev->client));
 	tcp_dev->server.sin_family = AF_INET;

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.cpp
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.cpp
@@ -81,6 +81,15 @@ void IPConnection::onOpenDevice(QString HostName, int Port, bool UseTCP)
         ipSocket = new QUdpSocket(this);
     }
 
+    // Disable Nagle algorithm to try and get data promptly rather than
+    // minimize packets.
+    ipSocket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
+
+    // Allow reuse of ports, so if we're running the simulator and GCS on
+    // the same host, and simulator crashes leaving ports in FIN_WAIT, we
+    // can restart simulator immediately.
+    ipSocket->bind(0, QAbstractSocket::ShareAddress);
+
     //do sanity check on hostname and port...
     if((HostName.length()==0)||(Port<1)){
         errorMsg = "Please configure Host and Port options before opening the connection";


### PR DESCRIPTION
Before, if the simulator crashed, sockets would linger in TIME_WAIT state
and require a timeout before the simulator could be launched again.  This is
now fixed.

Also, request low latency (TCP_NODELAY) service for telemetry data.
Minimizing packets isn't so important compared to getting low telemetry
latency.

This change needs verification in OSX that the simulator still compiles.