### PR TITLE
ENH: Native FrSky PWM RSSI Support

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -199,8 +199,6 @@ int32_t transmitter_control_update()
 		switch (settings.RssiType) {
 		case MANUALCONTROLSETTINGS_RSSITYPE_PWM:
 			value = PIOS_RCVR_Read(pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PWM], settings.RssiChannelNumber);
-			if(settings.RssiPwmPeriod != 0)
-				value = (value) % (settings.RssiPwmPeriod);
 			break;
 		case MANUALCONTROLSETTINGS_RSSITYPE_PPM:
 			value = PIOS_RCVR_Read(pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PPM], settings.RssiChannelNumber);

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -57,6 +57,10 @@
 #include "pios_usb_rctx.h"
 #endif	/* PIOS_INCLUDE_USB_RCTX */
 
+#if defined(PIOS_INCLUDE_FRSKY_RSSI)
+#include "pios_frsky_rssi.h"
+#endif /* PIOS_INCLUDE_FRSKY_RSSI */
+
 #define ARMED_THRESHOLD    0.50f
 //safe band to allow a bit of calibration error or trim offset (in microseconds)
 #define CONNECTION_OFFSET_THROTTLE 100
@@ -205,6 +209,11 @@ int32_t transmitter_control_update()
 #if defined(PIOS_INCLUDE_ADC)
 			value = PIOS_ADC_GetChannelRaw(settings.RssiChannelNumber);
 #endif
+			break;
+		case MANUALCONTROLSETTINGS_RSSITYPE_FRSKYPWM:
+#if defined(PIOS_INCLUDE_FRSKY_RSSI)
+			value = PIOS_FrSkyRssi_Get();
+#endif /* PIOS_INCLUDE_FRSKY_RSSI */
 			break;
 		}
 		if(value < 0)

--- a/flight/PiOS/STM32F4xx/inc/pios_frsky_rssi.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_frsky_rssi.h
@@ -1,0 +1,46 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS driver for PWM RSSI input
+ * @brief Input RSSI PWM
+ * @{
+ *
+ * @file       pios_frsky_rssi.h
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015.
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef PIOS_FRSKY_RSSI_H
+#define PIOS_FRSKY_RSSI_H
+
+#include <pios_stm32.h>
+#include <stm32f4xx_tim.h>
+
+struct pios_frsky_rssi_cfg {
+	struct pios_tim_clock_cfg clock_cfg;
+	struct pios_tim_channel channels[2];
+	TIM_ICInitTypeDef ic1;
+	TIM_ICInitTypeDef ic2;
+};
+
+int32_t PIOS_FrSkyRssi_Init(const struct pios_frsky_rssi_cfg * cfg_in);
+uint16_t PIOS_FrSkyRssi_Get();
+
+#endif /* PIOS_FRSKY_RSSI_H */

--- a/flight/PiOS/STM32F4xx/pios_frsky_rssi.c
+++ b/flight/PiOS/STM32F4xx/pios_frsky_rssi.c
@@ -1,0 +1,125 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS driver for FrSky RSSI input
+ * @brief Driver for FrSky RSSI, which is a PWM signal with a frequency of
+ * about 110kHz. The driver uses two capture-compare channels of the timer
+ * to measure the PWM pulse width. In contrast to the normal PWM driver, this
+ * procedure does not require any interrupts.
+ * @{
+ *
+ * @file       pios_frsky_rssi.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015.
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "pios_config.h"
+
+#if defined(PIOS_INCLUDE_FRSKY_RSSI)
+
+#include "pios.h"
+#include <pios_stm32.h>
+#include "stm32f4xx_tim.h"
+#include "pios_tim_priv.h"
+
+#if defined(PIOS_INCLUDE_FREERTOS)
+#include "FreeRTOS.h"
+#endif /* defined(PIOS_INCLUDE_FREERTOS) */
+
+
+#include "pios_frsky_rssi.h"
+
+static const struct pios_frsky_rssi_cfg * cfg = NULL;
+
+int32_t PIOS_FrSkyRssi_Init(const struct pios_frsky_rssi_cfg * cfg_in)
+{
+	PIOS_Assert(cfg_in);
+	cfg = cfg_in;
+
+	// this only works with the advanced timers
+	if ((cfg->channels[0].timer != TIM1) && (cfg->channels[0].timer != TIM8))
+		PIOS_Assert(0);
+
+	// both channels need to be on the same timer
+	if (cfg->channels[0].timer != cfg->channels[1].timer)
+		PIOS_Assert(0);
+
+	// we can only use channels 1 and 2
+	if ((cfg->channels[0].timer_chan != TIM_Channel_1) && (cfg->channels[0].timer_chan != TIM_Channel_2))
+		PIOS_Assert(0);
+
+	if ((cfg->channels[1].timer_chan != TIM_Channel_1) && (cfg->channels[1].timer_chan != TIM_Channel_2))
+		PIOS_Assert(0);
+
+	// Configure timer clock
+	PIOS_TIM_InitClock(&cfg->clock_cfg);
+
+	// Setup channels
+	uintptr_t tim_id;
+	if (PIOS_TIM_InitChannels(&tim_id, cfg->channels, 2, NULL, (uintptr_t)cfg)) {
+		return -1;
+	}
+
+	// Configure the input capture channels
+	TIM_ICInitTypeDef TIM_ICInitStructure = cfg->ic1;
+	TIM_ICInitStructure.TIM_Channel = cfg->channels[0].timer_chan;
+	TIM_ICInit(cfg->channels[0].timer, &TIM_ICInitStructure);
+
+	TIM_ICInitStructure = cfg->ic2;
+	TIM_ICInitStructure.TIM_Channel = cfg->channels[1].timer_chan;
+	TIM_ICInit(cfg->channels[1].timer, &TIM_ICInitStructure);
+
+	// slave mode and trigger configuration
+	TIM_SelectSlaveMode(cfg->channels[0].timer, TIM_SlaveMode_Reset);
+
+	switch(cfg->channels[0].timer_chan) {
+		case TIM_Channel_1:
+			TIM_SelectInputTrigger(cfg->channels[0].timer, TIM_TS_TI1FP1);
+			break;
+		case TIM_Channel_2:
+			TIM_SelectInputTrigger(cfg->channels[0].timer, TIM_TS_TI2FP2);
+			break;
+	}
+
+	// Enable CC channels
+	TIM_CCxCmd(cfg->channels[0].timer, cfg->channels[0].timer_chan, TIM_CCx_Enable);
+	TIM_CCxCmd(cfg->channels[1].timer, cfg->channels[1].timer_chan, TIM_CCx_Enable);
+
+	return 0;
+}
+
+uint16_t PIOS_FrSkyRssi_Get()
+{
+	uint16_t raw_rssi;
+	if (cfg == NULL)
+		return 0;
+
+	// test if no new capture occured
+	if ((cfg->channels[0].timer->SR & 0x02) == 0)
+		return 0;
+
+	raw_rssi = cfg->channels[0].timer->CCR1;
+
+	return raw_rssi;
+}
+#endif /* PIOS_INCLUDE_FRSKY_RSSI */
+
+
+

--- a/flight/PiOS/STM32F4xx/pios_frsky_rssi.c
+++ b/flight/PiOS/STM32F4xx/pios_frsky_rssi.c
@@ -10,7 +10,7 @@
  * @{
  *
  * @file       pios_frsky_rssi.c
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015.
  * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
@@ -39,12 +39,7 @@
 #include "stm32f4xx_tim.h"
 #include "pios_tim_priv.h"
 
-#if defined(PIOS_INCLUDE_FREERTOS)
-#include "FreeRTOS.h"
-#endif /* defined(PIOS_INCLUDE_FREERTOS) */
-
-
-#include "pios_frsky_rssi.h"
+#include "pios_frsky_rssi_priv.h"
 
 static const struct pios_frsky_rssi_cfg * cfg = NULL;
 

--- a/flight/PiOS/inc/pios_frsky_rssi.h
+++ b/flight/PiOS/inc/pios_frsky_rssi.h
@@ -7,7 +7,7 @@
  * @{
  *
  * @file       pios_frsky_rssi.h
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015.
  * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
@@ -30,17 +30,6 @@
 #ifndef PIOS_FRSKY_RSSI_H
 #define PIOS_FRSKY_RSSI_H
 
-#include <pios_stm32.h>
-#include <stm32f4xx_tim.h>
-
-struct pios_frsky_rssi_cfg {
-	struct pios_tim_clock_cfg clock_cfg;
-	struct pios_tim_channel channels[2];
-	TIM_ICInitTypeDef ic1;
-	TIM_ICInitTypeDef ic2;
-};
-
-int32_t PIOS_FrSkyRssi_Init(const struct pios_frsky_rssi_cfg * cfg_in);
 uint16_t PIOS_FrSkyRssi_Get();
 
 #endif /* PIOS_FRSKY_RSSI_H */

--- a/flight/PiOS/inc/pios_frsky_rssi_priv.h
+++ b/flight/PiOS/inc/pios_frsky_rssi_priv.h
@@ -1,0 +1,45 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS driver for PWM RSSI input
+ * @brief Input RSSI PWM
+ * @{
+ *
+ * @file       pios_frsky_rssi.h
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015.
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef PIOS_FRSKY_RSSI_PRIV_H
+#define PIOS_FRSKY_RSSI_PRIV_H
+
+#include <pios_stm32.h>
+#include <stm32f4xx_tim.h>
+
+struct pios_frsky_rssi_cfg {
+	struct pios_tim_clock_cfg clock_cfg;
+	struct pios_tim_channel channels[2];
+	TIM_ICInitTypeDef ic1;
+	TIM_ICInitTypeDef ic2;
+};
+
+int32_t PIOS_FrSkyRssi_Init(const struct pios_frsky_rssi_cfg * cfg_in);
+
+#endif /* PIOS_FRSKY_RSSI_PRIV_H */

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -43,7 +43,6 @@
 		<field name="RssiChannelNumber" units="channel" type="uint8" elements="1" defaultvalue="0"/>
 		<field name="RssiMax" units="" type="int16" elements="1" defaultvalue="2000"/>
 		<field name="RssiMin" units="" type="int16" elements="1" defaultvalue="1000"/>
-		<field name="RssiPwmPeriod" units="us" type="int16" elements="1" defaultvalue="260"/>
 		
 		<field name="ChannelNumber" units="channel" type="uint8" defaultvalue="0">
 			<elementnames>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -37,6 +37,7 @@
 				<option>PWM</option>
 				<option>PPM</option>
 				<option>ADC</option>
+				<option>FrSkyPWM</option>
 			</options>
 		</field>
 		<field name="RssiChannelNumber" units="channel" type="uint8" elements="1" defaultvalue="0"/>


### PR DESCRIPTION
FrSky receivers, e.g., model D4R-II, output a PWM RSSI frequency signal with a frequency of 110kHz, which is too high to be captured with normal PWM inputs in Tau Labs. This adds native support for such PWM signals by using two capture-compare channels. The disadvantage is that an entire timer is used, which limits the number of available PWM outputs.

I only have the Brain FC to test this, an example configuration for this target is given below.

[Example configuration for Brain](https://github.com/BrainFPV/TauLabs/blob/brain_frsky_rssi/flight/targets/brain/board-info/board_hw_defs.c#L1828)