### PR TITLE
Python: Fix multi-instance parsing

### DIFF
--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -54,7 +54,9 @@ class TelemetryBase():
         if githash:
             uavo_defs.from_git_hash(githash)
         else:
-            uavo_defs.from_uavo_xml_path("shared/uavobjectdefinition")
+            xml_path = os.path.join(os.path.dirname(__file__), "..", "..",
+                                    "shared", "uavobjectdefinition")
+            uavo_defs.from_uavo_xml_path(xml_path)
 
         self.githash = githash
 

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -39,7 +39,7 @@ class UAVTupleClass():
         return cls._packstruct.size
 
     @classmethod
-    def from_bytes(cls, data, timestamp, offset=0):
+    def from_bytes(cls, data, timestamp, instance_id, offset=0):
         """ Deserializes and creates an instance of this object.
         
          - data: the data to deserialize
@@ -53,23 +53,13 @@ class UAVTupleClass():
         field_values = []
         field_values.append(cls._name)
 
-        # This gets a bit awkward. The order of field_values must match the structure
-        # which for the intro header is name, timestamp, and id and then optionally
-        # instance ID. For the timestamped packets we must parse the instance ID and
-        # then the timestamp, so we will pop that out and shuffle the order. We also
-        # convert from ms to seconds here.
-
-        if timestamp != None:
+        if timestamp is not None:
             field_values.append(timestamp / 1000.0)
-        else:
-            if cls._single:
-                raw_ts = unpack_field_values.pop(0)
-            else:
-                raw_ts = unpack_field_values.pop(1)
-
-            field_values.append(raw_ts / 1000.0)
 
         field_values.append(cls._id)
+
+        if instance_id is not None:
+            field_values.append(instance_id)
 
         # add the remaining fields.  If the thing should be nested, construct
         # an appropriate tuple.
@@ -231,10 +221,10 @@ def make_class(xml_file):
     num_subelems = []
 
     # add format for instance-id IFF this is a multi-instance UAVO
-    if not is_single_inst:
-        # this is multi-instance so the optional instance-id is present
-        formats.append('H')
-        num_subelems.append(1)
+    #if not is_single_inst:
+    #    # this is multi-instance so the optional instance-id is present
+    #    formats.append('H')
+    #    num_subelems.append(1)
 
     is_flat = True
 
@@ -250,8 +240,10 @@ def make_class(xml_file):
     fmt = struct.Struct('<' + ''.join(formats))
 
     ##### CALCULATE THE NUMPY TYPE ASSOCIATED WITH THIS CLASS ##### 
-
     dtype  = [('name', 'S20'), ('time', 'double'), ('uavo_id', 'uint')]
+
+    if not is_single_inst:
+        dtype += ('inst_id', 'uint'),
 
     for f in fields:
         dtype += [(f['name'], '(' + `f['elements']` + ",)" + type_numpy_map[f['type']])]

--- a/python/taulabs/uavo.py
+++ b/python/taulabs/uavo.py
@@ -220,12 +220,6 @@ def make_class(xml_file):
     formats = []
     num_subelems = []
 
-    # add format for instance-id IFF this is a multi-instance UAVO
-    #if not is_single_inst:
-    #    # this is multi-instance so the optional instance-id is present
-    #    formats.append('H')
-    #    num_subelems.append(1)
-
     is_flat = True
 
     # add formats for each field

--- a/python/taulabs/uavtalk.py
+++ b/python/taulabs/uavtalk.py
@@ -223,19 +223,9 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=False):
             timestamp = timestamp_fmt.unpack_from(buf, header_fmt.size + instance_len + buf_offset)[0]
 
             # handle wraparound
-
-            # This is currently hacked because the ordering of instance id and
-            # time is messed up in this code-- hacked so at least timestamps
-            # don't jump.
             if timestamp < last_timestamp:
-                if timestamp > 200:
-                    timestamp_base = timestamp_base + 65536
-                    last_timestamp = timestamp
-                else:
-                    timestamp += 65536
-            else:
-                last_timestamp = timestamp
-
+                timestamp_base = timestamp_base + 65536
+            last_timestamp = timestamp
             timestamp += timestamp_base
         else:
             timestamp = last_timestamp


### PR DESCRIPTION
Fixes Python log parsing for logs that have multi-instance UAVOs present. 