### PR TITLE
Make: Update Windows openssl_install target to version 1.0.2c

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -555,7 +555,7 @@ endif
 
 # OPENSSL download URL
 ifdef WINDOWS
-  openssl_install: OPENSSL_URL  := http://slproweb.com/download/Win32OpenSSL-1_0_2a.exe
+  openssl_install: OPENSSL_URL  := http://slproweb.com/download/Win32OpenSSL-1_0_2c.exe
   
 openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl


### PR DESCRIPTION
Update Windows openssl_install target to version 1.0.2c (from 1.0.2a). The previous version has been deleted from the remote host breaking the target. I don't think this will cause any problems but I'm unfamiliar with how OpenSSL is used. The changelog is at https://www.openssl.org/news/openssl-1.0.2-notes.html.