### PR TITLE
ENH: Move things to fast heap

### DIFF
--- a/flight/Modules/FirmwareIAP/firmwareiap.c
+++ b/flight/Modules/FirmwareIAP/firmwareiap.c
@@ -182,7 +182,7 @@ static void FirmwareIAPCallback(UAVObjEvent* ev)
 						/* Note: Cant just wait timeout value, because first time is randomized */
 						reset_count = 0;
 						lastResetSysTime = PIOS_Thread_Systime();
-						UAVObjEvent * ev = PIOS_malloc(sizeof(UAVObjEvent));
+						UAVObjEvent * ev = PIOS_malloc_no_dma(sizeof(UAVObjEvent));
 						memset(ev,0,sizeof(UAVObjEvent));
 						EventPeriodicCallbackCreate(ev, resetTask, 100);
 						iap_state = IAP_STATE_RESETTING;

--- a/flight/PiOS/Common/pios_adc.c
+++ b/flight/PiOS/Common/pios_adc.c
@@ -81,7 +81,7 @@ static struct pios_adc_dev *PIOS_ADC_Allocate(void)
 {
 	struct pios_adc_dev *adc_dev;
 
-	adc_dev = (struct pios_adc_dev *)PIOS_malloc(sizeof(*adc_dev));
+	adc_dev = (struct pios_adc_dev *)PIOS_malloc_no_dma(sizeof(*adc_dev));
 	if (!adc_dev)
 		return (NULL );
 

--- a/flight/PiOS/Common/pios_flashfs_logfs.c
+++ b/flight/PiOS/Common/pios_flashfs_logfs.c
@@ -466,7 +466,7 @@ static struct logfs_state *PIOS_FLASHFS_Logfs_alloc(void)
 {
 	struct logfs_state *logfs;
 
-	logfs = (struct logfs_state *)PIOS_malloc(sizeof(*logfs));
+	logfs = (struct logfs_state *)PIOS_malloc_no_dma(sizeof(*logfs));
 	if (!logfs) return (NULL);
 
 	logfs->magic = PIOS_FLASHFS_LOGFS_DEV_MAGIC;

--- a/flight/PiOS/Common/pios_mutex.c
+++ b/flight/PiOS/Common/pios_mutex.c
@@ -52,7 +52,7 @@
  */
 struct pios_mutex *PIOS_Mutex_Create(void)
 {
-	struct pios_mutex *mtx = PIOS_malloc(sizeof(struct pios_mutex));
+	struct pios_mutex *mtx = PIOS_malloc_no_dma(sizeof(struct pios_mutex));
 
 	if (mtx == NULL)
 		return NULL;
@@ -110,7 +110,7 @@ bool PIOS_Mutex_Unlock(struct pios_mutex *mtx)
  */
 struct pios_recursive_mutex *PIOS_Recursive_Mutex_Create(void)
 {
-	struct pios_recursive_mutex *mtx = PIOS_malloc(sizeof(struct pios_recursive_mutex));
+	struct pios_recursive_mutex *mtx = PIOS_malloc_no_dma(sizeof(struct pios_recursive_mutex));
 
 	if (mtx == NULL)
 		return NULL;
@@ -170,7 +170,7 @@ bool PIOS_Recursive_Mutex_Unlock(struct pios_recursive_mutex *mtx)
  */
 struct pios_mutex *PIOS_Mutex_Create(void)
 {
-	struct pios_mutex *mtx = PIOS_malloc(sizeof(struct pios_mutex));
+	struct pios_mutex *mtx = PIOS_malloc_no_dma(sizeof(struct pios_mutex));
 
 	if (mtx == NULL)
 		return NULL;
@@ -226,7 +226,7 @@ bool PIOS_Mutex_Unlock(struct pios_mutex *mtx)
  */
 struct pios_recursive_mutex *PIOS_Recursive_Mutex_Create(void)
 {
-	struct pios_recursive_mutex *mtx = PIOS_malloc(sizeof(struct pios_recursive_mutex));
+	struct pios_recursive_mutex *mtx = PIOS_malloc_no_dma(sizeof(struct pios_recursive_mutex));
 
 	if (mtx == NULL)
 		return NULL;

--- a/flight/PiOS/Common/pios_queue.c
+++ b/flight/PiOS/Common/pios_queue.c
@@ -52,7 +52,7 @@
  */
 struct pios_queue *PIOS_Queue_Create(size_t queue_length, size_t item_size)
 {
-	struct pios_queue *queuep = PIOS_malloc(sizeof(struct pios_queue));
+	struct pios_queue *queuep = PIOS_malloc_no_dma(sizeof(struct pios_queue));
 
 	if (queuep == NULL)
 		return NULL;
@@ -147,12 +147,12 @@ bool PIOS_Queue_Receive(struct pios_queue *queuep, void *itemp, uint32_t timeout
  */
 struct pios_queue *PIOS_Queue_Create(size_t queue_length, size_t item_size)
 {
-	struct pios_queue *queuep = PIOS_malloc(sizeof(struct pios_queue));
+	struct pios_queue *queuep = PIOS_malloc_no_dma(sizeof(struct pios_queue));
 	if (queuep == NULL)
 		return NULL;
 
 	/* Create the memory pool. */
-	queuep->mpb = PIOS_malloc(item_size * (queue_length + PIOS_QUEUE_MAX_WAITERS));
+	queuep->mpb = PIOS_malloc_no_dma(item_size * (queue_length + PIOS_QUEUE_MAX_WAITERS));
 	if (queuep->mpb == NULL) {
 		PIOS_free(queuep);
 		return NULL;
@@ -161,7 +161,7 @@ struct pios_queue *PIOS_Queue_Create(size_t queue_length, size_t item_size)
 	chPoolLoadArray(&queuep->mp, queuep->mpb, queue_length + PIOS_QUEUE_MAX_WAITERS);
 
 	/* Create the mailbox. */
-	msg_t *mb_buf = PIOS_malloc(sizeof(msg_t) * queue_length);
+	msg_t *mb_buf = PIOS_malloc_no_dma(sizeof(msg_t) * queue_length);
 	chMBInit(&queuep->mb, mb_buf, queue_length);
 
 	return queuep;

--- a/flight/PiOS/Common/pios_semaphore.c
+++ b/flight/PiOS/Common/pios_semaphore.c
@@ -272,7 +272,7 @@ bool PIOS_Semaphore_Give_FromISR(struct pios_semaphore *sema, bool *woken)
  */
 struct pios_semaphore *PIOS_Semaphore_Create(void)
 {
-	struct pios_semaphore *sema = PIOS_malloc(sizeof(struct pios_semaphore));
+	struct pios_semaphore *sema = PIOS_malloc_no_dma(sizeof(struct pios_semaphore));
 
 	if (sema == NULL)
 		return NULL;

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -174,7 +174,7 @@ static struct streamfs_state *streamfs_alloc(void)
 {
 	struct streamfs_state *streamfs;
 
-	streamfs = (struct streamfs_state *)PIOS_malloc(sizeof(*streamfs));
+	streamfs = (struct streamfs_state *)PIOS_malloc_no_dma(sizeof(*streamfs));
 	if (!streamfs) return (NULL);
 
 	streamfs->magic = PIOS_FLASHFS_STREAMFS_DEV_MAGIC;
@@ -542,7 +542,7 @@ int32_t PIOS_STREAMFS_Init(uintptr_t *fs_id, const struct streamfs_cfg *cfg, enu
 		goto out_exit;
 	}
 
-	streamfs->com_buffer = (uint8_t *)PIOS_malloc(cfg->write_size);
+	streamfs->com_buffer = (uint8_t *)PIOS_malloc_no_dma(cfg->write_size);
 	if (!streamfs->com_buffer) {
 		PIOS_free(streamfs);
 		return -1;

--- a/flight/PiOS/Common/pios_thread.c
+++ b/flight/PiOS/Common/pios_thread.c
@@ -58,7 +58,7 @@
  */
 struct pios_thread *PIOS_Thread_Create(void (*fp)(void *), const char *namep, size_t stack_bytes, void *argp, enum pios_thread_prio_e prio)
 {
-	struct pios_thread *thread = PIOS_malloc(sizeof(struct pios_thread));
+	struct pios_thread *thread = PIOS_malloc_no_dma(sizeof(struct pios_thread));
 
 	if (thread == NULL)
 		return NULL;
@@ -251,7 +251,7 @@ static uint8_t * align8_alloc(uint32_t size)
  */
 struct pios_thread *PIOS_Thread_Create(void (*fp)(void *), const char *namep, size_t stack_bytes, void *argp, enum pios_thread_prio_e prio)
 {
-	struct pios_thread *thread = PIOS_malloc(sizeof(struct pios_thread));
+	struct pios_thread *thread = PIOS_malloc_no_dma(sizeof(struct pios_thread));
 	if (thread == NULL)
 		return NULL;
 

--- a/flight/UAVObjects/eventdispatcher.c
+++ b/flight/UAVObjects/eventdispatcher.c
@@ -231,7 +231,7 @@ static int32_t eventPeriodicCreate(UAVObjEvent* ev, UAVObjEventCallback cb, stru
 		}
 	}
     // Create handle
-	objEntry = (PeriodicObjectList*)PIOS_malloc(sizeof(PeriodicObjectList));
+	objEntry = (PeriodicObjectList*)PIOS_malloc_no_dma(sizeof(PeriodicObjectList));
 	if (objEntry == NULL) return -1;
 	objEntry->evInfo.ev.obj = ev->obj;
 	objEntry->evInfo.ev.instId = ev->instId;

--- a/flight/UAVTalk/uavtalk.c
+++ b/flight/UAVTalk/uavtalk.c
@@ -56,7 +56,7 @@ static void updateAck(UAVTalkConnectionData *connection, UAVObjHandle obj, uint1
 UAVTalkConnection UAVTalkInitialize(UAVTalkOutputStream outputStream)
 {
 	// allocate object
-	UAVTalkConnectionData * connection = PIOS_malloc(sizeof(UAVTalkConnectionData));
+	UAVTalkConnectionData * connection = PIOS_malloc_no_dma(sizeof(UAVTalkConnectionData));
 	if (!connection) return 0;
 	connection->canari = UAVTALK_CANARI;
 	connection->iproc.rxPacketLength = 0;


### PR DESCRIPTION
Moves some things to fast heap (heap on F4 targets that can only be accessed by the CPU and not the DMA controller). I only moved things in `PiOS` and not drivers, as it is easier to test and has a more significant impact (as queues etc. are allocated in many places).

On Brain, this reduces the heap utilization by about 5.5kB.

Fixes #1684