### PR TITLE
Input Config: fix glitch importing reversed channels

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -87,8 +87,8 @@ ConfigInputWidget::ConfigInputWidget(QWidget *parent) : ConfigTaskWidget(parent)
         addUAVObjectToWidgetRelation("ManualControlSettings","ChannelGroups",inpForm->ui->channelGroup,index);
         addUAVObjectToWidgetRelation("ManualControlSettings","ChannelNumber",inpForm->ui->channelNumber,index);
         addUAVObjectToWidgetRelation("ManualControlSettings","ChannelMin",inpForm->ui->channelMin,index);
-        addUAVObjectToWidgetRelation("ManualControlSettings","ChannelNeutral",inpForm->ui->channelNeutral,index);
         addUAVObjectToWidgetRelation("ManualControlSettings","ChannelMax",inpForm->ui->channelMax,index);
+        addUAVObjectToWidgetRelation("ManualControlSettings","ChannelNeutral",inpForm->ui->channelNeutral,index);
         ++index;
     }
 


### PR DESCRIPTION
Importing a .uav file that has an input channel reversed causes
the neutral value to hit the limits, because the neutral is set
before both channel limits are set.

Because the addUAVObjectToWidgetRelation preserves the order things
are registered, simply connecting min/max first fixes this issue.
A better solution would be to allow making changes to the whole
object atomically, but that would be a pretty major overhaul.