### PR TITLE
Allow 32767 min/max in channel input form

### DIFF
--- a/ground/gcs/src/plugins/config/inputchannelform.ui
+++ b/ground/gcs/src/plugins/config/inputchannelform.ui
@@ -60,7 +60,7 @@
       <enum>QAbstractSpinBox::NoButtons</enum>
      </property>
      <property name="maximum">
-      <number>9999</number>
+      <number>32767</number>
      </property>
      <property name="value">
       <number>1000</number>
@@ -248,7 +248,7 @@ p, li { white-space: pre-wrap; }
       <enum>QAbstractSpinBox::NoButtons</enum>
      </property>
      <property name="maximum">
-      <number>9999</number>
+      <number>32767</number>
      </property>
      <property name="value">
       <number>1000</number>


### PR DESCRIPTION
Allows entering values larger than 9999 in the input channel form (32767 was used as the underlying data type is `int16`). This is e.g. needed for RSSI support for the FrSky X8R receiver, which has a raw RSSI value of ~28000 (corresponds to a pulse with of 1ms when timer is running at 28MHz).