### PR TITLE
Flight / UAVObject: added S.Bus option for RSSI type

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -222,6 +222,11 @@ int32_t transmitter_control_update()
 			value = PIOS_FrSkyRssi_Get();
 #endif /* PIOS_INCLUDE_FRSKY_RSSI */
 			break;
+		case MANUALCONTROLSETTINGS_RSSITYPE_SBUS:
+#if defined(PIOS_INCLUDE_SBUS)
+			value = PIOS_RCVR_Read(pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_SBUS], settings.RssiChannelNumber);
+#endif /* PIOS_INCLUDE_SBUS */
+			break;
 		}
 		if(value < 0)
 			value = 0;

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -36,6 +36,7 @@
 				<option>None</option>
 				<option>PWM</option>
 				<option>PPM</option>
+				<option>S.Bus</option>
 				<option>ADC</option>
 				<option>OpenLRS</option>
 				<option>FrSkyPWM</option>


### PR DESCRIPTION
For example with the taranis you can send the RSSI value also as one of the rc channels.
So when using S.Bus you don't need extra cabels, filters etc. Just select the configured channel.

Signed-off-by: Trex4Git <trex_dev@gmx.net>