### PR TITLE
VtolPathFollower: deadband, lookahead, and refactor

### DIFF
--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -387,6 +387,9 @@ static void updatePathVelocity()
 		pathStatus.Status = PATHSTATUS_STATUS_INPROGRESS;
 	else
 		pathStatus.Status = PATHSTATUS_STATUS_COMPLETED;
+
+	pathStatus.Waypoint = pathDesired.Waypoint;
+
 	VelocityDesiredSet(&velocityDesired);
 }
 

--- a/flight/Modules/GroundPathFollower/groundpathfollower.c
+++ b/flight/Modules/GroundPathFollower/groundpathfollower.c
@@ -267,6 +267,9 @@ static void updatePathVelocity()
 		pathStatus.Status = PATHSTATUS_STATUS_INPROGRESS;
 	else
 		pathStatus.Status = PATHSTATUS_STATUS_COMPLETED;
+
+	pathStatus.Waypoint = pathDesired.Waypoint;
+
 	PathStatusSet(&pathStatus);
 
 	float groundspeed = pathDesired.StartingVelocity +

--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -264,7 +264,7 @@ static void holdLastPosition()
 
 	// Get the activated waypoint
 	WaypointData waypoint;
-	WaypointInstGet(idx, &waypoint);
+	WaypointInstGet(idx-1, &waypoint);
 
 	PositionActualData position;
 	PositionActualGet(&position);

--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -280,6 +280,7 @@ static void holdLastPosition()
 	pathDesired.StartingVelocity = 5; // This will be the max velocity it uses to try and hold
 	pathDesired.EndingVelocity = 5;
 	pathDesired.ModeParameters = 0;
+	pathDesired.Waypoint = -1;
 	PathDesiredSet(&pathDesired);
 }
 /**

--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -354,7 +354,7 @@ static void activateWaypoint(int idx)
 			break;
 		case WAYPOINT_MODE_LAND:
 			pathDesired.Mode = PATHDESIRED_MODE_LAND;
-		break;
+			break;
 		default:
 			holdCurrentPosition();
 			AlarmsSet(SYSTEMALARMS_ALARM_PATHPLANNER, SYSTEMALARMS_ALARM_ERROR);

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -104,8 +104,9 @@ static float vtol_magnitude(const float *v, int n)
  * @param[in] desired the setpoint of the system
  * @param[out] the resultant error vector desired-actual
  * @param[in] normalize True if it's desired to normalize the output vector
+ * @returns the norm, for fun.
  */
-static void vtol_calculate_distances(const float *actual,
+static float vtol_calculate_distances(const float *actual,
 	const float *desired, float *out, bool normalize)
 {
 	out[0] = desired[0] - actual[0];
@@ -115,13 +116,17 @@ static void vtol_calculate_distances(const float *actual,
 	if (normalize) {
 		float mag=vtol_magnitude(out, 3);
 
-		if (mag == 0) {
+		if (mag < 0.00001f) {
 			/* Just pick a direction. */
 			out[0] = 1.0; out[1] = 0.0; out[2] = 0.0;
 		} else {
 			out[0] /= mag;  out[1] /= mag;  out[2] /= mag;
 		}
+
+		return mag;
 	}
+
+	return 0.0;
 }
 
 /**
@@ -245,7 +250,7 @@ int32_t vtol_follower_control_path(const float dT, const PathDesiredData *pathDe
 
 		// Waypoint heights are thus treated as crossing restrictions-
 		// cross this point at or above...
-		if (criterion_altitude) {
+		if (criterion_altitude || current_leg_completed) {
 			pathStatus.Status = PATHSTATUS_STATUS_COMPLETED;
 			PathStatusSet(&pathStatus);
 		} else {
@@ -324,10 +329,8 @@ static int32_t vtol_follower_control_simple(const float dT,
 
 	/* Calculate the difference between where we want to be and the
 	 * above position */
-	vtol_calculate_distances(cur_pos_ned, hold_pos_ned, errors_ned, 0);
-
-	float horiz_error_mag = vtol_magnitude(errors_ned, 2);
-	float scale_horiz_error_mag = 0;
+	float horiz_error_norm = vtol_calculate_distances(cur_pos_ned,
+		hold_pos_ned, errors_ned, true);
 
 	/* Apply a cubic deadband; if we are already really close don't work
 	 * as hard to fix it as if we're far away.  Prevents chasing high
@@ -338,15 +341,14 @@ static int32_t vtol_follower_control_simple(const float dT,
 	 * close, there's a large directional / hunting component.  This
 	 * attenuates that.
 	 */
-	if (horiz_error_mag > 0.00001f) {
-		scale_horiz_error_mag = vtol_deadband(horiz_error_mag,
-			guidanceSettings.EndpointDeadbandWidth,
-			guidanceSettings.EndpointDeadbandCenterGain,
-			vtol_end_m, vtol_end_r) / horiz_error_mag;
-	}
 
-	float damped_ne[2] = { errors_ned[0] * scale_horiz_error_mag,
-			errors_ned[1] * scale_horiz_error_mag };
+	horiz_error_norm = vtol_deadband(horiz_error_norm,
+		guidanceSettings.EndpointDeadbandWidth,
+		guidanceSettings.EndpointDeadbandCenterGain,
+		vtol_end_m, vtol_end_r);
+
+	float damped_ne[2] = { errors_ned[0] * horiz_error_norm,
+			errors_ned[1] * horiz_error_norm };
 
 	float commands_ned[3];
 

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -243,15 +243,6 @@ int32_t vtol_follower_control_path(const float dT, const PathDesiredData *pathDe
 	}
 	PathStatusSet(&pathStatus);
 
-	/* Ensure that we don't fall terrifically behind requested alt.  If
-	 * we are requesting greater than 75% of VerticalVelMax, slow down
-	 * our groundspeed request to help.
-	 */
-	float groundscale = (guidanceSettings.VerticalVelMax - commands_ned[2]) * 4;
-
-	if (groundscale < 1)
-		groundspeed *= groundscale;
-	
 	float error_speed = vtol_deadband(progress->error,
 		guidanceSettings.PathDeadbandWidth,
 		guidanceSettings.PathDeadbandCenterGain,

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -229,6 +229,7 @@ int32_t vtol_follower_control_path(const float dT, const PathDesiredData *pathDe
 	PathStatusData pathStatus;
 	PathStatusGet(&pathStatus);
 	pathStatus.fractional_progress = progress->fractional_progress;
+	pathStatus.error = progress->error;
 
 	// Only if we are at the end, and above the end altitude, are we
 	// done.

--- a/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
@@ -693,7 +693,7 @@ static void go_enable_fly_home()
 }
 
 /**
- * Enable holding at home location for 10 s at current altitude. Configures for hold.
+ * Descends to land.
  */
 static void go_enable_land_home()
 {

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -159,7 +159,6 @@ static void vtolPathFollowerTask(void *parameters)
 
 		// Continue collecting data if not enough time
 		PIOS_Thread_Sleep_Until(&lastUpdateTime, guidanceSettings.UpdatePeriod);
-		
 		static uint8_t last_flight_mode;
 		FlightStatusGet(&flightStatus);
 

--- a/shared/uavobjectdefinition/pathdesired.xml
+++ b/shared/uavobjectdefinition/pathdesired.xml
@@ -6,6 +6,7 @@
 		<field name="End" units="m" type="float" elementnames="North,East,Down" default="0"/>
 		<field name="StartingVelocity" units="m/s" type="float" elements="1" default="0"/>
 		<field name="EndingVelocity" units="m/s" type="float" elements="1" default="0"/>
+		<field name="Waypoint" units="" type="int16" elements="1" default="-1"/>
 
 		<!-- Endpoint mode - move directly towards endpoint regardless of position -->
 		<!-- Straight Mode - move across linear path through Start towards the waypoint end, adjusting velocity - continue straight -->

--- a/shared/uavobjectdefinition/pathstatus.xml
+++ b/shared/uavobjectdefinition/pathstatus.xml
@@ -6,6 +6,8 @@
 		<field name="fractional_progress" units="" type="float" elements="1"/>
 		<field name="error" units="m" type="float" elements="1"/>
 
+		<field name="Waypoint" units="" type="int16" elements="1" default="-1"/>
+
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="false" updatemode="manual" period="0"/>
 		<telemetryflight acked="false" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/vtolpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/vtolpathfollowersettings.xml
@@ -16,8 +16,11 @@
 		<field name="VelocityChangePrediction" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
 		<field name="MaxRollPitch" units="deg" type="float" elements="1" defaultvalue="20"/>
 
-		<!-- The distance within the waypoint (horizontally) that should be achieved to mark completed -->
-		<field name="EndpointRadius" units="m" type="uint8" elements="1" defaultvalue="2"/>
+		<!-- The distance within the endpoint (horizontally) that should be achieved to mark completed -->
+		<field name="EndpointRadius" units="m" type="float" elements="1" defaultvalue="2.0"/>
+
+		<!-- The distance that we can be below a waypoint and still mark it as completed.  Silently ignored if ThrottleControl == false -->
+		<field name="WaypointAltitudeTol" units="m" type="float" elements="1" defaultvalue="2.0"/>
 	
 		<field name="UpdatePeriod" units="ms" type="int32" elements="1" defaultvalue="50"/>
 		<field name="YawMode" units="" type="enum" elements="1" options="Rate,AxisLock,Attitude,Path,POI" defaultvalue="AxisLock"/>

--- a/shared/uavobjectdefinition/vtolpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/vtolpathfollowersettings.xml
@@ -7,6 +7,12 @@
 		<field name="HorizontalVelPID" units="deg/(m/s)" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="3,0,0,0"/>
 		<field name="VelocityFeedforward" units="deg/(m/s)" type="float" elements="1" defaultvalue="0"/>
 		<field name="ThrottleControl" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
+		<!-- 0.7 seconds seems like a good value in most cases -->
+		<field name="PositionFeedforward" units="s" type="float" elements="1" defaultvalue="0"/>
+		<field name="EndpointDeadbandWidth" units="m" type="float" elements="1" defaultvalue="0.75"/>
+		<field name="EndpointDeadbandCenterGain" units="" type="float" elements="1" defaultvalue="0.25"/>
+		<field name="PathDeadbandWidth" units="m" type="float" elements="1" defaultvalue="1.25"/>
+		<field name="PathDeadbandCenterGain" units="" type="float" elements="1" defaultvalue="0.1"/>
 		<field name="VelocityChangePrediction" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
 		<field name="MaxRollPitch" units="deg" type="float" elements="1" defaultvalue="20"/>
 

--- a/shared/uavobjectdefinition/vtolpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/vtolpathfollowersettings.xml
@@ -7,10 +7,10 @@
 		<field name="HorizontalVelPID" units="deg/(m/s)" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="3,0,0,0"/>
 		<field name="VelocityFeedforward" units="deg/(m/s)" type="float" elements="1" defaultvalue="0"/>
 		<field name="ThrottleControl" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
-		<!-- 0.7 seconds seems like a good value in most cases -->
-		<field name="PositionFeedforward" units="s" type="float" elements="1" defaultvalue="0"/>
-		<field name="EndpointDeadbandWidth" units="m" type="float" elements="1" defaultvalue="0.75"/>
-		<field name="EndpointDeadbandCenterGain" units="" type="float" elements="1" defaultvalue="0.25"/>
+		<!-- 0.4-0.6 seconds seems like a good value in most cases, this is conservative -->
+		<field name="PositionFeedforward" units="s" type="float" elements="1" defaultvalue="0.25"/>
+		<field name="EndpointDeadbandWidth" units="m" type="float" elements="1" defaultvalue="0.45"/>
+		<field name="EndpointDeadbandCenterGain" units="" type="float" elements="1" defaultvalue="0.3"/>
 		<field name="PathDeadbandWidth" units="m" type="float" elements="1" defaultvalue="1.25"/>
 		<field name="PathDeadbandCenterGain" units="" type="float" elements="1" defaultvalue="0.1"/>
 		<field name="VelocityChangePrediction" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>


### PR DESCRIPTION
This adds lookahead to the path planner which should allow it to follow paths more
closely. In addition, it adds a deadband region - separately parameterized for path
legs and endpoint following. This should provide smoother control behavior along
paths and around endpoints.

It also refactors out some duplicated code.