### PR TITLE
Sparky: invert telemetry for FrSky Sensor Port

### DIFF
--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -677,7 +677,7 @@ void PIOS_Board_Init(void) {
 		break;
 	case HWSPARKY_FLEXIPORT_FRSKYSENSORHUB:
 #if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sensor_hub_id);
+		PIOS_Board_configure_com(&pios_flexi_usart_sport_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sensor_hub_id);
 #endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
 		break;
 	case HWSPARKY_FLEXIPORT_LIGHTTELEMETRYTX:


### PR DESCRIPTION
D4R-ii radios (which are quite popular) use the older D8
protocol for telemetry. This is handled in TauLabs by the
UavoFrSKYSensorHubBridge module. Both D8 and D16 (S.Port)
protocols use an inverted serial port. We used the F3
inverted for the S.Port module (UAVOFrskySPortBridge)  but
not the Sensor Hub.

This change allows using telemetry with D4R-ii without an
external inverter.