### PR TITLE
ARMING: add selectable delay to switch

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -523,10 +523,10 @@ static bool arming_position(ManualControlCommandData * cmd, ManualControlSetting
 			(cmd->Pitch > ARMED_THRESHOLD);
 			// Note that pulling pitch stick down corresponds to positive values
 	case MANUALCONTROLSETTINGS_ARMING_SWITCH:
-	case MANUALCONTROLSETTINGS_ARMING_SWITCHTIME:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHDELAY:
 		return cmd->ArmSwitch == MANUALCONTROLCOMMAND_ARMSWITCH_ARMED;
 	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE:
-	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLETIME:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLEDELAY:
 		return lowThrottle && cmd->ArmSwitch == MANUALCONTROLCOMMAND_ARMSWITCH_ARMED;
 	default:
 		return false;
@@ -558,9 +558,9 @@ static bool disarming_position(ManualControlCommandData * cmd, ManualControlSett
 			(cmd->Yaw > ARMED_THRESHOLD || cmd->Yaw < -ARMED_THRESHOLD) &&
 			(cmd->Roll > ARMED_THRESHOLD || cmd->Roll < -ARMED_THRESHOLD) );
 	case MANUALCONTROLSETTINGS_ARMING_SWITCH:
-	case MANUALCONTROLSETTINGS_ARMING_SWITCHTIME:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHDELAY:
 	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE:
-	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLETIME:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLEDELAY:
 		return cmd->ArmSwitch != MANUALCONTROLCOMMAND_ARMSWITCH_ARMED;
 	default:
 		return false;
@@ -678,9 +678,9 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 
   		bool disarm = disarming_position(cmd, settings) && valid;
 		if (disarm && (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCH ||
-				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTIME ||
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHDELAY ||
 				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE ||
-				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLETIME)) {
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLEDELAY)) {
 			arm_state = ARM_STATE_DISARMED;
 		} else if (disarm) {
 			armedDisarmStart = lastSysTime;

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -523,8 +523,10 @@ static bool arming_position(ManualControlCommandData * cmd, ManualControlSetting
 			(cmd->Pitch > ARMED_THRESHOLD);
 			// Note that pulling pitch stick down corresponds to positive values
 	case MANUALCONTROLSETTINGS_ARMING_SWITCH:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHTIME:
 		return cmd->ArmSwitch == MANUALCONTROLCOMMAND_ARMSWITCH_ARMED;
 	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLETIME:
 		return lowThrottle && cmd->ArmSwitch == MANUALCONTROLCOMMAND_ARMSWITCH_ARMED;
 	default:
 		return false;
@@ -556,7 +558,9 @@ static bool disarming_position(ManualControlCommandData * cmd, ManualControlSett
 			(cmd->Yaw > ARMED_THRESHOLD || cmd->Yaw < -ARMED_THRESHOLD) &&
 			(cmd->Roll > ARMED_THRESHOLD || cmd->Roll < -ARMED_THRESHOLD) );
 	case MANUALCONTROLSETTINGS_ARMING_SWITCH:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHTIME:
 	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE:
+	case MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLETIME:
 		return cmd->ArmSwitch != MANUALCONTROLCOMMAND_ARMSWITCH_ARMED;
 	default:
 		return false;
@@ -611,7 +615,7 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		bool arm = arming_position(cmd, settings) && valid;
 
 		if (arm && (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCH ||
-		       settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE)) {
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE)) {
 			arm_state = ARM_STATE_ARMED;
 		} else if (arm) {
 			armedDisarmStart = lastSysTime;
@@ -674,7 +678,9 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 
   		bool disarm = disarming_position(cmd, settings) && valid;
 		if (disarm && (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCH ||
-		       settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE)) {
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTIME ||
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE ||
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLETIME)) {
 			arm_state = ARM_STATE_DISARMED;
 		} else if (disarm) {
 			armedDisarmStart = lastSysTime;

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -1427,7 +1427,8 @@ Set to 0 to disable (recommended for soaring fixed wings).</string>
               <item>
                <widget class="QLabel" name="label_3">
                 <property name="text">
-                 <string>Airframe disarm is done by throttle off and opposite of above combination, except in the case of the switch option. For switch the throttle is ignored.</string>
+                 <string>Airframe disarm is done by throttle off and opposite of above combination, except in the case of the switch option. For switch only the throttle is ignored.
+Note: In switch configuration without delay, zeroing the gyros while arming is not possible.</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -114,7 +114,9 @@
 				<option>Yaw Right</option>
 				<option>Corners</option>
 				<option>Switch</option>
+				<option>Switch+Time</option>
 				<option>Switch+Throttle</option>
+				<option>Switch+Throttle+Time</option>
 			</options>
 		</field>
 		<field name="ArmTime" units="ms" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -114,9 +114,9 @@
 				<option>Yaw Right</option>
 				<option>Corners</option>
 				<option>Switch</option>
-				<option>Switch+Time</option>
+				<option>Switch+Delay</option>
 				<option>Switch+Throttle</option>
-				<option>Switch+Throttle+Time</option>
+				<option>Switch+Throttle+Delay</option>
 			</options>
 		</field>
 		<field name="ArmTime" units="ms" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>


### PR DESCRIPTION
This adds a selectable delay to arming by switch(+thottle). Zeroing the
gyros while arming the vehicle is not functional in switch mode only.
The result may be a poor flight performance on aggressively tuned
copters. Now you can select between immediately and delayed
arming. In delayed arming the gyro calibration is functional again.