### PR TITLE
Uploader: fix safe boot

### DIFF
--- a/ground/gcs/src/plugins/uploader/tl_dfu.cpp
+++ b/ground/gcs/src/plugins/uploader/tl_dfu.cpp
@@ -306,8 +306,11 @@ int DFUObject::JumpToApp(bool safeboot)
 {
     bl_messages message;
     message.flags_command = BL_MSG_JUMP_FW;
+
+    // 0x5afe must have the bytes flipped for consistency
+    // with how the bootloader process this.
     if(safeboot)
-        message.v.jump_fw.safe_word = 0x5afe;
+        message.v.jump_fw.safe_word = ntohs((quint16) 0x5afe);
     else
         message.v.jump_fw.safe_word = 0x0000;
     return SendData(message);


### PR DESCRIPTION
There was an inconsistency between the bootloader code
and the uploader code. The bootloader swapped the bytes
of the safe word and compared to the constant 0x5AFE.
However, the uploader did not swap those bytes and thus
the safe_word was never valid to trigger a safe boot.

The cleanest thing to do would be remove the swap in the
bootloader, but for ease of the users not updating the
bootloader it swaps in the GCS.