### PR TITLE
Upgrade to qt5.5

### DIFF
--- a/ground/gcs/src/libs/utils/xmlconfig.cpp
+++ b/ground/gcs/src/libs/utils/xmlconfig.cpp
@@ -39,6 +39,7 @@
 #include <QSize>
 #include <QPoint>
 #include <QtCore/QUrl>
+#include <QDataStream>
 
 #define NUM_PREFIX "arr_"
 

--- a/ground/gcs/src/plugins/hitl/il2simulator.cpp
+++ b/ground/gcs/src/plugins/hitl/il2simulator.cpp
@@ -71,6 +71,10 @@
 #include <coreplugin/threadmanager.h>
 #include <math.h>
 
+using std::isnan;
+using std::isinf;
+
+
 IL2Simulator::IL2Simulator(const SimulatorSettings& params) :
     Simulator(params)
 {

--- a/ground/gcs/src/shared/qtsingleapplication/qtlocalpeer.cpp
+++ b/ground/gcs/src/shared/qtsingleapplication/qtlocalpeer.cpp
@@ -38,6 +38,8 @@ typedef BOOL(WINAPI*PProcessIdToSessionId)(DWORD,DWORD*);
 static PProcessIdToSessionId pProcessIdToSessionId = 0;
 #endif
 
+#include <QDataStream>
+
 #if defined(Q_OS_UNIX)
 #include <time.h>
 #include <unistd.h>

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -22,13 +22,13 @@ ifdef OPENOCD_FTDI
 endif
 
 # Set up QT toolchain
-QT_SDK_DIR := $(TOOLS_DIR)/Qt5.4.1
+QT_SDK_DIR := $(TOOLS_DIR)/Qt5.5.0
 
 ifdef LINUX
   ifdef AMD64
-    QT_PLUGINS_DIR = $(QT_SDK_DIR)/5.4/gcc_64/plugins
+    QT_PLUGINS_DIR = $(QT_SDK_DIR)/5.5/gcc_64/plugins
   else
-    QT_PLUGINS_DIR = $(QT_SDK_DIR)/5.4/gcc/plugins
+    QT_PLUGINS_DIR = $(QT_SDK_DIR)/5.5/gcc/plugins
   endif
 endif
 
@@ -57,23 +57,23 @@ OPENOCD_FTDI ?= yes
 ifdef LINUX
   ifdef AMD64
     # Linux 64-bit
-    qt_sdk_install: QT_SDK_URL := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-linux-x64-5.4.1.run
-    QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/gcc_64/bin/qmake
+    qt_sdk_install: QT_SDK_URL := http://download.qt.io/official_releases/qt/5.5/5.5.0/qt-opensource-linux-x64-5.5.0.run
+    QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.5/gcc_64/bin/qmake
   else
     # Linux 32-bit
-    qt_sdk_install: QT_SDK_URL := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-linux-x86-5.4.1.run
-    QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/gcc/bin/qmake
+    qt_sdk_install: QT_SDK_URL := http://download.qt.io/official_releases/qt/5.5/5.5.0/qt-opensource-linux-x86-5.5.0.run
+    QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.5/gcc/bin/qmake
   endif
 endif
 
 ifdef MACOSX
-  qt_sdk_install: QT_SDK_URL  := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-mac-x64-clang-5.4.1.dmg
-  QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/clang_64/bin/qmake
+  qt_sdk_install: QT_SDK_URL  := http://download.qt.io/official_releases/qt/5.5/5.5.0/qt-opensource-mac-x64-clang-5.5.0.dmg
+  QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.5/clang_64/bin/qmake
 endif
 
 ifdef WINDOWS
-  qt_sdk_install: QT_SDK_URL  := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-windows-x86-mingw491_opengl-5.4.1.exe
-  QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/mingw491_32/bin/qmake
+  qt_sdk_install: QT_SDK_URL  := http://download.qt.io/official_releases/qt/5.5/5.5.0/qt-opensource-windows-x86-mingw492-5.5.0.exe
+  QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.5/mingw491_32/bin/qmake
 endif
 
 qt_sdk_install: QT_SDK_FILE := $(notdir $(QT_SDK_URL))
@@ -93,10 +93,10 @@ qt_sdk_install: qt_sdk_clean
 
 ifneq (,$(filter $(UNAME), Darwin))
 	$(V1) hdiutil attach -quiet -private -mountpoint /tmp/qt-installer "$(DL_DIR)/$(QT_SDK_FILE)" 
-	$(V1) /tmp/qt-installer/qt-opensource-mac-x64-clang-5.4.1.app/Contents/MacOS/qt-opensource-mac-x64-clang-5.4.1
+	$(V1) /tmp/qt-installer/qt-opensource-mac-x64-clang-5.5.0.app/Contents/MacOS/qt-opensource-mac-x64-clang-5.5.0
 	$(V1) hdiutil detach -quiet /tmp/qt-installer
 endif
- 
+
 ifneq (,$(filter $(UNAME), Linux))
         #installer is an executable, make it executable and run it
 	$(V1) chmod u+x "$(DL_DIR)/$(QT_SDK_FILE)"
@@ -104,7 +104,7 @@ ifneq (,$(filter $(UNAME), Linux))
 endif
 
 ifdef WINDOWS
-	$(V1) ./downloads/qt-opensource-windows-x86-mingw491_opengl-5.4.1.exe
+	$(V1) ./downloads/qt-opensource-windows-x86-mingw491_opengl-5.5.0.exe
 endif
 
 .PHONY: qt_sdk_clean
@@ -512,7 +512,7 @@ ifeq ($(shell [ -d "$(QT_SDK_DIR)" ] && echo "exists"), exists)
   QMAKE = $(QT_SDK_QMAKE_PATH)
 ifdef WINDOWS
   # Windows needs to be told where to find Qt libraries
-  export PATH := $(QT_SDK_DIR)/5.4/mingw491_32/bin:$(PATH) 
+  export PATH := $(QT_SDK_DIR)/5.5/mingw491_32/bin:$(PATH)
 endif
 else
   # not installed, hope it's in the path...
@@ -556,7 +556,7 @@ endif
 # OPENSSL download URL
 ifdef WINDOWS
   openssl_install: OPENSSL_URL  := http://slproweb.com/download/Win32OpenSSL-1_0_2c.exe
-  
+
 openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl
 # order-only prereq on directory existance:

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -73,7 +73,7 @@ endif
 
 ifdef WINDOWS
   qt_sdk_install: QT_SDK_URL  := http://download.qt.io/official_releases/qt/5.5/5.5.0/qt-opensource-windows-x86-mingw492-5.5.0.exe
-  QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.5/mingw491_32/bin/qmake
+  QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.5/mingw492_32/bin/qmake
 endif
 
 qt_sdk_install: QT_SDK_FILE := $(notdir $(QT_SDK_URL))
@@ -104,7 +104,7 @@ ifneq (,$(filter $(UNAME), Linux))
 endif
 
 ifdef WINDOWS
-	$(V1) ./downloads/qt-opensource-windows-x86-mingw491_opengl-5.5.0.exe
+	$(V1) ./downloads/qt-opensource-windows-x86-mingw492-5.5.0.exe
 endif
 
 .PHONY: qt_sdk_clean
@@ -512,7 +512,7 @@ ifeq ($(shell [ -d "$(QT_SDK_DIR)" ] && echo "exists"), exists)
   QMAKE = $(QT_SDK_QMAKE_PATH)
 ifdef WINDOWS
   # Windows needs to be told where to find Qt libraries
-  export PATH := $(QT_SDK_DIR)/5.5/mingw491_32/bin:$(PATH)
+  export PATH := $(QT_SDK_DIR)/5.5/mingw492_32/bin:$(PATH)
 endif
 else
   # not installed, hope it's in the path...


### PR DESCRIPTION
Qt 5.5.0 has been released.  These changes pick up the new release and fix a couple small build errors.

http://www.qt.io/qt5-5/

Builds and runs on Linux 64-bit.  Haven't tested with a board attached yet.  There's a segfault on exit that needs to be looked into.  Not sure if that's new.

I also noticed a few warnings about using deprecated header files.  Not a blocker but those should be looked into as well.  Might be as simple as just pointing at the new/non-deprecated header paths.

Would appreciate testing on other platforms.
