### PR TITLE
InputWizard: correctly identify stick center position

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -959,9 +959,6 @@ void ConfigInputWidget::identifyLimits()
             // ratio between + and - range.
             manualSettingsData.ChannelNeutral[i] = manualSettingsData.ChannelMin[i] +
                     (manualSettingsData.ChannelMax[i] - manualSettingsData.ChannelMin[i]) * THROTTLE_NEUTRAL_FRACTION;
-        } else {
-            manualSettingsData.ChannelNeutral[i] =
-                    (manualSettingsData.ChannelMin[i] + manualSettingsData.ChannelMax[i]) * 0.5;
         }
     }
     manualSettingsObj->setData(manualSettingsData);


### PR DESCRIPTION
I introduced a bug when adjusting the throttle neutral
position and made all sticks neutral the middle of the
range which is not true for all transmitters. This could
create some annoying input calibrations.