### PR TITLE
Logging module improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -908,7 +908,7 @@ $(eval $(call SIM_TEMPLATE,simulation,Simulation,'sim ',posix,elf))
 #
 ##############################
 
-ALL_UNITTESTS := logfs i2c_vm misc_math sin_lookup coordinate_conversions error_correcting streamfs dsm
+ALL_UNITTESTS := logfs i2c_vm misc_math sin_lookup coordinate_conversions error_correcting streamfs dsm timeutils
 ALL_PYTHON_UNITTESTS := python_ut_test
 
 UT_OUT_DIR := $(BUILD_DIR)/unit_tests

--- a/flight/Libraries/inc/timeutils.h
+++ b/flight/Libraries/inc/timeutils.h
@@ -1,0 +1,47 @@
+/**
+ ******************************************************************************
+ * @addtogroup TauLabsLibraries Tau Labs Libraries
+ * @{
+ *
+ * @file       timeutils.h
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
+ * @brief      Time conversion functions
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _TIMEUTILS_H
+#define _TIMEUTILS_H
+
+#include <stdint.h>
+
+typedef struct {
+	uint8_t sec;  // seconds after the minute - [0, 60]
+	uint8_t min;  // minutes after the hour - [0, 59]
+	uint8_t hour; // hours since midnight - [0, 23]
+	uint8_t mday; // day of the month - [1, 31]
+	uint8_t mon;  // months since January - [0, 11]
+	uint8_t wday; // days since Sunday - [0, 6]
+	uint8_t year; // years since 1900
+} __attribute__((packed)) DateTimeT;
+
+void date_from_timestamp(uint32_t timestamp, DateTimeT *date_time);
+
+
+#endif /* _TIMEUTILS_H */

--- a/flight/Libraries/timeutils.c
+++ b/flight/Libraries/timeutils.c
@@ -1,0 +1,99 @@
+/**
+ ******************************************************************************
+ * @addtogroup TauLabsLibraries Tau Labs Libraries
+ * @{
+ *
+ * @file       timeutils.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
+ * @brief      Time conversion functions
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "timeutils.h"
+
+/**
+ * Convert UNIX timestamp to date/time
+ * Based on: http://stackoverflow.com/questions/21593692/convert-unix-timestamp-to-date-without-system-libs
+ * NOTE: May not handle leap-seconds correctly
+ */
+void date_from_timestamp(uint32_t timestamp, DateTimeT *date_time)
+{
+	uint32_t minutes, hours;
+	uint16_t days, year, dayOfWeek;
+	uint8_t month;
+
+	/* calculate minutes */
+	minutes  = timestamp / 60;
+	timestamp -= minutes * 60;
+	/* calculate hours */
+	hours    = minutes / 60;
+	minutes -= hours   * 60;
+	/* calculate days */
+	days     = hours   / 24;
+	hours   -= days    * 24;
+
+	/* Unix time starts in 1970 on a Thursday */
+	year      = 1970;
+	dayOfWeek = 4;
+
+	while(1)
+	{
+		uint8_t leapYear = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0));
+		uint16_t daysInYear = leapYear ? 366 : 365;
+		if (days >= daysInYear)
+		{
+			dayOfWeek += leapYear ? 2 : 1;
+			days -= daysInYear;
+			if (dayOfWeek >= 7)
+				dayOfWeek -= 7;
+			++year;
+		}
+		else
+		{
+			dayOfWeek  += days;
+			dayOfWeek  %= 7;
+
+			/* calculate the month and day */
+			static const uint8_t daysInMonth[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+			for(month = 0; month < 12; ++month)
+			{
+				uint8_t dim = daysInMonth[month];
+
+				/* add a day to feburary if this is a leap year */
+				if (month == 1 && leapYear)
+					++dim;
+
+				if (days >= dim)
+					days -= dim;
+				else
+					break;
+			}
+			break;
+		}
+	}
+
+	date_time->sec  = timestamp;
+	date_time->min  = minutes;
+	date_time->hour = hours;
+	date_time->mday = days + 1;
+	date_time->mon = month;
+	date_time->year = year - 1900;
+	date_time->wday = dayOfWeek;
+}

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -30,23 +30,34 @@
 #include "openpilot.h"
 #include "modulesettings.h"
 #include "pios_thread.h"
+#include "timeutils.h"
+#include "uavobjectmanager.h"
 
 #include "pios_streamfs.h"
+#include <pios_board_info.h>
 
+#include "airspeedactual.h"
 #include "attitudeactual.h"
 #include "accels.h"
+#include "flightstatus.h"
 #include "gyros.h"
 #include "baroaltitude.h"
 #include "flightstatus.h"
 #include "gpsposition.h"
 #include "gpstime.h"
+#include "gpssatellites.h"
 #include "magnetometer.h"
+#include "positionactual.h"
 #include "loggingsettings.h"
 #include "loggingstats.h"
+#include "velocityactual.h"
+#include "waypoint.h"
+#include "waypointactive.h"
 
 // Private constants
 #define STACK_SIZE_BYTES 1200
 #define TASK_PRIORITY PIOS_THREAD_PRIO_LOW
+const char DIGITS[16] = "0123456789abcdef";
 
 // Private types
 
@@ -54,10 +65,16 @@
 static UAVTalkConnection uavTalkCon;
 static struct pios_thread *loggingTaskHandle;
 static bool module_enabled;
+static bool flightstatus_updated = false;
+static bool waypoint_updated = false;
 
 // Private functions
 static void    loggingTask(void *parameters);
 static int32_t send_data(uint8_t *data, int32_t length);
+static void logSettings(UAVObjHandle obj);
+static void FlightStatusUpdatedCb(UAVObjEvent * ev);
+static void WaypointActiveUpdatedCb(UAVObjEvent * ev);
+static void writeHeader();
 
 // Local variables
 static uintptr_t logging_com_id;
@@ -130,10 +147,15 @@ static void loggingTask(void *parameters)
 	bool armed = false;
 	bool write_open = false;
 	bool read_open = false;
+	bool first_run = true;
 	int32_t read_sector = 0;
 	uint8_t read_data[LOGGINGSTATS_FILESECTOR_NUMELEM];
 
 	//PIOS_STREAMFS_Format(streamfs_id);
+
+	// Connect callbacks
+	FlightStatusConnectCallback(FlightStatusUpdatedCb);
+	WaypointActiveConnectCallback(WaypointActiveUpdatedCb);
 
 	LoggingStatsData loggingData;
 	LoggingStatsGet(&loggingData);
@@ -151,6 +173,7 @@ static void loggingTask(void *parameters)
 		} else {
 			loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
 			write_open = true;
+			first_run = true;
 		}
 	} else {
 		loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
@@ -162,7 +185,7 @@ static void loggingTask(void *parameters)
 	// Loop forever
 	while (1) {
 
-		// Do not update anything at more than 40 Hz
+		// Do not update anything at more than 50 Hz
 		PIOS_Thread_Sleep(20);
 
 		LoggingStatsGet(&loggingData);
@@ -214,18 +237,62 @@ static void loggingTask(void *parameters)
 			if (!write_open)
 				continue;
 
+			if (first_run){
+				// Write information at start of the log file
+				writeHeader();
+
+				// Log settings
+				if (settings.LogSettingsOnStart == LOGGINGSETTINGS_LOGSETTINGSONSTART_TRUE){
+					UAVObjIterate(&logSettings);
+				}
+
+				// Log some data objects that are unlikely to change during flight
+				// Waypoints
+				for (int i = 0; i < UAVObjGetNumInstances(WaypointHandle()); i++) {
+					UAVTalkSendObjectTimestamped(uavTalkCon, WaypointHandle(), i, false, 0);
+				}
+
+				// Trigger logging for objects that are logged on change
+				flightstatus_updated = true;
+				waypoint_updated = true;
+
+				first_run = false;
+			}
+
+			// Log objects on change
+			if (flightstatus_updated){
+				UAVTalkSendObjectTimestamped(uavTalkCon, FlightStatusHandle(), 0, false, 0);
+				flightstatus_updated = false;
+			}
+
+			if (waypoint_updated){
+				UAVTalkSendObjectTimestamped(uavTalkCon, WaypointActiveHandle(), 0, false, 0);
+				waypoint_updated = false;
+			}
+
+			// Log fast (~50Hz)
 			UAVTalkSendObjectTimestamped(uavTalkCon, AttitudeActualHandle(), 0, false, 0);
 			UAVTalkSendObjectTimestamped(uavTalkCon, AccelsHandle(), 0, false, 0);
 			UAVTalkSendObjectTimestamped(uavTalkCon, GyrosHandle(), 0, false, 0);
 			UAVTalkSendObjectTimestamped(uavTalkCon, MagnetometerHandle(), 0, false, 0);
 
+			// Log slower (~5Hz)
 			if ((i % 10) == 0) {
+				UAVTalkSendObjectTimestamped(uavTalkCon, AirspeedActualHandle(), 0, false, 0);
 				UAVTalkSendObjectTimestamped(uavTalkCon, BaroAltitudeHandle(), 0, false, 0);
 				UAVTalkSendObjectTimestamped(uavTalkCon, GPSPositionHandle(), 0, false, 0);
+				UAVTalkSendObjectTimestamped(uavTalkCon, PositionActualHandle(), 0, false, 0);
+				UAVTalkSendObjectTimestamped(uavTalkCon, VelocityActualHandle(), 0, false, 0);
 			}
 
+			// Log slow (~1Hz)
 			if ((i % 50) == 1) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, GPSTimeHandle(), 0, false, 0);	
+				UAVTalkSendObjectTimestamped(uavTalkCon, GPSTimeHandle(), 0, false, 0);
+			}
+
+			// Log very slow (~0.1Hz)
+			if ((i % 500) == 2) {
+				UAVTalkSendObjectTimestamped(uavTalkCon, GPSSatellitesHandle(), 0, false, 0);
 			}
 
 			LoggingStatsBytesLoggedSet(&written_bytes);
@@ -283,6 +350,81 @@ static void loggingTask(void *parameters)
 
 		i++;
 	}
+}
+
+
+/**
+ * Log all settings objects
+ * \param[in] obj Object to log
+ */
+static void logSettings(UAVObjHandle obj)
+{
+	if (UAVObjIsSettings(obj)) {
+		UAVTalkSendObjectTimestamped(uavTalkCon, obj, 0, false, 0);
+	}
+}
+
+/**
+ * Write log file header
+ * see firmwareinfotemplate.c
+ */
+static void writeHeader()
+{
+	int pos;
+	char tmp_str[45];
+	char *info_str;
+	char this_char;
+	DateTimeT date_time;
+
+	const struct pios_board_info * bdinfo = &pios_board_info_blob;
+
+	sprintf(tmp_str, "%s\n", "Tau Labs git hash:");
+	send_data((uint8_t*)tmp_str, strlen(tmp_str));
+
+	// Commit tag name
+	info_str = (char*)(bdinfo->fw_base + bdinfo->fw_size + 14);
+	send_data((uint8_t*)info_str, strlen(info_str));
+
+	// Git commit hash
+	pos = 0;
+	tmp_str[pos++] = ':';
+	for (int i = 0; i < 4; i++){
+		this_char = *(char*)(bdinfo->fw_base + bdinfo->fw_size + 7 - i);
+		tmp_str[pos++] = DIGITS[(this_char & 0xF0) >> 4];
+		tmp_str[pos++] = DIGITS[(this_char & 0x0F)];
+	}
+	send_data((uint8_t*)tmp_str, pos);
+
+	// Date
+	date_from_timestamp(*(uint32_t *)(bdinfo->fw_base + bdinfo->fw_size + 8), &date_time);
+	sprintf(tmp_str, " %d%02d%02d\n", 1900 + date_time.year, date_time.mon + 1, date_time.mday);
+	send_data((uint8_t*)tmp_str, strlen(tmp_str));
+
+	// UAVO SHA1
+	pos = 0;
+	for (int i = 0; i < 20; i++){
+		this_char = *(char*)(bdinfo->fw_base + bdinfo->fw_size + 60 + i);
+		tmp_str[pos++] = DIGITS[(this_char & 0xF0) >> 4];
+		tmp_str[pos++] = DIGITS[(this_char & 0x0F)];
+	}
+	tmp_str[pos++] = '\n';
+	send_data((uint8_t*)tmp_str, pos);
+}
+
+/**
+ * Callback triggered when FlightStatus is updated
+ */
+static void FlightStatusUpdatedCb(UAVObjEvent * ev)
+{
+	flightstatus_updated = true;
+}
+
+/**
+ * Callback triggered when WaypointActive is updated
+ */
+static void WaypointActiveUpdatedCb(UAVObjEvent * ev)
+{
+	waypoint_updated = true;
 }
 
 /**

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -110,7 +110,7 @@ struct streamfs_state {
  * @brief Return the offset in flash of a particular slot within an arena
  * @return address of the requested slot
  */
-static uintptr_t streamfs_get_addr(const struct streamfs_state *streamfs, uint8_t arena_id, uint16_t arena_offset)
+static uintptr_t streamfs_get_addr(const struct streamfs_state *streamfs, uint16_t arena_id, uint16_t arena_offset)
 {
 	PIOS_Assert(arena_id < (streamfs->partition_size / streamfs->cfg->arena_size));
 	PIOS_Assert(arena_offset < streamfs->cfg->arena_size);
@@ -135,7 +135,7 @@ struct streamfs_footer {
  * @return 0 if success, < 0 on failure
  * @note Must be called while holding the flash transaction lock
  */
-static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint8_t arena_id)
+static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint16_t arena_id)
 {
 	uintptr_t arena_addr = streamfs_get_addr(streamfs, arena_id, 0);
 

--- a/flight/targets/colibri/fw/Makefile
+++ b/flight/targets/colibri/fw/Makefile
@@ -116,6 +116,7 @@ SRC += $(FLIGHTLIB)/WorldMagModel.c
 SRC += $(FLIGHTLIB)/insgps14state.c
 SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
+SRC += $(FLIGHTLIB)/timeutils.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/sin_lookup.c
 SRC += $(MATHLIB)/misc_math.c

--- a/flight/targets/quanton/fw/Makefile
+++ b/flight/targets/quanton/fw/Makefile
@@ -124,6 +124,7 @@ SRC += $(FLIGHTLIB)/WorldMagModel.c
 SRC += $(FLIGHTLIB)/insgps14state.c
 SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
+SRC += $(FLIGHTLIB)/timeutils.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/sin_lookup.c
 SRC += $(MATHLIB)/misc_math.c

--- a/flight/targets/sparky2/fw/Makefile
+++ b/flight/targets/sparky2/fw/Makefile
@@ -122,6 +122,7 @@ SRC += $(FLIGHTLIB)/WorldMagModel.c
 SRC += $(FLIGHTLIB)/insgps14state.c
 SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
+SRC += $(FLIGHTLIB)/timeutils.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/sin_lookup.c
 SRC += $(MATHLIB)/misc_math.c

--- a/flight/tests/timeutils/Makefile
+++ b/flight/tests/timeutils/Makefile
@@ -1,0 +1,42 @@
+###############################################################################
+# @file       Makefile
+# @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+# @addtogroup 
+# @{
+# @addtogroup 
+# @{
+# @brief Makefile for unit test
+###############################################################################
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#
+
+WHEREAMI := $(dir $(lastword $(MAKEFILE_LIST)))
+TOP      := $(realpath $(WHEREAMI)/../../../)
+include $(TOP)/make/firmware-defs.mk
+
+EXTRAINCDIRS += $(FLIGHTLIB)/inc
+EXTRAINCDIRS += $(SHAREDAPIDIR)
+
+CFLAGS += -O0
+CFLAGS += -Wall -Werror
+CFLAGS += -g
+CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
+
+CONLYFLAGS += -std=gnu99
+
+SRC := $(FLIGHTLIB)/timeutils.c
+
+include $(TOP)/make/unittest.mk

--- a/flight/tests/timeutils/unittest.cpp
+++ b/flight/tests/timeutils/unittest.cpp
@@ -1,0 +1,83 @@
+/**
+ ******************************************************************************
+ * @file       unittest.cpp
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @addtogroup UnitTests
+ * @{
+ * @addtogroup UnitTests
+ * @{
+ * @brief Unit test
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+/*
+ * NOTE: This program uses the Google Test infrastructure to drive the unit test
+ *
+ * Main site for Google Test: http://code.google.com/p/googletest/
+ * Documentation and examples: http://code.google.com/p/googletest/wiki/Documentation
+ */
+
+#include "gtest/gtest.h"
+
+#include <time.h>       /* time functions */
+#include <stdio.h>		/* printf */
+#include <stdlib.h>		/* abort */
+#include <string.h>		/* memset */
+#include <stdint.h>		/* uint*_t */
+
+extern "C" {
+#include "timeutils.h"		/* API for time conversion */
+}
+
+
+
+// To use a test fixture, derive a class from testing::Test.
+class Time : public testing::Test {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+};
+
+TEST_F(Time, DateSweep) {
+    struct tm *datetime1;
+    DateTimeT datetime2;
+    time_t timestamp = 0;
+ 
+    // test every day from 1970 to 2100
+    struct tm tm;
+    memset((void*)&tm, 0, sizeof(tm));
+    tm.tm_year = 130;
+    time_t end_time = mktime(&tm);
+
+    while (timestamp < end_time){
+        datetime1 = gmtime(&timestamp);
+        date_from_timestamp((uint32_t)timestamp, &datetime2);
+        EXPECT_EQ(datetime1->tm_year, datetime2.year);
+        EXPECT_EQ(datetime1->tm_mon, datetime2.mon);
+        EXPECT_EQ(datetime1->tm_mday, datetime2.mday);
+        EXPECT_EQ(datetime1->tm_hour, datetime2.hour);
+        EXPECT_EQ(datetime1->tm_min, datetime2.min);
+        EXPECT_EQ(datetime1->tm_sec, datetime2.sec);
+        EXPECT_EQ(datetime1->tm_wday, datetime2.wday);
+        timestamp += 86400 + 3600 + 42; // advance by one day, one hour, 42 seconds
+    }
+}
+
+

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -3,6 +3,7 @@
 		<description>Settings for the logging module</description>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
 		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
+		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100" elements="1" defaultvalue="25"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -2,6 +2,7 @@
 	<object name="LoggingSettings" singleinstance="true" settings="true">
 		<description>Settings for the logging module</description>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
+		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Adds the following improvements to the Logging module:

- Writes correct TauLabs log file header. Fixes #1507
- Adds the option to log all settings UAVOs at the start of the log file. This information will be very useful when analyzing logs. Also, the space needed for the settings is small, so it is enabled by default.
- Logs some UAVOs on change (currently only `FlightStatus` and `WaypointActive`)
- Adds some additional UAVOs to be logged
- Fixes a bug in `pios_streamfs` that limited the log file size to 1MB (`uint8_t` was used for `arena_id`)
