### PR TITLE
Fixed logging directory so it defaults to HOME env variable + fixed error prompt

### DIFF
--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -139,8 +139,9 @@ LoggingThread::~LoggingThread()
 bool LoggingThread::openFile(QString file, LoggingPlugin * parent)
 {
     logFile.setFileName(file);
-    logFile.open(QIODevice::WriteOnly);
-
+    if (!logFile.open(QIODevice::WriteOnly)) {
+        return false;
+    }
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
 
@@ -391,7 +392,7 @@ void LoggingPlugin::toggleLogging()
     {
 
         QString fileName = QFileDialog::getSaveFileName(NULL, tr("Start Log"),
-                                    tr("TauLabs-%0.tll").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss")),
+                                    QDir::homePath() + QDir::separator() + tr("TauLabs-%0.tll").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss")),
                                     tr("Tau Labs Log (*.tll)"));
         if (fileName.isEmpty())
             return;


### PR DESCRIPTION
Tested on OS X by running Start Logging and prompt opens in relevant HOME dir.

Also fixed error prompt if GCS can't write to the file location/name specified. - Tested by trying to open logging file in Macintosh HD.
![screen shot 2015-06-02 at 21 06 11](https://cloud.githubusercontent.com/assets/4996098/7946436/867de58a-096e-11e5-87a0-639307e0b1e0.png)
![screen shot 2015-06-02 at 21 17 16](https://cloud.githubusercontent.com/assets/4996098/7946437/869ffd28-096e-11e5-8633-f277e16b14ad.png)

Thanks to mlyle


