### PR TITLE
Build: add FLIGHT_BUILD_CONF environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ include $(ROOT_DIR)/flight/targets/*/target-defs.mk
 # OpenPilot GCS build configuration (debug | release)
 GCS_BUILD_CONF ?= debug
 
+# And the flight build configuration (debug | default | release)
+export FLIGHT_BUILD_CONF ?= default
+
 ##############################
 #
 # Check that environmental variables are sane
@@ -98,6 +101,16 @@ ifdef GCS_BUILD_CONF
  ifneq ($(GCS_BUILD_CONF), release)
   ifneq ($(GCS_BUILD_CONF), debug)
    $(error Only debug or release are allowed for GCS_BUILD_CONF)
+  endif
+ endif
+endif
+
+ifdef FLIGHT_BUILD_CONF
+ ifneq ($(FLIGHT_BUILD_CONF), release)
+  ifneq ($(FLIGHT_BUILD_CONF), debug)
+   ifneq ($(FLIGHT_BUILD_CONF), default)
+    $(error Only debug or release are allowed for FLIGHT_BUILD_CONF)
+   endif
   endif
  endif
 endif

--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -1,7 +1,19 @@
 # Toolchain prefix (i.e arm-elf- -> arm-elf-gcc.exe)
 TCHAIN_PREFIX ?= arm-none-eabi-
 
+CCACHE :=
+
+ifeq ($(FLIGHT_BUILD_CONF), debug)
+export DEBUG:=YES
 CCACHE := $(shell which ccache)
+else ifeq ($(FLIGHT_BUILD_CONF), default)
+# In the default case, keep the old "DEBUG"  variable handling
+CCACHE := $(shell which ccache)
+else ifeq ($(FLIGHT_BUILD_CONF), release)
+export DEBUG:=NO
+else
+$(error Only debug, release, or default allowed for FLIGHT_BUILD_CONF)
+endif
 
 # Define toolchain component names.
 CC      = $(CCACHE) $(TCHAIN_PREFIX)gcc


### PR DESCRIPTION
It's a knob, with the values 'default' (which is the default), 'release',
and 'debug'.  In debug, DEBUG is set to YES in the flight firmwares.  In
debug and default, compilation caching is allowed (and ccache is smart
enough to cache default/debug separately because it includes command line
arguments in its hash).  In release, there is no compilation caching (and
jenkins/release build scripts should be updated to use this mode).

This parallels the GCS_BUILD_CONF environment variable which also disables
compilation caching for GCS build.