### PR TITLE
Gps settings:  Allow user control of autoconfig

### DIFF
--- a/flight/Modules/GPS/UBX.c
+++ b/flight/Modules/GPS/UBX.c
@@ -286,18 +286,18 @@ static void parse_ubx_nav_svinfo (const struct UBX_NAV_SVINFO *svinfo)
 	GPSSatellitesData svdata;
 
 	svdata.SatsInView = 0;
-	for (chan = 0; chan < svinfo->numCh;	chan++) {
-		if (svdata.SatsInView < GPSSATELLITES_PRN_NUMELEM) {
-			svdata.Azimuth[svdata.SatsInView] = (float)svinfo->sv[chan].azim;
-			svdata.Elevation[svdata.SatsInView] = (float)svinfo->sv[chan].elev;
-			svdata.PRN[svdata.SatsInView] = svinfo->sv[chan].svid;
-			svdata.SNR[svdata.SatsInView] = svinfo->sv[chan].cno;
-			svdata.SatsInView++;
-		}
-
+	for (chan = 0;
+	    (chan < svinfo->numCh) && (chan < GPSSATELLITES_PRN_NUMELEM);	
+	    chan++) {
+		svdata.Azimuth[chan] = (float)svinfo->sv[chan].azim;
+		svdata.Elevation[chan] = (float)svinfo->sv[chan].elev;
+		svdata.PRN[chan] = svinfo->sv[chan].svid;
+		svdata.SNR[chan] = svinfo->sv[chan].cno;
+		svdata.SatsInView++;
 	}
+
 	// fill remaining slots (if any)
-	for (chan = svdata.SatsInView; chan < GPSSATELLITES_PRN_NUMELEM; chan++) {
+	for (; chan < GPSSATELLITES_PRN_NUMELEM; chan++) {
 		svdata.Azimuth[chan] = (float)0.0f;
 		svdata.Elevation[chan] = (float)0.0f;
 		svdata.PRN[chan] = 0;

--- a/flight/Modules/GPS/UBX.c
+++ b/flight/Modules/GPS/UBX.c
@@ -285,21 +285,21 @@ static void parse_ubx_nav_svinfo (const struct UBX_NAV_SVINFO *svinfo)
 	uint8_t chan;
 	GPSSatellitesData svdata;
 
-	svdata.SatsInView = 0;
+	svdata.SatsInView = svinfo->numCh;
+
 	for (chan = 0;
 	    (chan < svinfo->numCh) && (chan < GPSSATELLITES_PRN_NUMELEM);	
 	    chan++) {
-		svdata.Azimuth[chan] = (float)svinfo->sv[chan].azim;
-		svdata.Elevation[chan] = (float)svinfo->sv[chan].elev;
+		svdata.Azimuth[chan] = svinfo->sv[chan].azim;
+		svdata.Elevation[chan] = svinfo->sv[chan].elev;
 		svdata.PRN[chan] = svinfo->sv[chan].svid;
 		svdata.SNR[chan] = svinfo->sv[chan].cno;
-		svdata.SatsInView++;
 	}
 
 	// fill remaining slots (if any)
 	for (; chan < GPSSATELLITES_PRN_NUMELEM; chan++) {
-		svdata.Azimuth[chan] = (float)0.0f;
-		svdata.Elevation[chan] = (float)0.0f;
+		svdata.Azimuth[chan] = 0;
+		svdata.Elevation[chan] = 0;
 		svdata.PRN[chan] = 0;
 		svdata.SNR[chan] = 0;
 	}

--- a/flight/Modules/GPS/UBX.c
+++ b/flight/Modules/GPS/UBX.c
@@ -346,8 +346,9 @@ static void parse_ubx_mon_ver (const struct UBX_MON_VER *version_info)
 	ublox.swVersion = (version_info->swVersion[0] - '0') +
 		(version_info->swVersion[2] - '0') * 0.1f +
 		(version_info->swVersion[3] - '0') * 0.01f;
-	for (uint32_t i = 0; i < 8; i++) {
-		ublox.hwVersion[i] = version_info->hwVersion[i];
+	for (uint32_t i = 0; i < 4; i++) {
+		ublox.hwVersion = ublox.hwVersion * 10 +
+			version_info->hwVersion[i] - '0';
 	}
 	ublox.ParseErrors = parse_errors;
 	UBloxInfoSet(&ublox);

--- a/flight/Modules/GPS/inc/UBX.h
+++ b/flight/Modules/GPS/inc/UBX.h
@@ -184,7 +184,7 @@ struct UBX_NAV_SVINFO_SV {
 };
 
 // SV information message
-#define MAX_SVS	16
+#define MAX_SVS 	32
 
 struct UBX_NAV_SVINFO {
 	uint32_t	iTOW;         // GPS Millisecond Time of Week (ms)

--- a/flight/Modules/GPS/inc/ubx_cfg.h
+++ b/flight/Modules/GPS/inc/ubx_cfg.h
@@ -30,8 +30,12 @@
 
 #include "stdint.h"
 #include "modulesettings.h"
- 
-void ubx_cfg_send_configuration(uintptr_t gps_port, char *buffer);
+
+void ubx_cfg_send_configuration(uintptr_t gps_port, char *buffer,
+		ModuleSettingsGPSConstellationOptions constellation,
+		ModuleSettingsGPSSBASConstellationOptions sbas_const,
+		ModuleSettingsGPSDynamicsModeOptions dyn_mode);
+
 void ubx_cfg_set_baudrate(uintptr_t gps_port, ModuleSettingsGPSSpeedOptions baud_rate);
 
 /**

--- a/flight/Modules/GPS/ubx_cfg.c
+++ b/flight/Modules/GPS/ubx_cfg.c
@@ -401,7 +401,8 @@ static void ubx_cfg_set_constellation(uintptr_t gps_port,
         0
     };
 
-    ubx_cfg_send_checksummed(gps_port, msg, len);
+    // The 4 offset here is for the header.
+    ubx_cfg_send_checksummed(gps_port, msg, len + 4);
 }
 
 //! Apply firmware version specific configuration tweaks

--- a/flight/Modules/GPS/ubx_cfg.c
+++ b/flight/Modules/GPS/ubx_cfg.c
@@ -319,7 +319,10 @@ static void ubx_cfg_send_checksummed(uintptr_t gps_port,
  * Completely configure a UBX GPS with the messages we expect
  * in NAV5 mode at the appropriate rate.
  */
-void ubx_cfg_send_configuration(uintptr_t gps_port, char *buffer)
+void ubx_cfg_send_configuration(uintptr_t gps_port, char *buffer,
+		ModuleSettingsGPSConstellationOptions constellation,
+		ModuleSettingsGPSSBASConstellationOptions sbas_const,
+		ModuleSettingsGPSDynamicsModeOptions dyn_mode)
 {
     gps_rx_buffer = buffer;
 

--- a/flight/Modules/GPS/ubx_cfg.c
+++ b/flight/Modules/GPS/ubx_cfg.c
@@ -361,7 +361,7 @@ static void ubx_cfg_set_constellation(uintptr_t gps_port,
 
     if (enable_glonass) max_glonass_ch = MAX_CH_PER_CATEGORY;
 
-    if (enable_gps) {
+    if (!enable_gps) {
         max_gps_ch = 0;
         min_gps_ch = 0;
     }

--- a/flight/Modules/GPS/ubx_cfg.c
+++ b/flight/Modules/GPS/ubx_cfg.c
@@ -7,7 +7,7 @@
  * @{
  *
  * @file       ubx_cfg.h
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
  * @brief      Include file for UBX configuration
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -121,7 +121,7 @@
 #define UBLOX_GNSSID_GLONASS 6
 
 #define UBLOX_MAX_PAYLOAD   384
-#define UBLOX_WAIT_MS       20
+#define UBLOX_WAIT_MS       50
 
 uint8_t ubloxTxCK_A, ubloxTxCK_B;
 static char *gps_rx_buffer;
@@ -397,7 +397,7 @@ static void ubx_cfg_set_constellation(uintptr_t gps_port,
         0,               // reserved1
         1,               // flags, 1 here means enable
         0,
-        1,               // flags, sigcfgmask, GLONASS L1OF
+        1,               // flags, sigcfgmask, GLONASS L10F
         0
     };
 
@@ -518,7 +518,7 @@ void ubx_cfg_send_configuration(uintptr_t gps_port, char *buffer,
                 constellation, sbas_const);
 }
 
-//! Make sure the GPS is set to the same baudrate as the port
+//! Make sure the GPS is set to the same baud
 void ubx_cfg_set_baudrate(uintptr_t gps_port, ModuleSettingsGPSSpeedOptions baud_rate)
 {
     // UBX,41 msg

--- a/ground/gcs/src/plugins/gpsdisplay/gpsconstellationwidget.cpp
+++ b/ground/gcs/src/plugins/gpsdisplay/gpsconstellationwidget.cpp
@@ -64,7 +64,7 @@ GpsConstellationWidget::GpsConstellationWidget(QWidget *parent) : QGraphicsView(
     setScene(scene);
 
     // Now create 'maxSatellites' satellite icons which we will move around on the map:
-    for (int i=0; i < MAX_SATELLITES;i++) {
+    for (int i = 0; i < MAX_SATELLITES; i++) {
         satellites[i][0] = 0;
         satellites[i][1] = 0;
         satellites[i][2] = 0;

--- a/ground/gcs/src/plugins/gpsdisplay/gpsconstellationwidget.cpp
+++ b/ground/gcs/src/plugins/gpsdisplay/gpsconstellationwidget.cpp
@@ -64,7 +64,7 @@ GpsConstellationWidget::GpsConstellationWidget(QWidget *parent) : QGraphicsView(
     setScene(scene);
 
     // Now create 'maxSatellites' satellite icons which we will move around on the map:
-    for (int i=0; i < MAX_SATTELITES;i++) {
+    for (int i=0; i < MAX_SATELLITES;i++) {
         satellites[i][0] = 0;
         satellites[i][1] = 0;
         satellites[i][2] = 0;
@@ -112,7 +112,7 @@ void GpsConstellationWidget::resizeEvent(QResizeEvent* event)
 
 void GpsConstellationWidget::updateSat(int index, int prn, int elevation, int azimuth, int snr)
 {
-    if (index >= MAX_SATTELITES) {
+    if (index >= MAX_SATELLITES) {
         // A bit of error checking never hurts.
         return;
     }

--- a/ground/gcs/src/plugins/gpsdisplay/gpsconstellationwidget.h
+++ b/ground/gcs/src/plugins/gpsdisplay/gpsconstellationwidget.h
@@ -48,13 +48,13 @@ public slots:
 private slots:
 
 private:
-   static const int MAX_SATTELITES = 16;
-   int satellites[MAX_SATTELITES][4];
+   static const int MAX_SATELLITES = 32;
+   int satellites[MAX_SATELLITES][4];
    QGraphicsScene *scene;
    QSvgRenderer *renderer;
    QGraphicsSvgItem* world;
-   QGraphicsSvgItem* satIcons[MAX_SATTELITES];
-   QGraphicsSimpleTextItem* satTexts[MAX_SATTELITES];
+   QGraphicsSvgItem* satIcons[MAX_SATELLITES];
+   QGraphicsSimpleTextItem* satTexts[MAX_SATELLITES];
 
    QPointF polarToCoord(int elevation, int azimuth);
 

--- a/ground/gcs/src/plugins/gpsdisplay/gpssnrwidget.cpp
+++ b/ground/gcs/src/plugins/gpsdisplay/gpssnrwidget.cpp
@@ -7,7 +7,7 @@ GpsSnrWidget::GpsSnrWidget(QWidget *parent) :
     setScene(scene);
 
     // Now create 'maxSatellites' satellite icons which we will move around on the map:
-    for (int i=0; i < MAX_SATELLITES;i++) {
+    for (int i = 0; i < MAX_SATELLITES; i++) {
         satellites[i][0] = 0;
         satellites[i][1] = 0;
         satellites[i][2] = 0;

--- a/ground/gcs/src/plugins/gpsdisplay/gpssnrwidget.cpp
+++ b/ground/gcs/src/plugins/gpsdisplay/gpssnrwidget.cpp
@@ -7,7 +7,7 @@ GpsSnrWidget::GpsSnrWidget(QWidget *parent) :
     setScene(scene);
 
     // Now create 'maxSatellites' satellite icons which we will move around on the map:
-    for (int i=0; i < MAX_SATTELITES;i++) {
+    for (int i=0; i < MAX_SATELLITES;i++) {
         satellites[i][0] = 0;
         satellites[i][1] = 0;
         satellites[i][2] = 0;
@@ -38,7 +38,7 @@ GpsSnrWidget::~GpsSnrWidget() {
 void GpsSnrWidget::showEvent(QShowEvent *event) {
     Q_UNUSED(event)
     scene->setSceneRect(0,0, this->viewport()->width(), this->viewport()->height());
-    for(int index = 0 ;index < MAX_SATTELITES ; index++) {
+    for(int index = 0 ;index < MAX_SATELLITES ; index++) {
         drawSat(index);
     }
 }
@@ -46,13 +46,13 @@ void GpsSnrWidget::showEvent(QShowEvent *event) {
 void GpsSnrWidget::resizeEvent(QResizeEvent* event) {
     Q_UNUSED(event);
     scene->setSceneRect(0,0, this->viewport()->width(), this->viewport()->height());
-    for(int index = 0 ;index < MAX_SATTELITES ; index++) {
+    for(int index = 0 ;index < MAX_SATELLITES ; index++) {
         drawSat(index);
     }
 }
 
 void GpsSnrWidget::updateSat(int index, int prn, int elevation, int azimuth, int snr) {
-    if (index >= MAX_SATTELITES) {
+    if (index >= MAX_SATELLITES) {
         // A bit of error checking never hurts.
         return;
     }
@@ -67,7 +67,7 @@ void GpsSnrWidget::updateSat(int index, int prn, int elevation, int azimuth, int
 }
 
 void GpsSnrWidget::drawSat(int index) {
-    if (index >= MAX_SATTELITES) {
+    if (index >= MAX_SATELLITES) {
         // A bit of error checking never hurts.
         return;
     }
@@ -85,7 +85,7 @@ void GpsSnrWidget::drawSat(int index) {
 
         // Casting to int rounds down, which is what I want.
         // Minus 2 to allow a pixel of white left and right.
-        int availableWidth = (int)((scene->width()-2) / MAX_SATTELITES);
+        int availableWidth = (int)((scene->width()-2) / MAX_SATELLITES);
 
         // 2 pixels, one on each side.
         qreal width = availableWidth - 2;

--- a/ground/gcs/src/plugins/gpsdisplay/gpssnrwidget.h
+++ b/ground/gcs/src/plugins/gpsdisplay/gpssnrwidget.h
@@ -16,12 +16,12 @@ public slots:
     void updateSat(int index, int prn, int elevation, int azimuth, int snr);
 
 private:
-    static const int MAX_SATTELITES = 16;
-    int satellites[MAX_SATTELITES][4];
+    static const int MAX_SATELLITES = 32;
+    int satellites[MAX_SATELLITES][4];
     QGraphicsScene *scene;
-    QGraphicsRectItem *boxes[MAX_SATTELITES];
-    QGraphicsSimpleTextItem *satTexts[MAX_SATTELITES];
-    QGraphicsSimpleTextItem *satSNRs[MAX_SATTELITES];
+    QGraphicsRectItem *boxes[MAX_SATELLITES];
+    QGraphicsSimpleTextItem *satTexts[MAX_SATELLITES];
+    QGraphicsSimpleTextItem *satSNRs[MAX_SATELLITES];
 
     void drawSat(int index);
 

--- a/shared/uavobjectdefinition/gpssatellites.xml
+++ b/shared/uavobjectdefinition/gpssatellites.xml
@@ -1,8 +1,8 @@
 <xml>
     <object name="GPSSatellites" singleinstance="true" settings="false">
         <description>Contains information about the GPS satellites in view from @ref GPSModule.</description>
-        <field name="SatsInView" units="" type="int8" elements="1"/>
-        <field name="PRN" units="" type="int8" elements="24"/>
+        <field name="SatsInView" units="" type="uint8" elements="1"/>
+        <field name="PRN" units="" type="uint8" elements="24"/>
         <field name="Elevation" units="degrees" type="float" elements="24"/>
         <field name="Azimuth" units="degrees" type="float" elements="24"/>
         <field name="SNR" units="" type="int8" elements="24"/>

--- a/shared/uavobjectdefinition/gpssatellites.xml
+++ b/shared/uavobjectdefinition/gpssatellites.xml
@@ -2,10 +2,10 @@
     <object name="GPSSatellites" singleinstance="true" settings="false">
         <description>Contains information about the GPS satellites in view from @ref GPSModule.</description>
         <field name="SatsInView" units="" type="int8" elements="1"/>
-        <field name="PRN" units="" type="int8" elements="16"/>
-        <field name="Elevation" units="degrees" type="float" elements="16"/>
-        <field name="Azimuth" units="degrees" type="float" elements="16"/>
-        <field name="SNR" units="" type="int8" elements="16"/>
+        <field name="PRN" units="" type="int8" elements="24"/>
+        <field name="Elevation" units="degrees" type="float" elements="24"/>
+        <field name="Azimuth" units="degrees" type="float" elements="24"/>
+        <field name="SNR" units="" type="int8" elements="24"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="periodic" period="10000"/>

--- a/shared/uavobjectdefinition/gpssatellites.xml
+++ b/shared/uavobjectdefinition/gpssatellites.xml
@@ -2,10 +2,10 @@
     <object name="GPSSatellites" singleinstance="true" settings="false">
         <description>Contains information about the GPS satellites in view from @ref GPSModule.</description>
         <field name="SatsInView" units="" type="uint8" elements="1"/>
-        <field name="PRN" units="" type="uint8" elements="24"/>
-        <field name="Elevation" units="degrees" type="int8" elements="24"/>
-        <field name="Azimuth" units="degrees" type="int16" elements="24"/>
-        <field name="SNR" units="" type="int8" elements="24"/>
+        <field name="PRN" units="" type="uint8" elements="30"/>
+        <field name="Elevation" units="degrees" type="int8" elements="30"/>
+        <field name="Azimuth" units="degrees" type="int16" elements="30"/>
+        <field name="SNR" units="" type="int8" elements="30"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="periodic" period="10000"/>

--- a/shared/uavobjectdefinition/gpssatellites.xml
+++ b/shared/uavobjectdefinition/gpssatellites.xml
@@ -5,10 +5,11 @@
         <field name="PRN" units="" type="uint8" elements="30"/>
         <field name="Elevation" units="degrees" type="int8" elements="30"/>
         <field name="Azimuth" units="degrees" type="int16" elements="30"/>
-        <field name="SNR" units="" type="int8" elements="30"/>
+        <!-- This is C/N0 - dB-Hz and not a conventional SNR -->
+        <field name="SNR" units="dB-Hz" type="int8" elements="30"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="periodic" period="10000"/>
         <logging updatemode="periodic" period="30000"/>
-	</object>
+    </object>
 </xml>

--- a/shared/uavobjectdefinition/gpssatellites.xml
+++ b/shared/uavobjectdefinition/gpssatellites.xml
@@ -3,8 +3,8 @@
         <description>Contains information about the GPS satellites in view from @ref GPSModule.</description>
         <field name="SatsInView" units="" type="uint8" elements="1"/>
         <field name="PRN" units="" type="uint8" elements="24"/>
-        <field name="Elevation" units="degrees" type="float" elements="24"/>
-        <field name="Azimuth" units="degrees" type="float" elements="24"/>
+        <field name="Elevation" units="degrees" type="int8" elements="24"/>
+        <field name="Azimuth" units="degrees" type="int16" elements="24"/>
         <field name="SNR" units="" type="int8" elements="24"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -58,6 +58,9 @@
 		</field>
 		<field name="GPSDataProtocol" units="" type="enum" elements="1" options="NMEA,UBX" defaultvalue="UBX"/>
 		<field name="GPSAutoConfigure" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE"/>
+		<field name="GPSConstellation" units="" type="enum" elements="1" options="All, GPS, GLONASS" defaultvalue="GPS"/>
+		<field name="GPSSBASConstellation" units="" type="enum" elements="1" options="All, WAAS, EGNOS, MSAS, GAGAN, None" defaultvalue="All"/>
+		<field name="GPSDynamicsMode" units="" type="enum" elements="1" options="Portable, Pedestrian, Automotive, Airborne1G, Airborne2G, Airborne4G" defaultvalue="Airborne2G"/>
 
 		<!-- ComUsbBridge Module Settings -->
 		<field name="ComUsbBridgeSpeed" units="bps" type="enum" elements="1" defaultvalue="57600">

--- a/shared/uavobjectdefinition/ubloxinfo.xml
+++ b/shared/uavobjectdefinition/ubloxinfo.xml
@@ -1,8 +1,8 @@
 <xml>
     <object name="UBloxInfo" singleinstance="true" settings="false">
         <description>UBlox specific information</description>
-        <field name="swVersion" units="" type="float" elements="1"/>
-        <field name="hwVersion" units="" type="uint8" elements="8"/>
+        <field name="swVersion" units="" type="uint32" elements="1"/>
+        <field name="hwVersion" units="" type="uint16" elements="1"/>
         <field name="ParseErrors" units="" type="uint32" elements="1"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>


### PR DESCRIPTION
Allows the user to enable simultaneous GPS+GLONASS and thus resolves #1394.  Also corrects version detection logic, enables GCS to see greater numbers of satellites.

Most possible combinations of settings verified to work on hardware.

Future work will be in the GCS, making the GPS widget prettier when more satellites are present, and adding options to save the configuration to the GPS.