### PR TITLE
Logging fix

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -207,6 +207,8 @@ static void loggingTask(void *parameters)
 			case LOGGINGSETTINGS_MAXLOGRATE_100:
 				PIOS_Thread_Sleep(10);
 				break;
+			default:
+				PIOS_Thread_Sleep(1000);
 		}
 
 		LoggingStatsGet(&loggingData);

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -289,7 +289,7 @@ static void loggingTask(void *parameters)
 				flightstatus_updated = false;
 			}
 
-			if (waypoint_updated){
+			if (waypoint_updated && WaypointActiveHandle()){
 				UAVTalkSendObjectTimestamped(uavTalkCon, WaypointActiveHandle(), 0, false, 0);
 				waypoint_updated = false;
 			}
@@ -310,18 +310,21 @@ static void loggingTask(void *parameters)
 			if ((i % 10) == 1) {
 				UAVTalkSendObjectTimestamped(uavTalkCon, AirspeedActualHandle(), 0, false, 0);
 				UAVTalkSendObjectTimestamped(uavTalkCon, BaroAltitudeHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, GPSPositionHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, PositionActualHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, VelocityActualHandle(), 0, false, 0);
+				if (GPSPositionHandle())
+					UAVTalkSendObjectTimestamped(uavTalkCon, GPSPositionHandle(), 0, false, 0);
+				if (PositionActualHandle())
+					UAVTalkSendObjectTimestamped(uavTalkCon, PositionActualHandle(), 0, false, 0);
+				if (VelocityActualHandle())
+					UAVTalkSendObjectTimestamped(uavTalkCon, VelocityActualHandle(), 0, false, 0);
 			}
 
 			// Log slow
-			if ((i % 50) == 2) {
+			if ((i % 50) == 2 && GPSTimeHandle()) {
 				UAVTalkSendObjectTimestamped(uavTalkCon, GPSTimeHandle(), 0, false, 0);
 			}
 
 			// Log very slow
-			if ((i % 500) == 3) {
+			if ((i % 500) == 3 && GPSSatellitesHandle()) {
 				UAVTalkSendObjectTimestamped(uavTalkCon, GPSSatellitesHandle(), 0, false, 0);
 			}
 

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -163,7 +163,8 @@ static void loggingTask(void *parameters)
 
 	// Connect callbacks for UAVOs being logged on change
 	FlightStatusConnectCallback(FlightStatusUpdatedCb);
-	WaypointActiveConnectCallback(WaypointActiveUpdatedCb);
+	if (WaypointActiveHandle())
+		WaypointActiveConnectCallback(WaypointActiveUpdatedCb);
 
 	LoggingStatsData loggingData;
 	LoggingStatsGet(&loggingData);


### PR DESCRIPTION
Fixes a bug introduced by #1682 that connected to objects even if they might not be
registered by the ObjectManager. This would cause CPU usage of the logging module
to skyrocket.