### PR TITLE
PathPlanner: use a queue to respond immediately to FlightStatus

### DIFF
--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -117,6 +117,7 @@ int32_t PathPlannerInitialize()
 
 		// Create object queue
 		queue = PIOS_Queue_Create(MAX_QUEUE_SIZE, sizeof(UAVObjEvent));
+		FlightStatusConnectQueue(queue);
 
 		return 0;
 	}
@@ -157,7 +158,9 @@ static void pathPlannerTask(void *parameters)
 	while (1)
 	{
 
-		PIOS_Thread_Sleep(UPDATE_RATE_MS);
+		// Make sure when flight mode toggles, to immediately update the path
+		UAVObjEvent ev;
+		PIOS_Queue_Receive(queue, &ev, UPDATE_RATE_MS);
 
 		// When not running the path planner short circuit and wait
 		FlightStatusGet(&flightStatus);


### PR DESCRIPTION
Because the PathPlanner runs at a fairly slow rate, we could miss
rapid toggles of the FlightMode switch. This would, for example,
allow the follower to briefly enter RTH mode and then resume the
current path segment. For longer switches a different behavior
would emerge (the path planner detects it and resets to path
beginning).