### PR TITLE
gps: enable SBAS/DGPS, and select correct dynamics

### DIFF
--- a/flight/Modules/GPS/ubx_cfg.c
+++ b/flight/Modules/GPS/ubx_cfg.c
@@ -270,15 +270,6 @@ static void ubx_cfg_version_specific(uintptr_t gps_port, uint8_t ver) {
     } else if (ver == 7) {
         // 10Hz for ver 7
         ubx_cfg_set_rate(gps_port, (uint16_t)100);
-
-        // History: Code here used to disable SBAS.  A survey of other projects
-        // shows no evidence of a defect with SBAS on Neo-7 modules and there
-        // has been no vendor firmware update to improve / fix SBAS.  There is
-        // no documentation as to what any supposed Neo-7 SBAS defect is.
-        //
-        // This code has been left as a comment for now in case any anomalies
-        // are noticed in this area.
-        // ubx_cfg_set_sbas(gps_port, 0);
     } else if (ver == 6) {
         // 10Hz seems to work on 6
         ubx_cfg_set_rate(gps_port, (uint16_t)100);


### PR DESCRIPTION
FIRST: The dynamic model we were using is the <1g, lightweight dynamics air model.  This is a position filter that tries to figure out how we could possibly be moving.  Normal, full-scale fixed wing airplanes are suggested to use the 2G model, and I've selected this.  We are still more agile than this and should possibly consider using an even more aggressive dynamics model.

Note that this is a tradeoff-- the GPS having an aggressive dynamics model means we will have a less accurate position when sitting / completely still.  But the GPS will be able to react to aircraft movements in a realistic amount of time and will not introduce as much latency and rounding on observations.

SECOND: SBAS/WAAS/DGPS was disabled on Neo-7 and Neo-8 modules.  This is code inherited from autoquad, and no other projects do it (checked Ardupilot, Cleanflight, Openpilot).  There is no vendor update or substantiation of a problem with SBAS with Neo-7 modules.  Note the openpilot platinum receiver is a Neo-7 module, so it can't be completely broken.  This can't be good for our navigation performance.  The code has been changed to explicitly enable SBAS.