### PR TITLE
paths: simplify constants/remove "DRIVE"

### DIFF
--- a/flight/Libraries/paths.c
+++ b/flight/Libraries/paths.c
@@ -68,16 +68,13 @@ void path_progress(const PathDesiredData *pathDesired,
 	float end_point[2] = {pathDesired->End[0],pathDesired->End[1]};
 
 	switch(mode) {
-		case PATHDESIRED_MODE_FLYVECTOR:
-		case PATHDESIRED_MODE_DRIVEVECTOR:
+		case PATHDESIRED_MODE_VECTOR:
 			return path_vector(start_point, end_point, cur_point, status);
 			break;
-		case PATHDESIRED_MODE_FLYCIRCLERIGHT:
-		case PATHDESIRED_MODE_DRIVECIRCLERIGHT:
+		case PATHDESIRED_MODE_CIRCLERIGHT:
 			return path_curve(start_point, end_point, pathDesired->ModeParameters, cur_point, status, 1);
 			break;
-		case PATHDESIRED_MODE_FLYCIRCLELEFT:
-		case PATHDESIRED_MODE_DRIVECIRCLELEFT:
+		case PATHDESIRED_MODE_CIRCLELEFT:
 			return path_curve(start_point, end_point, pathDesired->ModeParameters, cur_point, status, 0);
 			break;
 		case PATHDESIRED_MODE_CIRCLEPOSITIONLEFT:
@@ -86,8 +83,7 @@ void path_progress(const PathDesiredData *pathDesired,
 		case PATHDESIRED_MODE_CIRCLEPOSITIONRIGHT:
 			return path_circle(end_point, pathDesired->ModeParameters, cur_point, status, 1);
 			break;
-		case PATHDESIRED_MODE_FLYENDPOINT:
-		case PATHDESIRED_MODE_DRIVEENDPOINT:
+		case PATHDESIRED_MODE_ENDPOINT:
 		case PATHDESIRED_MODE_HOLDPOSITION:
 		default:
 			// use the endpoint as default failsafe if called in unknown modes

--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -269,10 +269,10 @@ static void pathfollowerTask(void *parameters)
 
 				PathDesiredGet(&pathDesired);
 				switch(pathDesired.Mode) {
-					case PATHDESIRED_MODE_FLYENDPOINT:
-					case PATHDESIRED_MODE_FLYVECTOR:
-					case PATHDESIRED_MODE_FLYCIRCLERIGHT:
-					case PATHDESIRED_MODE_FLYCIRCLELEFT:
+					case PATHDESIRED_MODE_ENDPOINT:
+					case PATHDESIRED_MODE_VECTOR:
+					case PATHDESIRED_MODE_CIRCLERIGHT:
+					case PATHDESIRED_MODE_CIRCLELEFT:
 						break;
 					default:
 						state = FW_FOLLOWER_ERR;
@@ -342,17 +342,13 @@ static void updatePathVelocity()
 	float groundspeed = 0;
 	float altitudeSetpoint = 0;
 	switch (pathDesired.Mode) {
-		case PATHDESIRED_MODE_FLYCIRCLERIGHT:
-		case PATHDESIRED_MODE_DRIVECIRCLERIGHT:
-		case PATHDESIRED_MODE_FLYCIRCLELEFT:
-		case PATHDESIRED_MODE_DRIVECIRCLELEFT:
+		case PATHDESIRED_MODE_CIRCLERIGHT:
+		case PATHDESIRED_MODE_CIRCLELEFT:
 			groundspeed = pathDesired.EndingVelocity;
 			altitudeSetpoint = pathDesired.End[2];
 			break;
-		case PATHDESIRED_MODE_FLYENDPOINT:
-		case PATHDESIRED_MODE_DRIVEENDPOINT:
-		case PATHDESIRED_MODE_FLYVECTOR:
-		case PATHDESIRED_MODE_DRIVEVECTOR:
+		case PATHDESIRED_MODE_ENDPOINT:
+		case PATHDESIRED_MODE_VECTOR:
 		default:
 			groundspeed = pathDesired.StartingVelocity + (pathDesired.EndingVelocity - pathDesired.StartingVelocity) *
 				bound_min_max(progress.fractional_progress,0,1);

--- a/flight/Modules/GroundPathFollower/groundpathfollower.c
+++ b/flight/Modules/GroundPathFollower/groundpathfollower.c
@@ -210,13 +210,13 @@ static void groundPathFollowerTask(void *parameters)
 				}
 				break;
 			case FLIGHTSTATUS_FLIGHTMODE_PATHPLANNER:
-				if (pathDesired.Mode == PATHDESIRED_MODE_FLYENDPOINT ||
+				if (pathDesired.Mode == PATHDESIRED_MODE_ENDPOINT ||
 					pathDesired.Mode == PATHDESIRED_MODE_HOLDPOSITION) {
 					updateEndpointVelocity();
 					updateGroundDesiredAttitude();
-				} else if (pathDesired.Mode == PATHDESIRED_MODE_FLYVECTOR ||
-					pathDesired.Mode == PATHDESIRED_MODE_FLYCIRCLELEFT ||
-					pathDesired.Mode == PATHDESIRED_MODE_FLYCIRCLERIGHT) {
+				} else if (pathDesired.Mode == PATHDESIRED_MODE_VECTOR ||
+					pathDesired.Mode == PATHDESIRED_MODE_CIRCLELEFT ||
+					pathDesired.Mode == PATHDESIRED_MODE_CIRCLERIGHT) {
 					updatePathVelocity();
 					updateGroundDesiredAttitude();
 				} else {

--- a/flight/Modules/PathPlanner/path_saving.c
+++ b/flight/Modules/PathPlanner/path_saving.c
@@ -59,7 +59,7 @@ int32_t pathplanner_save_path(uint32_t path_id)
 		WaypointInstGet(i, &waypoint);
 
 		// Stop saving when get to invalid waypoint.  Nothing after or including is valid
-		if (waypoint.Mode == WAYPOINT_MODE_INVALID || waypoint.Mode == WAYPOINT_MODE_STOP)
+		if (waypoint.Mode == WAYPOINT_MODE_INVALID)
 			break;
 
 		retval = PIOS_FLASHFS_ObjSave(pios_waypoints_settings_fs_id, path_id, i, (uint8_t *) &waypoint, waypoint_size);
@@ -67,7 +67,7 @@ int32_t pathplanner_save_path(uint32_t path_id)
 	}
 
 	// Use an explicit indication of the end of path
-	waypoint.Mode = WAYPOINT_MODE_STOP;
+	waypoint.Mode = WAYPOINT_MODE_INVALID;
 	retval = PIOS_FLASHFS_ObjSave(pios_waypoints_settings_fs_id, path_id, ++last_save_id,
 	                              (uint8_t *) &waypoint, waypoint_size);
 
@@ -106,7 +106,7 @@ int32_t pathplanner_load_path(uint32_t path_id)
 		if (retval == 0) {
 
 			// Indicates end of path
-			if (waypoint.Mode == WAYPOINT_MODE_STOP)
+			if (waypoint.Mode == WAYPOINT_MODE_INVALID)
 				break;
 
 			// Loaded waypoint locally, store in UAVO manager

--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -301,10 +301,6 @@ static bool waypointValid(int32_t idx) {
 		return false;
 	}
 
-	if (waypoint.Mode == WAYPOINT_MODE_STOP) {
-		return false;
-	}
-
 	return true;
 }
 

--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -367,17 +367,17 @@ static void activateWaypoint(int idx)
 	// Use this to ensure the cases match up (catastrophic if not) and to cover any cases
 	// that don't make sense to come from the path planner
 	switch(waypoint.Mode) {
-		case WAYPOINT_MODE_FLYVECTOR:
-			pathDesired.Mode = PATHDESIRED_MODE_FLYVECTOR;
+		case WAYPOINT_MODE_VECTOR:
+			pathDesired.Mode = PATHDESIRED_MODE_VECTOR;
 			break;
-		case WAYPOINT_MODE_FLYENDPOINT:
-			pathDesired.Mode = PATHDESIRED_MODE_FLYENDPOINT;
+		case WAYPOINT_MODE_ENDPOINT:
+			pathDesired.Mode = PATHDESIRED_MODE_ENDPOINT;
 			break;
-		case WAYPOINT_MODE_FLYCIRCLELEFT:
-			pathDesired.Mode = PATHDESIRED_MODE_FLYCIRCLELEFT;
+		case WAYPOINT_MODE_CIRCLELEFT:
+			pathDesired.Mode = PATHDESIRED_MODE_CIRCLELEFT;
 			break;
-		case WAYPOINT_MODE_FLYCIRCLERIGHT:
-			pathDesired.Mode = PATHDESIRED_MODE_FLYCIRCLERIGHT;
+		case WAYPOINT_MODE_CIRCLERIGHT:
+			pathDesired.Mode = PATHDESIRED_MODE_CIRCLERIGHT;
 			break;
 		case WAYPOINT_MODE_LAND:
 			pathDesired.Mode = PATHDESIRED_MODE_LAND;
@@ -503,7 +503,7 @@ static void createPathBox()
 	// Draw O
 	WaypointData waypoint;
 	waypoint.Velocity = 2.5;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 
 	waypoint.Position[0] = 0;
 	waypoint.Position[1] = 0;
@@ -517,8 +517,7 @@ static void createPathBox()
 
 	waypoint.Position[0] = -5;
 	waypoint.Position[1] = 5;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
-	//waypoint.Mode = WAYPOINT_MODE_FLYCIRCLERIGHT;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	waypoint.ModeParameters = 35;
 	WaypointInstSet(2, &waypoint);
 
@@ -536,7 +535,7 @@ static void createPathBox()
 
 	waypoint.Position[0] = 0;
 	waypoint.Position[1] = 0;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	WaypointInstSet(6, &waypoint);
 }
 
@@ -545,7 +544,7 @@ static void createPathLogo()
 	// Draw O
 	WaypointData waypoint;
 	waypoint.Velocity = 5; // Since for now this isn't directional just set a mag
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	waypoint.ModeParameters = 0;
 	waypoint.Position[2] = -20;
 
@@ -570,67 +569,66 @@ static void createPathLogo()
 
 	waypoint.Position[0] = -26.42;
 	waypoint.Position[1] = -69.30;
-	waypoint.Mode = WAYPOINT_MODE_FLYCIRCLELEFT;
+	waypoint.Mode = WAYPOINT_MODE_CIRCLELEFT;
 	waypoint.ModeParameters = 10;
 	WaypointCreateInstance();
 	WaypointInstSet(4, &waypoint);
 
 	waypoint.Position[0] = -27.06;
 	waypoint.Position[1] = -59.58;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	waypoint.ModeParameters = 0;
 	WaypointCreateInstance();
 	WaypointInstSet(5, &waypoint);
 
 	waypoint.Position[0] = -22.37;
 	waypoint.Position[1] = -51.81;
-	waypoint.Mode = WAYPOINT_MODE_FLYCIRCLELEFT;
+	waypoint.Mode = WAYPOINT_MODE_CIRCLELEFT;
 	waypoint.ModeParameters = 8;
 	WaypointCreateInstance();
 	WaypointInstSet(6, &waypoint);
 
 	waypoint.Position[0] = -4.25;
 	waypoint.Position[1] = -38.64;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	waypoint.ModeParameters = 0;
 	WaypointCreateInstance();
 	WaypointInstSet(7, &waypoint);
 
 	waypoint.Position[0] = 6.33;
 	waypoint.Position[1] = -45.74;
-	waypoint.Mode = WAYPOINT_MODE_FLYCIRCLELEFT;
+	waypoint.Mode = WAYPOINT_MODE_CIRCLELEFT;
 	waypoint.ModeParameters = 10;
 	WaypointCreateInstance();
 	WaypointInstSet(8, &waypoint);
 
 	waypoint.Position[0] = -5.11;
 	waypoint.Position[1] = -52.46;
-	waypoint.Mode = WAYPOINT_MODE_FLYCIRCLELEFT;
+	waypoint.Mode = WAYPOINT_MODE_CIRCLELEFT;
 	waypoint.ModeParameters = 10;
 	WaypointCreateInstance();
 	WaypointInstSet(9, &waypoint);
 
 	waypoint.Position[0] = -26.84;
 	waypoint.Position[1] = -41.45;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	waypoint.ModeParameters = 0;
 	WaypointCreateInstance();
 	WaypointInstSet(10, &waypoint);
 
 	waypoint.Position[0] = -18.11;
 	waypoint.Position[1] = -34.11;
-	waypoint.Mode = WAYPOINT_MODE_FLYCIRCLERIGHT;
+	waypoint.Mode = WAYPOINT_MODE_CIRCLERIGHT;
 	waypoint.ModeParameters = 10;
 	WaypointCreateInstance();
 	WaypointInstSet(11, &waypoint);
 
 	waypoint.Position[0] = -10.65;
 	waypoint.Position[1] = -3.45;
-	waypoint.Mode = WAYPOINT_MODE_FLYVECTOR;
+	waypoint.Mode = WAYPOINT_MODE_VECTOR;
 	waypoint.ModeParameters = 0;
 	WaypointCreateInstance();
 	WaypointInstSet(12, &waypoint);
-
 }
 
 /**

--- a/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
@@ -512,7 +512,7 @@ static int32_t do_requested_path()
 			vtol_hold_position_ned[i] = vtol_fsm_path_desired.End[i];
 		return do_land();
 	case PATHDESIRED_MODE_HOLDPOSITION:
-	case PATHDESIRED_MODE_FLYENDPOINT:
+	case PATHDESIRED_MODE_ENDPOINT:
 		for (uint8_t i = 0; i < 3; i++)
 			vtol_hold_position_ned[i] = vtol_fsm_path_desired.End[i];
 		return do_hold();
@@ -641,7 +641,7 @@ static void hold_position(float north, float east, float down)
 	vtol_fsm_path_desired.End[2] = down;
 	vtol_fsm_path_desired.StartingVelocity = 0;
 	vtol_fsm_path_desired.EndingVelocity   = 0;
-	vtol_fsm_path_desired.Mode = PATHDESIRED_MODE_FLYENDPOINT;
+	vtol_fsm_path_desired.Mode = PATHDESIRED_MODE_ENDPOINT;
 	vtol_fsm_path_desired.ModeParameters = 0;
 	PathDesiredSet(&vtol_fsm_path_desired);
 }
@@ -736,7 +736,7 @@ static void go_enable_fly_home()
 	vtol_fsm_path_desired.StartingVelocity = RTH_VELOCITY;
 	vtol_fsm_path_desired.EndingVelocity = RTH_VELOCITY;
 
-	vtol_fsm_path_desired.Mode = PATHDESIRED_MODE_FLYVECTOR;
+	vtol_fsm_path_desired.Mode = PATHDESIRED_MODE_VECTOR;
 	vtol_fsm_path_desired.ModeParameters = 0;
 
 	PathDesiredSet(&vtol_fsm_path_desired);

--- a/ground/gcs/src/plugins/magicwaypoint/magicwaypointgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/magicwaypoint/magicwaypointgadgetwidget.cpp
@@ -135,7 +135,7 @@ void MagicWaypointGadgetWidget::positionSelected(double north, double east) {
     PathDesired::DataFields pathDesired = getPathDesired()->getData();
     pathDesired.End[PathDesired::END_NORTH] = north * scale;
     pathDesired.End[PathDesired::END_EAST] = east * scale;
-    pathDesired.Mode = PathDesired::MODE_FLYENDPOINT;
+    pathDesired.Mode = PathDesired::MODE_ENDPOINT;
     getPathDesired()->setData(pathDesired);
 }
 

--- a/ground/gcs/src/plugins/opmap/modelmapproxy.cpp
+++ b/ground/gcs/src/plugins/opmap/modelmapproxy.cpp
@@ -97,18 +97,14 @@ ModelMapProxy::overlayType ModelMapProxy::overlayTranslate(int type)
 {
     switch(type)
     {
-    case Waypoint::MODE_FLYENDPOINT:
-    case Waypoint::MODE_FLYVECTOR:
-    case Waypoint::MODE_DRIVEENDPOINT:
-    case Waypoint::MODE_DRIVEVECTOR:
+    case Waypoint::MODE_ENDPOINT:
+    case Waypoint::MODE_VECTOR:
         return OVERLAY_LINE;
         break;
-    case Waypoint::MODE_FLYCIRCLERIGHT:
-    case Waypoint::MODE_DRIVECIRCLERIGHT:
+    case Waypoint::MODE_CIRCLERIGHT:
         return OVERLAY_CURVE_RIGHT;
         break;
-    case Waypoint::MODE_FLYCIRCLELEFT:
-    case Waypoint::MODE_DRIVECIRCLELEFT:
+    case Waypoint::MODE_CIRCLELEFT:
         return OVERLAY_CURVE_LEFT;
         break;
     default:

--- a/ground/gcs/src/plugins/opmap/opmap_edit_waypoint_dialog.cpp
+++ b/ground/gcs/src/plugins/opmap/opmap_edit_waypoint_dialog.cpp
@@ -89,14 +89,10 @@ void opmap_edit_waypoint_dialog::setupModeWidgets()
     MapDataDelegate::ModeOptions mode=(MapDataDelegate::ModeOptions)ui->cbMode->itemData(ui->cbMode->currentIndex()).toInt();
     switch(mode)
     {
-    case MapDataDelegate::MODE_FLYENDPOINT:
-    case MapDataDelegate::MODE_FLYVECTOR:
-    case MapDataDelegate::MODE_FLYCIRCLERIGHT:
-    case MapDataDelegate::MODE_FLYCIRCLELEFT:
-    case MapDataDelegate::MODE_DRIVEENDPOINT:
-    case MapDataDelegate::MODE_DRIVEVECTOR:
-    case MapDataDelegate::MODE_DRIVECIRCLELEFT:
-    case MapDataDelegate::MODE_DRIVECIRCLERIGHT:
+    case MapDataDelegate::MODE_ENDPOINT:
+    case MapDataDelegate::MODE_VECTOR:
+    case MapDataDelegate::MODE_CIRCLERIGHT:
+    case MapDataDelegate::MODE_CIRCLELEFT:
         ui->modeParams->setVisible(false);
         break;
     }

--- a/ground/gcs/src/plugins/pathplanner/algorithms/pathfillet.cpp
+++ b/ground/gcs/src/plugins/pathplanner/algorithms/pathfillet.cpp
@@ -107,14 +107,12 @@ bool PathFillet::processPath(FlightDataModel *model)
         {
         case Waypoint::MODE_CIRCLEPOSITIONRIGHT:
             return false;
-        case Waypoint::MODE_FLYCIRCLERIGHT:
-        case Waypoint::MODE_DRIVECIRCLERIGHT:
+        case Waypoint::MODE_CIRCLERIGHT:
             curvature = 1.0f/ModeParameters;
             break;
         case Waypoint::MODE_CIRCLEPOSITIONLEFT:
             return false;
-        case Waypoint::MODE_FLYCIRCLELEFT:
-        case Waypoint::MODE_DRIVECIRCLELEFT:
+        case Waypoint::MODE_CIRCLELEFT:
             curvature = -1.0f/ModeParameters;
             break;
         }
@@ -398,13 +396,13 @@ void PathFillet::setNewWaypoint(int index, float *pos, float velocity, float cur
         new_model->insertRow(index);
 
     // Convert from curvature representation to waypoint
-    quint8 mode = Waypoint::MODE_FLYVECTOR;
+    quint8 mode = Waypoint::MODE_VECTOR;
     float radius = 0;
     if (curvature > 0 && !isinf(curvature)) {
-        mode = Waypoint::MODE_FLYCIRCLERIGHT;
+        mode = Waypoint::MODE_CIRCLERIGHT;
         radius = 1.0 / curvature;
     } else if (curvature < 0 && !isinf(curvature)) {
-        mode = Waypoint::MODE_FLYCIRCLELEFT;
+        mode = Waypoint::MODE_CIRCLELEFT;
         radius = -1.0 / curvature;
     }
 

--- a/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
+++ b/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
@@ -45,14 +45,13 @@ FlightDataModel::FlightDataModel(QObject *parent) : QAbstractTableModel(parent)
     // model depends on run time properties and we might want to exclude certain modes
     // being presented later (e.g. driving on a multirotor)
     modeNames.clear();
+    modeNames.insert(Waypoint::MODE_VECTOR, tr("Vector"));
+    modeNames.insert(Waypoint::MODE_CIRCLELEFT, tr("Circle Left"));
+    modeNames.insert(Waypoint::MODE_CIRCLERIGHT, tr("Circle Right"));
+    modeNames.insert(Waypoint::MODE_ENDPOINT, tr("Endpoint"));
     modeNames.insert(Waypoint::MODE_CIRCLEPOSITIONLEFT, tr("Circle Position Left"));
     modeNames.insert(Waypoint::MODE_CIRCLEPOSITIONRIGHT, tr("Circle Position Right"));
-    modeNames.insert(Waypoint::MODE_CIRCLELEFT, tr("Fly Circle Left"));
-    modeNames.insert(Waypoint::MODE_CIRCLERIGHT, tr("Fly Circle Right"));
-    modeNames.insert(Waypoint::MODE_ENDPOINT, tr("Fly Endpoint"));
-    modeNames.insert(Waypoint::MODE_VECTOR, tr("Fly Vector"));
     modeNames.insert(Waypoint::MODE_LAND, tr("Land"));
-    modeNames.insert(Waypoint::MODE_STOP, tr("Stop"));
 }
 
 //! Return the number of waypoints

--- a/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
+++ b/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
@@ -47,14 +47,10 @@ FlightDataModel::FlightDataModel(QObject *parent) : QAbstractTableModel(parent)
     modeNames.clear();
     modeNames.insert(Waypoint::MODE_CIRCLEPOSITIONLEFT, tr("Circle Position Left"));
     modeNames.insert(Waypoint::MODE_CIRCLEPOSITIONRIGHT, tr("Circle Position Right"));
-    modeNames.insert(Waypoint::MODE_DRIVECIRCLELEFT, tr("Drive Circle Left"));
-    modeNames.insert(Waypoint::MODE_DRIVECIRCLERIGHT, tr("Drive Circle Right"));
-    modeNames.insert(Waypoint::MODE_DRIVEENDPOINT, tr("Drive Endpoint"));
-    modeNames.insert(Waypoint::MODE_DRIVEVECTOR, tr("Drive Vector"));
-    modeNames.insert(Waypoint::MODE_FLYCIRCLELEFT, tr("Fly Circle Left"));
-    modeNames.insert(Waypoint::MODE_FLYCIRCLERIGHT, tr("Fly Circle Right"));
-    modeNames.insert(Waypoint::MODE_FLYENDPOINT, tr("Fly Endpoint"));
-    modeNames.insert(Waypoint::MODE_FLYVECTOR, tr("Fly Vector"));
+    modeNames.insert(Waypoint::MODE_CIRCLELEFT, tr("Fly Circle Left"));
+    modeNames.insert(Waypoint::MODE_CIRCLERIGHT, tr("Fly Circle Right"));
+    modeNames.insert(Waypoint::MODE_ENDPOINT, tr("Fly Endpoint"));
+    modeNames.insert(Waypoint::MODE_VECTOR, tr("Fly Vector"));
     modeNames.insert(Waypoint::MODE_LAND, tr("Land"));
     modeNames.insert(Waypoint::MODE_STOP, tr("Stop"));
 }
@@ -316,7 +312,7 @@ bool FlightDataModel::insertRows(int row, int count, const QModelIndex &/*parent
         } else {
             data->altitude    = 0;
             data->velocity    = 0;
-            data->mode        = Waypoint::MODE_FLYVECTOR;
+            data->mode        = Waypoint::MODE_VECTOR;
             data->mode_params = 0;
             data->locked      = false;
         }

--- a/ground/gcs/src/plugins/pathplanner/modeluavoproxy.cpp
+++ b/ground/gcs/src/plugins/pathplanner/modeluavoproxy.cpp
@@ -233,9 +233,6 @@ void ModelUavoProxy::objectsToModel()
         if (wpfields.Mode == Waypoint::MODE_INVALID)
             break;
 
-        if (wpfields.Mode == Waypoint::MODE_STOP)
-            break;
-
         myModel->insertRow(x);
 
         // Compute the coordinates in LLA

--- a/ground/gcs/src/plugins/pathplanner/waypointdialog.cpp
+++ b/ground/gcs/src/plugins/pathplanner/waypointdialog.cpp
@@ -112,10 +112,8 @@ void WaypointDialog::setupModeWidgets()
     int mode = ui->cbMode->itemData(ui->cbMode->currentIndex()).toInt();
     switch(mode)
     {
-    case Waypoint::MODE_FLYCIRCLERIGHT:
-    case Waypoint::MODE_FLYCIRCLELEFT:
-    case Waypoint::MODE_DRIVECIRCLELEFT:
-    case Waypoint::MODE_DRIVECIRCLERIGHT:
+    case Waypoint::MODE_CIRCLERIGHT:
+    case Waypoint::MODE_CIRCLELEFT:
         ui->modeParams->setVisible(true);
         ui->modeParams->setText(tr("Radius"));
         ui->dsb_modeParams->setVisible(true);

--- a/shared/uavobjectdefinition/pathdesired.xml
+++ b/shared/uavobjectdefinition/pathdesired.xml
@@ -13,14 +13,10 @@
 		<!-- Circle Mode - move a circular from start to end with the radius in the mode parameter -->
 		<field name="Mode" units="" type="enum" elements="1">
 			<options>
-				<option>FlyEndpoint</option>
-				<option>FlyVector</option>
-				<option>FlyCircleRight</option>
-				<option>FlyCircleLeft</option>
-				<option>DriveEndpoint</option>
-				<option>DriveVector</option>
-				<option>DriveCircleLeft</option>
-				<option>DriveCircleRight</option>
+				<option>Endpoint</option>
+				<option>Vector</option>
+				<option>CircleRight</option>
+				<option>CircleLeft</option>
 				<option>HoldPosition</option>
 				<option>CirclePositionLeft</option>
 				<option>CirclePositionRight</option>

--- a/shared/uavobjectdefinition/waypoint.xml
+++ b/shared/uavobjectdefinition/waypoint.xml
@@ -10,14 +10,10 @@
 
 		<field name="Mode" units="" type="enum" elements="1">
 			<options>
-				<option>FlyEndpoint</option>
-				<option>FlyVector</option>
-				<option>FlyCircleRight</option>
-				<option>FlyCircleLeft</option>
-				<option>DriveEndpoint</option>
-				<option>DriveVector</option>
-				<option>DriveCircleLeft</option>
-				<option>DriveCircleRight</option>
+				<option>Endpoint</option>
+				<option>Vector</option>
+				<option>CircleRight</option>
+				<option>CircleLeft</option>
 				<option>HoldPosition</option>
 				<option>CirclePositionLeft</option>
 				<option>CirclePositionRight</option>

--- a/shared/uavobjectdefinition/waypoint.xml
+++ b/shared/uavobjectdefinition/waypoint.xml
@@ -18,7 +18,6 @@
 				<option>CirclePositionLeft</option>
 				<option>CirclePositionRight</option>
 				<option>Land</option>
-				<option>Stop</option>
 				<option>Invalid</option>
 			</options>
 		</field>


### PR DESCRIPTION
"FLY" was used even in the GroundPathFollower; DRIVE was never valid.