### PR TITLE
Attitude: take barometric altitude on powerup as zero

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -1101,7 +1101,7 @@ static int32_t updateAttitudeINSGPS(bool first_run, bool outdoor_mode)
 			getNED(&gpsData, NED);
 
 			// Initialize barometric offset to current GPS NED coordinate
-			baro_offset = -NED[2] - baroData.Altitude;
+			baro_offset = -baroData.Altitude;
 
 			INSSetState(NED, zeros, q, zeros, zeros);
 		} 


### PR DESCRIPTION
Previously we tried to compare the home location altitude
against the current gps altitude and preserve that offset.
In practice, this is inconvenient and we should take the
powerup altitude as zero.