### PR TITLE
attitude/ins: Use GPS pos/vel accuracy estimates

### DIFF
--- a/shared/uavobjectdefinition/inssettings.xml
+++ b/shared/uavobjectdefinition/inssettings.xml
@@ -6,7 +6,7 @@
 		<field name="AccelVar" units="(m/s)^2" type="float" elementnames="X,Y,Z" defaultvalue="0.003"/>
 		<field name="GyroVar" units="(deg/s)^2" type="float" elementnames="X,Y,Z" defaultvalue="0.00001,0.00001,0.0001"/>
 		<field name="MagVar" units="mGau^2" type="float" elementnames="X,Y,Z" defaultvalue="10,10,100"/>
-		<field name="GpsVar" units="m^2" type="float" elementnames="Pos,Vel,VertPos" defaultvalue="0.001,0.01,10"/>
+		<field name="GpsVar" units="m^2" type="float" elementnames="Pos,Vel,VertPos" defaultvalue="0.001,0.01,0.5"/>
 		<field name="BaroVar" units="m^2" type="float" elements="1" defaultvalue="0.01"/>
 
 		<!-- Features for the INS -->


### PR DESCRIPTION
This also weighs the GPS Z information more highly, but probably not as
high as we ultimately should.

Also we should move to these being real-world units.  Originally in my changeset I had done this, but I had problems with my baro on my frame that led me to removing this change (that turned out to be unrelated / also happened on base code).  Next time around.