### PR TITLE
Sparky: invert telemetry for FrSky Sensor Port on MainPort

### DIFF
--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -765,7 +765,7 @@ void PIOS_Board_Init(void) {
 		break;
 	case HWSPARKY_MAINPORT_FRSKYSENSORHUB:
 #if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sensor_hub_id);
+		PIOS_Board_configure_com(&pios_main_usart_sport_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sensor_hub_id);
 #endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
 		break;
 	case HWSPARKY_MAINPORT_LIGHTTELEMETRYTX:


### PR DESCRIPTION
This should have been included with previous commits. Also allow
Sparky to invert telemetry on MainPort as well as FlexiPort.