### PR TITLE
GCS/ExpoCurve: use a new QwtSymbol instance for each QwtPlotMarker

### DIFF
--- a/ground/gcs/src/plugins/config/expocurve.cpp
+++ b/ground/gcs/src/plugins/config/expocurve.cpp
@@ -102,27 +102,33 @@ ExpoCurve::ExpoCurve(QWidget *parent) :
     //marker for horizon transition value
     QwtSymbol *sym1 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::blue), QPen(Qt::blue), QSize(7, 7));
     roll_elements.Mark.setSymbol(sym1);
+    sym1 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::blue), QPen(Qt::blue), QSize(7, 7));
     roll_elements.Mark_.setSymbol(sym1);
     QwtSymbol *sym1_2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::darkBlue), QPen(Qt::darkBlue), QSize(7, 7));
     roll_elements.Mark2.setSymbol(sym1_2);
+    sym1_2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::darkBlue), QPen(Qt::darkBlue), QSize(7, 7));
     roll_elements.Mark2_.setSymbol(sym1_2);
     roll_elements.Mark2.setYAxis(QwtPlot::yRight);
     roll_elements.Mark2_.setYAxis(QwtPlot::yRight);
 
     QwtSymbol *sym2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::red), QPen(Qt::red), QSize(7, 7));
     pitch_elements.Mark.setSymbol(sym2);
+    sym2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::red), QPen(Qt::red), QSize(7, 7));
     pitch_elements.Mark_.setSymbol(sym2);
     QwtSymbol *sym2_2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::darkRed), QPen(Qt::darkRed), QSize(7, 7));
     pitch_elements.Mark2.setSymbol(sym2_2);
+    sym2_2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::darkRed), QPen(Qt::darkRed), QSize(7, 7));
     pitch_elements.Mark2_.setSymbol(sym2_2);
     pitch_elements.Mark2.setYAxis(QwtPlot::yRight);
     pitch_elements.Mark2_.setYAxis(QwtPlot::yRight);
 
     QwtSymbol *sym3 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::green), QPen(Qt::green), QSize(7, 7));
     yaw_elements.Mark.setSymbol(sym3);
+    sym3 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::green), QPen(Qt::green), QSize(7, 7));
     yaw_elements.Mark_.setSymbol(sym3);
     QwtSymbol *sym3_2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::darkGreen), QPen(Qt::darkGreen), QSize(7, 7));
     yaw_elements.Mark2.setSymbol(sym3_2);
+    sym3_2 = new QwtSymbol(QwtSymbol::Star1, QBrush(Qt::darkGreen), QPen(Qt::darkGreen), QSize(7, 7));
     yaw_elements.Mark2_.setSymbol(sym3_2);
     yaw_elements.Mark2.setYAxis(QwtPlot::yRight);
     yaw_elements.Mark2_.setYAxis(QwtPlot::yRight);


### PR DESCRIPTION
Fixes crash on exit