### PR TITLE
gcs: add autotune to modules tab

### DIFF
--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -91,6 +91,7 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbUAVOFrskyBridge, ModuleSettings::ADMINSTATE_UAVOFRSKYSENSORHUBBRIDGE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbUAVOFrSkySPortBridge, ModuleSettings::ADMINSTATE_UAVOFRSKYSPORTBRIDGE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbGeofence, ModuleSettings::ADMINSTATE_GEOFENCE);
+    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAutotune, ModuleSettings::ADMINSTATE_AUTOTUNE);
 
     // Connect the voltage and current checkboxes, such that the ADC pins are toggled and vice versa
     connect(ui->gb_measureVoltage, SIGNAL(toggled(bool)), this, SLOT(toggleBatteryMonitoringPin()));
@@ -364,6 +365,9 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
 
     ui->cbGeofence->setProperty(trueString.toLatin1(), "Enabled");
     ui->cbGeofence->setProperty(falseString.toLatin1(), "Disabled");
+
+    ui->cbAutotune->setProperty(trueString.toLatin1(), "Enabled");
+    ui->cbAutotune->setProperty(falseString.toLatin1(), "Disabled");
 
     ui->gb_measureVoltage->setProperty(trueString.toLatin1(), "Enabled");
     ui->gb_measureVoltage->setProperty(falseString.toLatin1(), "Disabled");

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -93,6 +93,9 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbGeofence, ModuleSettings::ADMINSTATE_GEOFENCE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAutotune, ModuleSettings::ADMINSTATE_AUTOTUNE);
 
+    // Don't allow this to be changed here, only in the autotune tab.
+    ui->cbAutotune->setDisabled(true);
+
     // Connect the voltage and current checkboxes, such that the ADC pins are toggled and vice versa
     connect(ui->gb_measureVoltage, SIGNAL(toggled(bool)), this, SLOT(toggleBatteryMonitoringPin()));
     connect(ui->gb_measureCurrent, SIGNAL(toggled(bool)), this, SLOT(toggleBatteryMonitoringPin()));
@@ -443,6 +446,10 @@ void ConfigModuleWidget::recheckTabs()
     obj = getObjectManager()->getObject(PicoCSettings::NAME);
     connect(obj, SIGNAL(transactionCompleted(UAVObject*,bool)), this, SLOT(objectUpdated(UAVObject*,bool)), Qt::UniqueConnection);
     obj->requestUpdate();
+
+    // This requires re-evaluation so that board connection doesn't re-enable
+    // the field.
+    ui->cbAutotune->setDisabled(true);
 }
 
 //! Enable appropriate tab when objects are updated

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -192,6 +192,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="cbAutotune">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the autotune module, which allows the autotune flight mode to gather information on flight characteristics.  See the Autotune configuration tab for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Autotune</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="cbUAVOFrSkySPortBridge">
          <property name="text">
           <string>FrSky S.PORT Telemetry</string>

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -194,7 +194,7 @@
        <item>
         <widget class="QCheckBox" name="cbAutotune">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the autotune module, which allows the autotune flight mode to gather information on flight characteristics.  See the Autotune configuration tab for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The autotune module enables automated tuning of PIDs from observed flight characteristics.  See the Autotune configuration tab for more information and to enable this module.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Autotune</string>


### PR DESCRIPTION
I agree the enabling button should stay at the bottom of the current autotune page.  But it's nice to see when you're enabling modules whether or not it's enabled (so you don't blow through resources).. and it has caused some user confusion / support requests as to why autotune is not in the modules list.

(Confused me as a new user, as well).