### PR TITLE
FlyingF4 extended support: ADC / Battery, UART4 and UART5

### DIFF
--- a/flight/targets/flyingf4/board-info/board_hw_defs.c
+++ b/flight/targets/flyingf4/board-info/board_hw_defs.c
@@ -790,6 +790,71 @@ static const struct pios_usart_cfg pios_usart3_cfg = {
 
 /* uart 4 and 5 are RX only and available */
 
+static const struct pios_usart_cfg pios_usart4_cfg = {
+	.regs = UART4,
+	.remap = GPIO_AF_UART4,
+	.init = {
+		.USART_BaudRate = 57600,
+		.USART_WordLength = USART_WordLength_8b,
+		.USART_Parity = USART_Parity_No,
+		.USART_StopBits = USART_StopBits_1,
+		.USART_HardwareFlowControl = USART_HardwareFlowControl_None,
+		.USART_Mode = USART_Mode_Rx,
+	},
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel = UART4_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
+			.NVIC_IRQChannelSubPriority = 0,
+			.NVIC_IRQChannelCmd = ENABLE,
+		},
+	},
+	.rx = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_11,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource11,
+	},
+};
+
+static const struct pios_usart_cfg pios_usart5_cfg = {
+	.regs = UART5,
+	.remap = GPIO_AF_UART5,
+	.init = {
+		.USART_BaudRate = 57600,
+		.USART_WordLength = USART_WordLength_8b,
+		.USART_Parity = USART_Parity_No,
+		.USART_StopBits = USART_StopBits_1,
+		.USART_HardwareFlowControl = USART_HardwareFlowControl_None,
+		.USART_Mode = USART_Mode_Rx,
+	},
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel = UART5_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
+			.NVIC_IRQChannelSubPriority = 0,
+			.NVIC_IRQChannelCmd = ENABLE,
+		},
+	},
+	.rx = {
+		.gpio = GPIOD,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_2,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource2,
+	},
+};
+
+
 #endif  /* PIOS_INCLUDE_USART */
 
 #if defined(PIOS_INCLUDE_COM)
@@ -1683,6 +1748,48 @@ const struct pios_usb_hid_cfg pios_usb_hid_cfg = {
 	.data_tx_ep = 1,
 };
 #endif	/* PIOS_INCLUDE_USB_HID && PIOS_INCLUDE_USB_CDC */
+
+#if defined(PIOS_INCLUDE_ADC)
+#include "pios_adc_priv.h"
+#include "pios_internal_adc_priv.h"
+
+static void PIOS_ADC_DMA_irq_handler(void);
+void DMA2_Stream4_IRQHandler(void) __attribute__((alias("PIOS_ADC_DMA_irq_handler")));
+struct pios_internal_adc_cfg pios_adc_cfg = {
+	.adc_dev_master = ADC1,
+	.dma = {
+		.irq = {
+			.flags = (DMA_FLAG_TCIF4 | DMA_FLAG_TEIF4 | DMA_FLAG_HTIF4),
+			.init = {
+				.NVIC_IRQChannel = DMA2_Stream4_IRQn,
+				.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
+				.NVIC_IRQChannelSubPriority = 0,
+				.NVIC_IRQChannelCmd = ENABLE,
+			},
+		},
+		.rx = {
+			.channel = DMA2_Stream4,
+			.init = {
+				.DMA_Channel = DMA_Channel_0,
+				.DMA_PeripheralBaseAddr = (uint32_t)&ADC1->DR
+			},
+		}
+	},
+	.half_flag = DMA_IT_HTIF4,
+	.full_flag = DMA_IT_TCIF4,
+	
+};
+
+void PIOS_ADC_DMA_irq_handler(void)
+{
+	/* Call into the generic code to handle the IRQ for this specific device */
+	PIOS_INTERNAL_ADC_DMA_Handler();
+}
+
+#endif /* PIOS_INCLUDE_ADC */
+
+
+
 
 /**
  * @}

--- a/flight/targets/flyingf4/board-info/pios_board.h
+++ b/flight/targets/flyingf4/board-info/pios_board.h
@@ -226,13 +226,13 @@ extern uintptr_t pios_com_debug_id;
 // PIOS_ADC_PinGet(0) = PC_11
 // PIOS_ADC_PinGet(1) = PC_12
 //-------------------------
-#define PIOS_DMA_PIN_CONFIG																	\
-{																							\
-	{ GPIOC,	GPIO_Pin_1,		ADC_Channel_11 },											\
-	{ GPIOC,	GPIO_Pin_2,		ADC_Channel_12 },											\
-	{ NULL,		0,				ADC_Channel_Vrefint },		/* Voltage reference */			\
-	{ NULL,		0,				ADC_Channel_TempSensor },	/* Temperature sensor */		\
-	{ GPIOC,	GPIO_Pin_1,		ADC_Channel_11 }											\
+#define PIOS_DMA_PIN_CONFIG                                                       \
+{                                                                                 \
+	{ GPIOC, GPIO_Pin_1,     ADC_Channel_11         },                            \
+	{ GPIOC, GPIO_Pin_2,     ADC_Channel_12         },                            \
+	{ NULL,  0,              ADC_Channel_Vrefint    },  /* Voltage reference */   \
+	{ NULL,  0,              ADC_Channel_TempSensor },  /* Temperature sensor */  \
+	{ GPIOC, GPIO_Pin_1,     ADC_Channel_11         }                             \
 }
 
 /* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */

--- a/flight/targets/flyingf4/board-info/pios_board.h
+++ b/flight/targets/flyingf4/board-info/pios_board.h
@@ -226,13 +226,13 @@ extern uintptr_t pios_com_debug_id;
 // PIOS_ADC_PinGet(0) = PC_11
 // PIOS_ADC_PinGet(1) = PC_12
 //-------------------------
-#define PIOS_DMA_PIN_CONFIG                                                                   \
-{                                                                                             \
-	{ GPIOC, GPIO_Pin_1,     ADC_Channel_11 },                                                 \
-	{ GPIOC, GPIO_Pin_2,     ADC_Channel_12 },                                                 \
-	{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
-	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
-	{ GPIOC, GPIO_Pin_1,    ADC_Channel_11 }        \
+#define PIOS_DMA_PIN_CONFIG																	\
+{																							\
+	{ GPIOC,	GPIO_Pin_1,		ADC_Channel_11 },											\
+	{ GPIOC,	GPIO_Pin_2,		ADC_Channel_12 },											\
+	{ NULL,		0,				ADC_Channel_Vrefint },		/* Voltage reference */			\
+	{ NULL,		0,				ADC_Channel_TempSensor },	/* Temperature sensor */		\
+	{ GPIOC,	GPIO_Pin_1,		ADC_Channel_11 }											\
 }
 
 /* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */

--- a/flight/targets/flyingf4/board-info/pios_board.h
+++ b/flight/targets/flyingf4/board-info/pios_board.h
@@ -223,7 +223,27 @@ extern uintptr_t pios_com_debug_id;
 //-------------------------
 #define PIOS_ADC_SUB_DRIVER_MAX_INSTANCES       3
 
-#define VREF_PLUS				3.0f
+// PIOS_ADC_PinGet(0) = PC_11
+// PIOS_ADC_PinGet(1) = PC_12
+//-------------------------
+#define PIOS_DMA_PIN_CONFIG                                                                   \
+{                                                                                             \
+	{ GPIOC, GPIO_Pin_1,     ADC_Channel_11 },                                                 \
+	{ GPIOC, GPIO_Pin_2,     ADC_Channel_12 },                                                 \
+	{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
+	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
+	{ GPIOC, GPIO_Pin_1,    ADC_Channel_11 }        \
+}
+
+/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
+/* which is annoying because this then determines the rate at which we generate buffer turnover events */
+/* the objective here is to get enough buffer space to support 100Hz averaging rate */
+#define PIOS_ADC_NUM_CHANNELS           4
+#define PIOS_ADC_MAX_OVERSAMPLING       2
+#define PIOS_ADC_USE_ADC2               0
+
+#define VREF_PLUS			3.3
+
 
 //-------------------------
 // USB

--- a/flight/targets/flyingf4/board-info/pios_board.h
+++ b/flight/targets/flyingf4/board-info/pios_board.h
@@ -228,11 +228,11 @@ extern uintptr_t pios_com_debug_id;
 //-------------------------
 #define PIOS_DMA_PIN_CONFIG                                                       \
 {                                                                                 \
-	{ GPIOC, GPIO_Pin_1,     ADC_Channel_11         },                            \
-	{ GPIOC, GPIO_Pin_2,     ADC_Channel_12         },                            \
-	{ NULL,  0,              ADC_Channel_Vrefint    },  /* Voltage reference */   \
-	{ NULL,  0,              ADC_Channel_TempSensor },  /* Temperature sensor */  \
-	{ GPIOC, GPIO_Pin_1,     ADC_Channel_11         }                             \
+    { GPIOC, GPIO_Pin_1,     ADC_Channel_11         },                            \
+    { GPIOC, GPIO_Pin_2,     ADC_Channel_12         },                            \
+    { NULL,  0,              ADC_Channel_Vrefint    },  /* Voltage reference */   \
+    { NULL,  0,              ADC_Channel_TempSensor },  /* Temperature sensor */  \
+    { GPIOC, GPIO_Pin_1,     ADC_Channel_11         }                             \
 }
 
 /* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
@@ -242,7 +242,7 @@ extern uintptr_t pios_com_debug_id;
 #define PIOS_ADC_MAX_OVERSAMPLING       2
 #define PIOS_ADC_USE_ADC2               0
 
-#define VREF_PLUS			3.3
+#define VREF_PLUS                       3.3
 
 
 //-------------------------

--- a/flight/targets/flyingf4/fw/pios_board.c
+++ b/flight/targets/flyingf4/fw/pios_board.c
@@ -783,6 +783,35 @@ void PIOS_Board_Init(void) {
 	}
 
 
+	/* UART4 Port */
+	uint8_t hw_uart4;
+	HwFlyingF4Uart4Get(&hw_uart4);
+	switch (hw_uart4) {
+	case HWFLYINGF4_UART4_DISABLED:
+		break;
+	case HWFLYINGF4_UART4_GPS:
+#if defined(PIOS_INCLUDE_GPS) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
+		PIOS_Board_configure_com(&pios_usart4_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_GPS_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_gps_id);
+#endif
+		break;
+	}
+
+	/* UART5 Port */
+	uint8_t hw_uart5;
+	HwFlyingF4Uart5Get(&hw_uart5);
+	switch (hw_uart5) {
+	case HWFLYINGF4_UART5_DISABLED:
+		break;
+	case HWFLYINGF4_UART5_GPS:
+#if defined(PIOS_INCLUDE_GPS) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
+		PIOS_Board_configure_com(&pios_usart5_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_GPS_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_gps_id);
+#endif
+		break;
+	}
+
+	
+	
+	
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;
 	HwFlyingF4RcvrPortGet(&hw_rcvrport);

--- a/flight/targets/flyingf4/fw/pios_board.c
+++ b/flight/targets/flyingf4/fw/pios_board.c
@@ -170,6 +170,8 @@ uintptr_t pios_com_frsky_sport_id;
 uintptr_t pios_uavo_settings_fs_id;
 uintptr_t pios_waypoints_settings_fs_id;
 
+uintptr_t pios_internal_adc_id = 0;
+
 /*
  * Setup a com port based on the passed cfg, driver and buffer sizes. rx or tx size of 0 disables rx or tx
  */
@@ -1020,7 +1022,9 @@ void PIOS_Board_Init(void) {
 #endif
 
 #if defined(PIOS_INCLUDE_ADC)
-	PIOS_ADC_Init(&pios_adc_cfg);
+	uint32_t internal_adc_id;
+	PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);
+	PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);	
 #endif
 
 	/* Make sure we have at least one telemetry link configured or else fail initialization */

--- a/flight/targets/flyingf4/fw/pios_config.h
+++ b/flight/targets/flyingf4/fw/pios_config.h
@@ -35,7 +35,7 @@
 #define PIOS_INCLUDE_BL_HELPER
 
 /* Enable/Disable PiOS Modules */
-//#define PIOS_INCLUDE_ADC
+#define PIOS_INCLUDE_ADC
 #define PIOS_INCLUDE_DELAY
 #define PIOS_INCLUDE_I2C
 #define WDG_STATS_DIAGNOSTICS
@@ -94,6 +94,8 @@
 #define PIOS_INCLUDE_LOGFS_SETTINGS
 #define PIOS_INCLUDE_FLASH_JEDEC
 #define PIOS_INCLUDE_FLASH_INTERNAL
+
+//#define PIOS_INCLUDE_DEBUG_CONSOLE
 
 /* Flags that alter behaviors - mostly to lower resources for CC */
 #define PIOS_INCLUDE_INITCALL           /* Include init call structures */

--- a/shared/uavobjectdefinition/hwflyingf4.xml
+++ b/shared/uavobjectdefinition/hwflyingf4.xml
@@ -54,6 +54,24 @@
 			</options>
 		</field>
 
+		<field name="Uart4" units="function" type="enum" elements="1"  defaultvalue="Disabled">
+			<options>
+				<option>Disabled</option>
+				<option>S.Bus</option>
+				<option>GPS</option>
+				<option>MavLinkTX_GPS_RX</option>
+			</options>
+		</field>
+	
+		<field name="Uart5" units="function" type="enum" elements="1"  defaultvalue="Disabled">
+			<options>
+				<option>Disabled</option>
+				<option>S.Bus</option>
+				<option>GPS</option>
+				<option>MavLinkTX_GPS_RX</option>
+			</options>
+		</field>	
+		
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" options="USBTelemetry,RCTransmitter,Disabled" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" options="USBTelemetry,ComBridge,DebugConsole,PicoC,Disabled" defaultvalue="Disabled"/>
 

--- a/shared/uavobjectdefinition/hwflyingf4.xml
+++ b/shared/uavobjectdefinition/hwflyingf4.xml
@@ -57,18 +57,14 @@
 		<field name="Uart4" units="function" type="enum" elements="1"  defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>
-				<option>S.Bus</option>
 				<option>GPS</option>
-				<option>MavLinkTX_GPS_RX</option>
 			</options>
 		</field>
 	
 		<field name="Uart5" units="function" type="enum" elements="1"  defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>
-				<option>S.Bus</option>
 				<option>GPS</option>
-				<option>MavLinkTX_GPS_RX</option>
 			</options>
 		</field>	
 		


### PR DESCRIPTION
Hi,
This patchset enable following FlyingF4 components:
ADC in PC1 and PC2 pins (battery monitor can be enabled now)
UART4-RX in PC11 pin.
UART5-RX in PD2 pin.

Support UART4 and UART5 in GCS
