### PR TITLE
gps: reinit GPS at runtime / issue #1617

### DIFF
--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -81,9 +81,6 @@ static struct pios_thread *gpsTaskHandle;
 
 static char* gps_rx_buffer;
 
-static uint32_t timeOfLastCommandMs;
-static uint32_t timeOfLastUpdateMs;
-
 static struct GPS_RX_STATS gpsRxStats;
 
 // ****************
@@ -190,6 +187,9 @@ static void gpsTask(void *parameters)
 
 	GPSPositionData gpsposition;
 	uint8_t	gpsProtocol;
+
+	uint32_t timeOfLastUpdateMs;
+	uint32_t timeOfLastCommandMs;
 
 	ModuleSettingsGPSDataProtocolGet(&gpsProtocol);
 

--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -242,7 +242,9 @@ static void gpsTask(void *parameters)
 			ModuleSettingsGPSDataProtocolGet(&gpsProtocol);
 
 			gpsConfigure(gpsProtocol);
-			timeOfConfigAttemptMs = loopTimeMs;
+			timeOfConfigAttemptMs = PIOS_Thread_Systime();
+
+			continue;
 		}
 
 		uint8_t c;
@@ -268,7 +270,7 @@ static void gpsTask(void *parameters)
 			}
 
 			if (res == PARSER_COMPLETE) {
-				timeOfLastUpdateMs = PIOS_Thread_Systime();
+				timeOfLastUpdateMs = loopTimeMs;
 			}
 
 			xDelay = 0;	// For now on, don't block / wait,


### PR DESCRIPTION
Fixes issue #1617.  Confirmed to properly reinit at runtime on Sparky2.