### PR TITLE
python-api: cleanup, functionality

### DIFF
--- a/python/calibration/mag_calibration.py
+++ b/python/calibration/mag_calibration.py
@@ -107,7 +107,7 @@ def main():
         sys.path.insert(1, os.path.dirname(sys.path[0]))
         from taulabs import telemetry
         uavo_list = telemetry.get_telemetry_by_args()
-	from taulabs.uavo import UAVO_Magnetometer, UAVO_Gyros
+        from taulabs.uavo import UAVO_Magnetometer, UAVO_Gyros
 
         print mag_calibration(uavo_list.as_numpy_array(UAVO_Magnetometer), uavo_list.as_numpy_array(UAVO_Gyros))
 

--- a/python/minimal_connection.py
+++ b/python/minimal_connection.py
@@ -33,19 +33,24 @@ def main():
 
     githash = args.githash
 
-    tStream = telemetry.NetworkTelemetry()
+    tStream = telemetry.NetworkTelemetry(service_in_iter=False)
+    tStream.start_thread()
 
-#    tStream = telemetry.NetworkTelemetry(serviceInIter=False)
-#    tStream.start_thread()
+    settings_objects = tStream.uavo_defs.get_settings_objects()
 
-#    print settingsObjs
-#    print tStream.get_last_values()
-#    print [v for (k,v) in tStream.get_last_values().iteritems() 
-#                if k in settingsObjs]
+    # Need to actually control send rates and see when we're done.
+    for s in settings_objects:
+        tStream.request_object(s)
+        time.sleep(0.15)
 
-    for obj in tStream:
-        print obj
-        pass
+    time.sleep(2.5)
+
+    for s in settings_objects:
+        val = tStream.last_values.get(s)
+        if val is not None:
+            print val
+        else:
+            print "No instance of %s" % (s._name)
 
 #-------------------------------------------------------------------------------
 if __name__ == "__main__":

--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -73,7 +73,7 @@ class TelemetryBase():
 
         self.eof = False
 
-    def as_numpy_array(self, match_class): 
+    def as_numpy_array(self, match_class):
         """ Transforms all received instances of a given object to a numpy array.
         
         match_class: the UAVO_* class you'd like to match.
@@ -81,14 +81,14 @@ class TelemetryBase():
 
         import numpy as np
 
-        # Find the subset of this list that is of the requested class 
-        filtered_list = filter(lambda x: isinstance(x, match_class), self) 
+        # Find the subset of this list that is of the requested class
+        filtered_list = filter(lambda x: isinstance(x, match_class), self)
  
-        # Check for an empty list 
-        if filtered_list == []: 
-            return np.array([]) 
+        # Check for an empty list
+        if filtered_list == []:
+            return np.array([])
  
-        return np.array(filtered_list, dtype=match_class._dtype) 
+        return np.array(filtered_list, dtype=match_class._dtype)
 
     def __iter__(self):
         """ Iterator service routine. """
@@ -205,7 +205,7 @@ class TelemetryBase():
 
         def run():
             while not self._done():
-                self.service_connection()    
+                self.service_connection()
 
         t = Thread(target=run, name="telemetry svc thread")
 
@@ -296,7 +296,7 @@ class FDTelemetry(TelemetryBase):
             wrSet.append(self.fd)
 
         now = time.time()
-        if finish_time is None: 
+        if finish_time is None:
             r,w,e = select.select(rdSet, wrSet, [])
         else:
             tm = finish_time-now
@@ -438,7 +438,7 @@ def get_telemetry_by_args(desc="Process telemetry"):
     parser = argparse.ArgumentParser(description=desc)
 
     # Log format indicates this log is using the old file format which
-    # embeds the timestamping information between the UAVTalk packet 
+    # embeds the timestamping information between the UAVTalk packet
     # instead of as part of the packet
     parser.add_argument("-t", "--timestamped",
                         action  = 'store_false',

--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -435,7 +435,7 @@ class FileTelemetry(TelemetryBase):
     def _receive(self, finish_time):
         """ Fetch available data from file """
 
-        buf = self.f.read(128)
+        buf = self.f.read(524288)   # 512k
 
         if buf == '':
             self.done=True

--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -159,7 +159,13 @@ class TelemetryBase():
 
             self._send(uavtalk.send_object(send_obj))
 
-    def __handleFrames(self, frames):
+    def request_object(self, obj):
+        if not self.do_handshaking:
+            raise ValueError("Can only request on handshaking/bidir sessions")
+
+        self._send(uavtalk.request_object(obj))
+
+    def __handle_frames(self, frames):
         objs = []
 
         obj = self.uavtalk_generator.send(frames)
@@ -183,7 +189,7 @@ class TelemetryBase():
                 self.eof=True
 
             for obj in objs:
-                self.last_values[obj.name]=obj
+                self.last_values[obj.__class__]=obj
 
             self.cond.notifyAll()
 
@@ -225,7 +231,7 @@ class TelemetryBase():
             finish_time = None
 
         data = self._receive(finish_time)
-        self.__handleFrames(data)
+        self.__handle_frames(data)
 
     @abstractmethod
     def _receive(self, finish_time):

--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -88,17 +88,7 @@ class TelemetryBase():
         if filtered_list == []: 
             return np.array([]) 
  
-        # Find the uavo definition associated with this UAVO type 
-        if not "{0:08x}".format(filtered_list[0].uavo_id) in self.uavo_defs: 
-            dtype = None 
-        else: 
-            uavo_def = self.uavo_defs["{0:08x}".format(filtered_list[0].uavo_id)] 
-            dtype  = [('name', 'S20'), ('time', 'double'), ('uavo_id', 'uint')] 
- 
-            for f in uavo_def.fields: 
-                dtype += [(f['name'], '(' + `f['elements']` + ",)" + uavo_def.type_numpy_map[f['type']])] 
- 
-        return np.array(filtered_list, dtype=dtype) 
+        return np.array(filtered_list, dtype=match_class._dtype) 
 
     def __iter__(self):
         """ Iterator service routine. """

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -2,7 +2,7 @@ import struct
 
 def flatten(lst):
     result = []
-    for element in lst: 
+    for element in lst:
         if hasattr(element, '__iter__'):
             result.extend(flatten(element))
         else:
@@ -53,7 +53,7 @@ class UAVTupleClass():
         # convert from ms to seconds here.
 
         if timestamp != None:
-            field_values.append(timestamp / 1000.0) 
+            field_values.append(timestamp / 1000.0)
         else:
             if cls._single:
                 raw_ts = unpack_field_values.pop(0)
@@ -65,7 +65,7 @@ class UAVTupleClass():
         field_values.append(cls._id)
 
         # add the remaining fields.  If the thing should be nested, construct
-        # an appropriate tuple. 
+        # an appropriate tuple.
         if not cls._flat:
             pos = 0
 
@@ -76,7 +76,7 @@ class UAVTupleClass():
                     field_values.append(tuple(unpack_field_values[pos:pos+n]))
                 pos += n
 
-            field_values = tuple(field_values) 
+            field_values = tuple(field_values)
         else:
             # Short cut; nothing is nested
             field_values = tuple(field_values) + tuple(unpack_field_values)

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -28,6 +28,10 @@ class UAVTupleClass():
         return self.packstruct.pack(*flatten(self[3:]))
 
     @classmethod
+    def get_size_of_data(cls):
+        return cls.packstruct.size
+
+    @classmethod
     def from_bytes(cls, data, timestamp, offset=0):
         """ Deserializes and creates an instance of this object.
         
@@ -62,10 +66,10 @@ class UAVTupleClass():
 
         # add the remaining fields.  If the thing should be nested, construct
         # an appropriate tuple. 
-        if not cls.flat:
+        if not cls._flat:
             pos = 0
 
-            for n in cls.num_subelems:
+            for n in cls._num_subelems:
                 if n == 1:
                     field_values.append(unpack_field_values[pos])
                 else:
@@ -79,223 +83,203 @@ class UAVTupleClass():
 
         return cls._make(field_values)
 
-# Hopefully this class can be deleted in favor of a generator function and our
-# dynamically generated namedtuple child classes.  We're close.
-class UAVO():
-    type_enum_map = {
-        'int8'    : 0,
-        'int16'   : 1,
-        'int32'   : 2,
-        'uint8'   : 3,
-        'uint16'  : 4,
-        'uint32'  : 5,
-        'float'   : 6,
-        'enum'    : 7,
+type_enum_map = {
+    'int8'    : 0,
+    'int16'   : 1,
+    'int32'   : 2,
+    'uint8'   : 3,
+    'uint16'  : 4,
+    'uint32'  : 5,
+    'float'   : 6,
+    'enum'    : 7,
+    }
+
+type_numpy_map = {
+    'int8'    : 'int8',
+    'int16'   : 'int16',
+    'int32'   : 'int32',
+    'uint8'   : 'uint8',
+    'uint16'  : 'uint16',
+    'uint32'  : 'uint32',
+    'float'   : 'float',
+    'enum'    : 'uint8',
+    }
+
+struct_element_map = {
+    'int8'    : 'b',
+    'int16'   : 'h',
+    'int32'   : 'i',
+    'uint8'   : 'B',
+    'uint16'  : 'H',
+    'uint32'  : 'I',
+    'float'   : 'f',
+    'enum'    : 'B',
+    }
+
+# This is a very long, scary method.  It parses an XML file describing
+# a UAVO and builds an implementation class.
+def make_class(xml_file):
+    fields = []
+
+    ##### PARSE THE XML FILE INTO INTERNAL REPRESENTATIONS #####
+
+    from lxml import etree
+
+    tree = etree.parse(xml_file)
+
+    subs = {
+        'tree'            : tree,
+        'object'          : tree.find('object'),
+        'fields'          : tree.findall('object/field'),
+        'description'     : tree.find('object/description'),
+        'access'          : tree.find('object/access'),
+        'logging'         : tree.find('object/logging'),
+        'telemetrygcs'    : tree.find('object/telemetrygcs'),
+        'telemetryflight' : tree.find('object/telemetryflight'),
         }
 
-    type_numpy_map = {
-        'int8'    : 'int8',
-        'int16'   : 'int16',
-        'int32'   : 'int32',
-        'uint8'   : 'uint8',
-        'uint16'  : 'uint16',
-        'uint32'  : 'uint32',
-        'float'   : 'float',
-        'enum'    : 'uint8',
-        }
+    name = subs['object'].get('name')
+    is_single_inst = int((subs['object'].get('singleinstance') == 'true'))
+    is_settings = int((subs['object'].get('settings') == 'true'))
 
-    struct_element_map = {
-        'int8'    : 'b',
-        'int16'   : 'h',
-        'int32'   : 'i',
-        'uint8'   : 'B',
-        'uint16'  : 'H',
-        'uint32'  : 'I',
-        'float'   : 'f',
-        'enum'    : 'B',
-        }
+    description = subs['description'].text
 
-    def __init__(self, xml_file):
-        self.fields = []
-        self.id = 0
+    ##### CONSTRUCT PROPER INTERNAL REPRESENTATION OF FIELD DATA #####
 
-        self.hash = 0
+    import copy
+    import re
+    for field in subs['fields']:
+        info = {}
+        # process typical attributes
+        for attr in ['name', 'units', 'type', 'elements', 'elementnames']:
+            info[attr] = field.get(attr)
+        if field.get('cloneof'):
+            # this is a clone of another field, find its data
+            cloneof_name = field.get('cloneof')
+            for i, field in enumerate(fields):
+                if field['name'] == cloneof_name:
+                    clone_info = copy.deepcopy(field)
+                    break
 
-        from lxml import etree
-
-        tree = etree.parse(xml_file)
-
-        subs = {
-            'tree'            : tree,
-            'object'          : tree.find('object'),
-            'fields'          : tree.findall('object/field'),
-            'description'     : tree.find('object/description'),
-            'access'          : tree.find('object/access'),
-            'logging'         : tree.find('object/logging'),
-            'telemetrygcs'    : tree.find('object/telemetrygcs'),
-            'telemetryflight' : tree.find('object/telemetryflight'),
-            }
-
-        self.tree = tree
-        self.subs = subs
-
-        self.name = subs['object'].get('name')
-        self.is_single_inst = int((subs['object'].get('singleinstance') == 'true'))
-        self.is_settings = int((subs['object'].get('settings') == 'true'))
-
-        self.description = subs['description'].text
-
-        import copy
-        import re
-        for field in subs['fields']:
-            info = {}
-            # process typical attributes
-            for attr in ['name', 'units', 'type', 'elements', 'elementnames']:
-                info[attr] = field.get(attr)
-            if field.get('cloneof'):
-                # this is a clone of another field, find its data
-                cloneof_name = field.get('cloneof')
-                for i, field in enumerate(self.fields):
-                    if field['name'] == cloneof_name:
-                        clone_info = copy.deepcopy(field)
-                        break
-
-                # replace it with the new name
-                clone_info['name'] = info['name']
-                # use the expanded/substituted info instead of the stub
-                info = clone_info
+            # replace it with the new name
+            clone_info['name'] = info['name']
+            # use the expanded/substituted info instead of the stub
+            info = clone_info
+        else:
+            if info['elements'] != None:
+                # we've got an inline "elements" attribute
+                info['elementnames'] = []
+                info['elements'] = int(field.get('elements'))
+            elif info['elementnames'] != None:
+                # we've got an inline "elementnames" attribute
+                info['elementnames'] = []
+                info['elements'] = 0
+                for elementname in field.get('elementnames').split(','):
+                    info['elementnames'].append(elementname.strip(' '))
+                    info['elements'] += 1
             else:
-                if info['elements'] != None:
-                    # we've got an inline "elements" attribute
-                    info['elementnames'] = []
-                    info['elements'] = int(field.get('elements'))
-                elif info['elementnames'] != None:
-                    # we've got an inline "elementnames" attribute
-                    info['elementnames'] = []
-                    info['elements'] = 0
-                    for elementname in field.get('elementnames').split(','):
-                        info['elementnames'].append(elementname.strip(' '))
-                        info['elements'] += 1
+                # we must have one or more elementnames/elementname elements in this sub-tree
+                info['elementnames'] = []
+                info['elements'] = 0
+                for elementname_text in [elementname.text for elementname in field.findall('elementnames/elementname')]:
+                    info['elementnames'].append(elementname_text)
+                    info['elements'] += 1
+
+            if info['type'] == 'enum':
+                info['options'] = []
+                if field.get('options'):
+                    # we've got an inline "options" attribute
+                    for option_text in field.get('options').split(','):
+                        info['options'].append(option_text.strip(' '))
                 else:
-                    # we must have one or more elementnames/elementname elements in this sub-tree
-                    info['elementnames'] = []
-                    info['elements'] = 0
-                    for elementname_text in [elementname.text for elementname in field.findall('elementnames/elementname')]:
-                        info['elementnames'].append(elementname_text)
-                        info['elements'] += 1
+                    # we must have some 'option' elements in this sub-tree
+                    for option_text in [option.text for option in field.findall('options/option')]:
+                        info['options'].append(option_text)
 
-                if info['type'] == 'enum':
-                    info['options'] = []
-                    if field.get('options'):
-                        # we've got an inline "options" attribute
-                        for option_text in field.get('options').split(','):
-                            info['options'].append(option_text.strip(' '))
-                    else:
-                        # we must have some 'option' elements in this sub-tree
-                        for option_text in [option.text for option in field.findall('options/option')]:
-                            info['options'].append(option_text)
+            # convert type string to an int
+            info['type_val'] = type_enum_map[info['type']]
+        fields.append(info)
 
-                # convert type string to an int
-                info['type_val'] = self.type_enum_map[info['type']]
-            self.fields.append(info)
+    # Sort fields by size (bigger to smaller) to ensure alignment when packed
+    fields.sort(key=lambda x: struct.calcsize(struct_element_map[x['type']]), reverse = True)
 
-        # Sort fields by size (bigger to smaller) to ensure alignment when packed
-        self.fields.sort(key=lambda x: struct.calcsize(self.struct_element_map[x['type']]), reverse = True)
+    ##### CALCULATE THE APPROPRIATE UAVO ID #####
+    hash_calc = UAVOHash()
 
-        self.uavo_id = self.__calculate_id()
+    hash_calc.update_hash_string(name)
+    hash_calc.update_hash_byte(is_settings)
+    hash_calc.update_hash_byte(is_single_inst)
 
-        self.__build_class_of()
+    for field in fields:
+        hash_calc.update_hash_string(field['name'])
+        hash_calc.update_hash_byte(int(field['elements']))
+        hash_calc.update_hash_byte(field['type_val'])
+        if field['type'] == 'enum':
+            for option in field['options']:
+                hash_calc.update_hash_string(option)
+    uavo_id = hash_calc.get_hash()
 
-    def __build_class_of(self):
-        from collections import namedtuple
-        fields = ['name', 'time', 'uavo_id']
-        if not self.is_single_inst:
-            fields.append("inst_id")
+    ##### FORM A STRUCT TO PACK/UNPACK THIS UAVO'S CONTENT #####
+    formats = []
+    num_subelems = []
 
-        fields.extend([f['name'] for f in self.fields])
+    # add format for instance-id IFF this is a multi-instance UAVO
+    if not is_single_inst:
+        # this is multi-instance so the optional instance-id is present
+        formats.append('H')
+        num_subelems.append(1)
 
-        name = 'UAVO_' + self.name
+    is_flat = True
 
-        self.__form_packformat()
+    # add formats for each field
+    for f in fields:
+        if f['elements'] != 1:
+            is_flat = False
 
-        class tmpClass(namedtuple(name, fields), UAVTupleClass):
-            packstruct = self.fmt
-            num_subelems = self.num_subelems
-            flat = self.flat
-            uavometa = self
-            _name = name
-            _id = self.uavo_id
-            _single = self.is_single_inst
+        num_subelems.append(f['elements'])
 
-        # This is magic for two reasons.  First, we create the class to have
-        # the proper dynamic name.  Second, we override __slots__, so that
-        # child classes don't get a dict / keep all their namedtuple goodness
-        self.tuple_class = type(name, (tmpClass,), { "__slots__" : () })
+        formats.append('' + f['elements'].__str__() + struct_element_map[f['type']])
 
-        # Make sure this new class is exposed in the module globals so that it can be pickled
-        globals()[self.tuple_class.__name__] = self.tuple_class
+    fmt = struct.Struct('<' + ''.join(formats))
 
-    def get_size_of_data(self):
-        size = self.fmt.size
+    ##### DYNAMICALLY CREATE A CLASS TO CONTAIN THIS OBJECT #####
 
-        return size
+    from collections import namedtuple
+    tuple_fields = ['name', 'time', 'uavo_id']
+    if not is_single_inst:
+        tuple_fields.append("inst_id")
 
-    def __form_packformat(self):
-        formats = []
-        num_subelems = []
+    tuple_fields.extend([f['name'] for f in fields])
 
-        # add format for instance-id IFF this is a multi-instance UAVO
-        if not self.is_single_inst:
-            # this is multi-instance so the optional instance-id is present
-            formats.append('H')
-            num_subelems.append(1)
+    name = 'UAVO_' + name
 
-        flat = True
+    class tmpClass(namedtuple(name, tuple_fields), UAVTupleClass):
+        packstruct = fmt
+        _flat = is_flat
+        _name = name
+        _id = uavo_id
+        _single = is_single_inst
+        _num_subelems = num_subelems
 
-        # add formats for each field
-        for f in self.fields:
-            if f['elements'] != 1:
-                flat = False
+    # This is magic for two reasons.  First, we create the class to have
+    # the proper dynamic name.  Second, we override __slots__, so that
+    # child classes don't get a dict / keep all their namedtuple goodness
+    tuple_class = type(name, (tmpClass,), { "__slots__" : () })
 
-            num_subelems.append(f['elements'])
+    globals()[tuple_class.__name__] = tuple_class
 
-            formats.append('' + f['elements'].__str__() + self.struct_element_map[f['type']])
+    return tuple_class
 
-        self.flat = flat
+class UAVOHash():
+    def __init__(self):
+        self.hval = 0
 
-        self.fmt = struct.Struct('<' + ''.join(formats))
+    def update_hash_byte(self, value):
+        self.hval = (self.hval ^ ((self.hval << 5) + (self.hval >> 2) + value)) & 0x0FFFFFFFF
 
-        self.num_subelems = num_subelems
-
-    def instance_from_bytes(self, *args, **kwargs):
-        return self.tuple_class.from_bytes(*args, **kwargs)
-
-    def __str__(self):
-        return "%s(id='%08x') %s" % (self.name, self._id, " ".join([f['name'] for f in self.fields]))
-
-    def __repr__(self):
-        return "%s(id='%08x', name=%r)" % (self.__class__, self._id, self.name)
-
-    def __update_hash_byte(self, value):
-        self.hash = (self.hash ^ ((self.hash << 5) + (self.hash >> 2) + value)) & 0x0FFFFFFFF
-
-    def __update_hash_string(self, string):
+    def update_hash_string(self, string):
         for c in string:
-            self.__update_hash_byte(ord(c))
+            self.update_hash_byte(ord(c))
 
-    def __calculate_id(self):
-        self.hash = 0
-
-        self.__update_hash_string(self.name)
-        self.__update_hash_byte(self.is_settings)
-        self.__update_hash_byte(self.is_single_inst)
-
-        for field in self.fields:
-            self.__update_hash_string(field['name'])
-            self.__update_hash_byte(int(field['elements']))
-            self.__update_hash_byte(field['type_val'])
-            if field['type'] == 'enum':
-                for option in field['options']:
-                    self.__update_hash_string(option)
-
-        return self.hash & 0x0FFFFFFFE
+    def get_hash(self):
+        return self.hval & 0x0FFFFFFFE

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -77,8 +77,6 @@ class UAVTupleClass():
             # Short cut; nothing is nested
             field_values = tuple(field_values) + tuple(unpack_field_values)
 
-        print field_values
-
         return cls._make(field_values)
 
 # Hopefully this class can be deleted in favor of a generator function and our
@@ -205,7 +203,7 @@ class UAVO():
         # Sort fields by size (bigger to smaller) to ensure alignment when packed
         self.fields.sort(key=lambda x: struct.calcsize(self.struct_element_map[x['type']]), reverse = True)
 
-        self.id = self.__calculate_id()
+        self.uavo_id = self.__calculate_id()
 
         self.__build_class_of()
 
@@ -227,7 +225,7 @@ class UAVO():
             flat = self.flat
             uavometa = self
             _name = name
-            _id = self.id
+            _id = self.uavo_id
             _single = self.meta['is_single_inst']
 
         # This is magic for two reasons.  First, we create the class to have

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -106,17 +106,6 @@ class UAVO():
         'enum'    : 'uint8',
         }
 
-    type_size_map = {
-        'int8'    : 1,
-        'int16'   : 2,
-        'int32'   : 4,
-        'uint8'   : 1,
-        'uint16'  : 2,
-        'uint32'  : 4,
-        'float'   : 4,
-        'enum'    : 1,
-        }
-
     struct_element_map = {
         'int8'    : 'b',
         'int16'   : 'h',
@@ -214,7 +203,7 @@ class UAVO():
             self.fields.append(info)
 
         # Sort fields by size (bigger to smaller) to ensure alignment when packed
-        self.fields.sort(key=lambda x: self.type_size_map[x['type']], reverse = True)
+        self.fields.sort(key=lambda x: struct.calcsize(self.struct_element_map[x['type']]), reverse = True)
 
         self.id = self.__calculate_id()
 
@@ -250,14 +239,7 @@ class UAVO():
         globals()[self.tuple_class.__name__] = self.tuple_class
 
     def get_size_of_data(self):
-        size = 0
-
-        if not self.meta['is_single_inst']:
-            # this is multi-instance so the optional instance-id is present
-            size += 2
-
-        for f in self.fields:
-            size += self.type_size_map[f['type']] * f['elements']
+        size = self.fmt.size
 
         return size
 

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -117,7 +117,6 @@ class UAVO():
 
     def __init__(self, xml_file):
         self.fields = []
-        self.meta = {}
         self.id = 0
 
         self.hash = 0
@@ -140,11 +139,11 @@ class UAVO():
         self.tree = tree
         self.subs = subs
 
-        self.meta['name']           = subs['object'].get('name')
-        self.meta['is_single_inst'] = int((subs['object'].get('singleinstance') == 'true'))
-        self.meta['is_settings']    = int((subs['object'].get('settings') == 'true'))
+        self.name = subs['object'].get('name')
+        self.is_single_inst = int((subs['object'].get('singleinstance') == 'true'))
+        self.is_settings = int((subs['object'].get('settings') == 'true'))
 
-        self.meta['description']    = subs['description'].text
+        self.description = subs['description'].text
 
         import copy
         import re
@@ -210,12 +209,12 @@ class UAVO():
     def __build_class_of(self):
         from collections import namedtuple
         fields = ['name', 'time', 'uavo_id']
-        if not self.meta['is_single_inst']:
+        if not self.is_single_inst:
             fields.append("inst_id")
 
         fields.extend([f['name'] for f in self.fields])
 
-        name = 'UAVO_' + self.meta['name']
+        name = 'UAVO_' + self.name
 
         self.__form_packformat()
 
@@ -226,7 +225,7 @@ class UAVO():
             uavometa = self
             _name = name
             _id = self.uavo_id
-            _single = self.meta['is_single_inst']
+            _single = self.is_single_inst
 
         # This is magic for two reasons.  First, we create the class to have
         # the proper dynamic name.  Second, we override __slots__, so that
@@ -246,7 +245,7 @@ class UAVO():
         num_subelems = []
 
         # add format for instance-id IFF this is a multi-instance UAVO
-        if not self.meta['is_single_inst']:
+        if not self.is_single_inst:
             # this is multi-instance so the optional instance-id is present
             formats.append('H')
             num_subelems.append(1)
@@ -272,10 +271,10 @@ class UAVO():
         return self.tuple_class.from_bytes(*args, **kwargs)
 
     def __str__(self):
-        return "%s(id='%08x') %s" % (self.meta['name'], self._id, " ".join([f['name'] for f in self.fields]))
+        return "%s(id='%08x') %s" % (self.name, self._id, " ".join([f['name'] for f in self.fields]))
 
     def __repr__(self):
-        return "%s(id='%08x', name=%r)" % (self.__class__, self._id, self.meta['name'])
+        return "%s(id='%08x', name=%r)" % (self.__class__, self._id, self.name)
 
     def __update_hash_byte(self, value):
         self.hash = (self.hash ^ ((self.hash << 5) + (self.hash >> 2) + value)) & 0x0FFFFFFFF
@@ -287,9 +286,9 @@ class UAVO():
     def __calculate_id(self):
         self.hash = 0
 
-        self.__update_hash_string(self.meta['name'])
-        self.__update_hash_byte(self.meta['is_settings'])
-        self.__update_hash_byte(self.meta['is_single_inst'])
+        self.__update_hash_string(self.name)
+        self.__update_hash_byte(self.is_settings)
+        self.__update_hash_byte(self.is_single_inst)
 
         for field in self.fields:
             self.__update_hash_string(field['name'])

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -242,6 +242,14 @@ def make_class(xml_file):
 
     fmt = struct.Struct('<' + ''.join(formats))
 
+    ##### CALCULATE THE NUMPY TYPE ASSOCIATED WITH THIS CLASS ##### 
+
+    dtype  = [('name', 'S20'), ('time', 'double'), ('uavo_id', 'uint')]
+
+    for f in fields:
+        dtype += [(f['name'], '(' + `f['elements']` + ",)" + type_numpy_map[f['type']])]
+
+
     ##### DYNAMICALLY CREATE A CLASS TO CONTAIN THIS OBJECT #####
 
     from collections import namedtuple
@@ -260,6 +268,7 @@ def make_class(xml_file):
         _id = uavo_id
         _single = is_single_inst
         _num_subelems = num_subelems
+        _dtype = dtype
 
     # This is magic for two reasons.  First, we create the class to have
     # the proper dynamic name.  Second, we override __slots__, so that

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -23,13 +23,13 @@ class UAVTupleClass():
         import time
         return cls(cls._name, round(time.time() * 1000), cls._id, *args)
 
-    def bytes(self):
+    def to_bytes(self):
         """ Serializes this object into a byte stream. """
-        return self.packstruct.pack(*flatten(self[3:]))
+        return self._packstruct.pack(*flatten(self[3:]))
 
     @classmethod
     def get_size_of_data(cls):
-        return cls.packstruct.size
+        return cls._packstruct.size
 
     @classmethod
     def from_bytes(cls, data, timestamp, offset=0):
@@ -41,7 +41,7 @@ class UAVTupleClass():
         """
         import struct
 
-        unpack_field_values = cls.packstruct.unpack_from(data, offset)
+        unpack_field_values = cls._packstruct.unpack_from(data, offset)
 
         field_values = []
         field_values.append(cls._name)
@@ -262,13 +262,14 @@ def make_class(xml_file):
     name = 'UAVO_' + name
 
     class tmpClass(namedtuple(name, tuple_fields), UAVTupleClass):
-        packstruct = fmt
+        _packstruct = fmt
         _flat = is_flat
         _name = name
         _id = uavo_id
         _single = is_single_inst
         _num_subelems = num_subelems
         _dtype = dtype
+        _is_settings = is_settings
 
     # This is magic for two reasons.  First, we create the class to have
     # the proper dynamic name.  Second, we override __slots__, so that

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -272,10 +272,10 @@ class UAVO():
         return self.tuple_class.from_bytes(*args, **kwargs)
 
     def __str__(self):
-        return "%s(id='%08x') %s" % (self.meta['name'], self.id, " ".join([f['name'] for f in self.fields]))
+        return "%s(id='%08x') %s" % (self.meta['name'], self._id, " ".join([f['name'] for f in self.fields]))
 
     def __repr__(self):
-        return "%s(id='%08x', name=%r)" % (self.__class__, self.id, self.meta['name'])
+        return "%s(id='%08x', name=%r)" % (self.__class__, self._id, self.meta['name'])
 
     def __update_hash_byte(self, value):
         self.hash = (self.hash ^ ((self.hash << 5) + (self.hash >> 2) + value)) & 0x0FFFFFFFF

--- a/python/taulabs/uavo_collection.py
+++ b/python/taulabs/uavo_collection.py
@@ -50,7 +50,7 @@ class UAVOCollection(dict):
             u = uavo.UAVO(f)
 
             # add this uavo definition to our dictionary
-            self.update([('{0:08x}'.format(u.id), u)])
+            self.update([('{0:08x}'.format(u.uavo_id), u)])
 
     def from_uavo_xml_path(self, path):
         import os
@@ -61,4 +61,4 @@ class UAVOCollection(dict):
                 u = uavo.UAVO(f)
 
                 # add this uavo definition to our dictionary
-                self.update([('{0:08x}'.format(u.id), u)])
+                self.update([('{0:08x}'.format(u.uavo_id), u)])

--- a/python/taulabs/uavo_collection.py
+++ b/python/taulabs/uavo_collection.py
@@ -1,5 +1,7 @@
 import uavo
 
+import operator
+
 class UAVOCollection(dict):
     def __init__(self):
         self.clear()
@@ -13,6 +15,12 @@ class UAVOCollection(dict):
                 return u
 
         return None
+
+    def get_settings_objects(self):
+        objs = [ u for u in self.itervalues() if u._is_settings ]
+        objs.sort(key=operator.attrgetter('_name'))
+
+        return objs
 
     def from_git_hash(self, githash):
         import subprocess

--- a/python/taulabs/uavo_collection.py
+++ b/python/taulabs/uavo_collection.py
@@ -9,18 +9,10 @@ class UAVOCollection(dict):
             uavo_name = uavo_name[5:]
 
         for u in self.itervalues():
-            if u.meta['name'] == uavo_name:
-                return u.tuple_class
+            if u._name == uavo_name:
+                return u
 
         return None
-
-    def get_data_objects(self):
-        return [ u.meta['name'] for u in self.itervalues()
-                if not u.meta['is_settings'] ]
-
-    def get_settings_objects(self):
-        return [ u.meta['name'] for u in self.itervalues()
-                if u.meta['is_settings'] ]
 
     def from_git_hash(self, githash):
         import subprocess
@@ -47,10 +39,10 @@ class UAVOCollection(dict):
 
             f = t.extractfile(f_info)
 
-            u = uavo.UAVO(f)
+            u = uavo.make_class(f)
 
             # add this uavo definition to our dictionary
-            self.update([('{0:08x}'.format(u.uavo_id), u)])
+            self.update([('{0:08x}'.format(u._id), u)])
 
     def from_uavo_xml_path(self, path):
         import os
@@ -58,7 +50,7 @@ class UAVOCollection(dict):
 
         for file_name in glob.glob(os.path.join(path, '*.xml')):
             with open(file_name, 'rU') as f:
-                u = uavo.UAVO(f)
+                u = uavo.make_class(f)
 
                 # add this uavo definition to our dictionary
-                self.update([('{0:08x}'.format(u.uavo_id), u)])
+                self.update([('{0:08x}'.format(u._id), u)])

--- a/python/taulabs/uavtalk.py
+++ b/python/taulabs/uavtalk.py
@@ -206,9 +206,19 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=False):
             timestamp = timestamp_fmt.unpack_from(buf, header_fmt.size + buf_offset)[0]
 
             # handle wraparound
+
+            # This is currently hacked because the ordering of instance id and
+            # time is messed up in this code-- hacked so at least timestamps
+            # don't jump.
             if timestamp < last_timestamp:
-                timestamp_base = timestamp_base + 65536
-            last_timestamp = timestamp
+                if timestamp > 200:
+                    timestamp_base = timestamp_base + 65536
+                    last_timestamp = timestamp
+                else:
+                    timestamp += 65536
+            else:
+                last_timestamp = timestamp
+
             timestamp += timestamp_base
         else:
             timestamp = last_timestamp

--- a/python/taulabs/uavtalk.py
+++ b/python/taulabs/uavtalk.py
@@ -17,7 +17,7 @@ __all__ = [ "send_object", "process_stream" ]
 
 # Serialization of header elements
 
-# sync(1) + type(1) + len(2) + objid(4) 
+# sync(1) + type(1) + len(2) + objid(4)
 header_fmt = struct.Struct("<BBHL")
 logheader_fmt = struct.Struct("<IQ")
 timestamp_fmt = struct.Struct("<H")
@@ -93,7 +93,7 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=False):
         # Ensure we have enough room for all the
         # plain required fields to avoid duplicating
         # this code lots.
-        # sync(1) + type(1) + len(2) + objid(4) 
+        # sync(1) + type(1) + len(2) + objid(4)
 
         while (len(buf) < header_fmt.size + buf_offset) or (buf[buf_offset] != chr(SYNC_VAL)):
             #print "waitingsync len=%d, offset=%d"%(len(buf), buf_offset)
@@ -220,7 +220,7 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=False):
 
         if obj is not None:
             objInstance = obj.from_bytes(buf,
-                timestamp, offset=header_fmt.size + timestamp_len + buf_offset) 
+                timestamp, offset=header_fmt.size + timestamp_len + buf_offset)
 
             received += 1
             if not (received % 20000):

--- a/python/taulabs/uavtalk.py
+++ b/python/taulabs/uavtalk.py
@@ -219,7 +219,7 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=False):
             timestamp = overrideTimestamp
 
         if obj is not None:
-            objInstance = obj.instance_from_bytes(buf,
+            objInstance = obj.from_bytes(buf,
                 timestamp, offset=header_fmt.size + timestamp_len + buf_offset) 
 
             received += 1
@@ -238,10 +238,8 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=False):
 def send_object(obj):
     """Generates a string containing a UAVTalk packet describing this object"""
 
-    uavo_def = obj.uavometa
-
     hdr = header_fmt.pack(SYNC_VAL, TYPE_OBJ | TYPE_VER,
-        header_fmt.size + uavo_def.get_size_of_data(),
+        header_fmt.size + obj.get_size_of_data(),
         obj.uavo_id)
 
     packet = hdr + obj.bytes()

--- a/python/visualize/vid_overlay_position.py
+++ b/python/visualize/vid_overlay_position.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 
 def video_overlay(pa,ned,pos_des,output_filename):
     # Generate video of the performance during loiter, this
@@ -99,7 +100,7 @@ def main():
         import sys, os
         sys.path.insert(1, os.path.dirname(sys.path[0]))
         from taulabs import telemetry
-        uavo_list = telemetry.GetUavoBasedOnArgs()
+        uavo_list = telemetry.get_telemetry_by_args()
         from taulabs.uavo import UAVO_PositionActual, UAVO_NEDPosition, UAVO_PathDesired
 
         pa = uavo_list.as_numpy_array(UAVO_PositionActual)

--- a/python/visualize/vid_overlay_position.py
+++ b/python/visualize/vid_overlay_position.py
@@ -1,0 +1,114 @@
+
+def video_overlay(pa,ned,pos_des,output_filename):
+    # Generate video of the performance during loiter, this
+    # includes the loiter position, current estimate of
+    # position and raw gps position
+
+    #output_filename = 'out.mp4'
+
+    import matplotlib.animation as animation
+    import scipy.signal as signal
+    import matplotlib.pyplot as plt
+    from numpy import nan, arange
+    from numpy.lib.function_base import diff
+    from matplotlib.pyplot import plot, xlabel, ylabel, xlim, ylim, draw
+    from matplotlib.mlab import find
+
+    ####### plot section
+
+    fig, ax = plt.subplots(1,sharex=True)
+    fig.set_size_inches([8,4])
+    fig.patch.set_facecolor('green')
+
+    t0_s = pa['time'][0]
+    t1_s = pa['time'][-1]
+
+    # nan out gaps between flights
+    idx = find(diff(pos_des['time']) > 5000)
+    pos_des['End'][idx,2] = nan
+
+    # Plot position
+    plot(pa['East'][:,0], pa['North'][:,0], linewidth=3, color=(0.2,0.2,0.2), label="Position")
+    plot(pa['East'][:,0], pa['North'][:,0], linewidth=2, color=(0.8,0.8,0.8), label="Position")
+    desired_marker = plot(pos_des['End'][0,1], pos_des['End'][0,0], '*k', markersize=15, label="Desired")
+    ned_marker = plot(pa['East'][0,0], pa['North'][0,0], '.b', markersize=8)
+    current_marker = plot(pa['East'][0,0], pa['North'][0,0], '.r', markersize=13)
+
+    xlabel('East (m)')
+    ylabel('North (m)')
+    xlim(min(pa['East'][:,0]-20), max(pa['East'][:,0])+20)
+    ylim(min(pa['North'][:,0]-10), max(pa['North'][:,0])+10)
+
+    ax.set_axis_bgcolor('green')
+    ax.xaxis.label.set_color('white')
+    ax.yaxis.label.set_color('white')
+    ax.spines['bottom'].set_color('white')
+    ax.spines['top'].set_color('green')
+    ax.spines['right'].set_color('green')
+    ax.spines['left'].set_color('white')
+    ax.tick_params(axis='x', colors='white')
+    ax.tick_params(axis='y', colors='white')
+
+    fig.set_facecolor('green')
+    fig.subplots_adjust(left=0.15)
+    fig.subplots_adjust(bottom=0.15)
+
+    draw()
+
+    def init(fig=fig):
+        fig.set_facecolor('green')
+
+    # Plot a segment of the path
+    def update_img(t, pa=pa, pos_des=pos_des, ned=ned, desired_marker=desired_marker, current_marker=current_marker, ned_marker=ned_marker, t0_s=t0_s):
+
+        import numpy as np
+        import matplotlib.pyplot
+
+        # convert to minutes
+        t = t / 60
+
+        idx = np.argmin(abs(np.double(pa['time']) / 60 - t))
+        x = pa['East'][idx,0]
+        y = pa['North'][idx,0]
+        current_marker[0].set_xdata(x)
+        current_marker[0].set_ydata(y)
+
+        idx = np.argmin(abs(np.double(ned['time']) / 60 - t))
+        ned_marker[0].set_xdata(ned['East'][idx])
+        ned_marker[0].set_ydata(ned['North'][idx])
+
+        idx = np.argmin(abs(np.double(pos_des['time']) / 60 - t))
+        delta = abs(np.double(pos_des['time'][idx]) / 60 - t)
+        if delta < (1/60.0):
+            desired_marker[0].set_xdata(pos_des['End'][idx,1])
+            desired_marker[0].set_ydata(pos_des['End'][idx,0])
+
+
+    fig.patch.set_facecolor('green')
+
+    fps = 30.0
+    dpi = 150
+    t = arange(t0_s, t1_s, 1/fps)
+
+    ani = animation.FuncAnimation(fig,update_img,t,init_func=init,interval=0,blit=False)
+    writer = animation.writers['ffmpeg'](fps=30)
+    ani.save(output_filename,dpi=dpi,fps=30,writer=writer,savefig_kwargs={'facecolor':'green'})
+
+
+def main():
+        import sys, os
+        sys.path.insert(1, os.path.dirname(sys.path[0]))
+        from taulabs import telemetry
+        uavo_list = telemetry.GetUavoBasedOnArgs()
+        from taulabs.uavo import UAVO_PositionActual, UAVO_NEDPosition, UAVO_PathDesired
+
+        pa = uavo_list.as_numpy_array(UAVO_PositionActual)
+        ned = uavo_list.as_numpy_array(UAVO_NEDPosition)
+        pos_des = uavo_list.as_numpy_array(UAVO_PathDesired)
+
+        out = "position_overlay.mp4"
+        video_overlay(pa,ned,pos_des,out)
+
+
+if __name__ == "__main__":
+        main()


### PR DESCRIPTION
- Performance 20-30% better depending on workload
- Buffering model changes to not "scrunch down" the packet buffer all the time and instead burn a little RAM.
- Use the precomputed structure unpack even for nested uavos-- now just keep a depth map and restructure the output tuple on demand.
- UAVO class eliminated; additional cleanup in class creation is needed, though (there's a scary method-of-death)
- Various indirection through the UAVO class eliminated too
- Add a simple function to request UAVOs.
- Teach the minimal_connection.py to crudely retrieve configuration from the simulator!

I think I'm getting close to not need nearly so much refactoring at each functional step and I should be able to mostly focus on functional API work from this point.