### PR TITLE
make: upgrade qt install package to qt5.4.2

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -22,7 +22,7 @@ ifdef OPENOCD_FTDI
 endif
 
 # Set up QT toolchain
-QT_SDK_DIR := $(TOOLS_DIR)/Qt5.4.1
+QT_SDK_DIR := $(TOOLS_DIR)/Qt5.4.2
 
 ifdef LINUX
   ifdef AMD64
@@ -57,22 +57,22 @@ OPENOCD_FTDI ?= yes
 ifdef LINUX
   ifdef AMD64
     # Linux 64-bit
-    qt_sdk_install: QT_SDK_URL := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-linux-x64-5.4.1.run
+    qt_sdk_install: QT_SDK_URL := http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-linux-x64-5.4.2.run
     QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/gcc_64/bin/qmake
   else
     # Linux 32-bit
-    qt_sdk_install: QT_SDK_URL := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-linux-x86-5.4.1.run
+    qt_sdk_install: QT_SDK_URL := http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-linux-x86-5.4.2.run
     QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/gcc/bin/qmake
   endif
 endif
 
 ifdef MACOSX
-  qt_sdk_install: QT_SDK_URL  := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-mac-x64-clang-5.4.1.dmg
+  qt_sdk_install: QT_SDK_URL  := http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-mac-x64-clang-5.4.2.dmg
   QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/clang_64/bin/qmake
 endif
 
 ifdef WINDOWS
-  qt_sdk_install: QT_SDK_URL  := http://download.qt-project.org/official_releases/qt/5.4/5.4.1/qt-opensource-windows-x86-mingw491_opengl-5.4.1.exe
+  qt_sdk_install: QT_SDK_URL  := http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-windows-x86-mingw491_opengl-5.4.2.exe
   QT_SDK_QMAKE_PATH := $(QT_SDK_DIR)/5.4/mingw491_32/bin/qmake
 endif
 
@@ -93,10 +93,10 @@ qt_sdk_install: qt_sdk_clean
 
 ifneq (,$(filter $(UNAME), Darwin))
 	$(V1) hdiutil attach -quiet -private -mountpoint /tmp/qt-installer "$(DL_DIR)/$(QT_SDK_FILE)" 
-	$(V1) /tmp/qt-installer/qt-opensource-mac-x64-clang-5.4.1.app/Contents/MacOS/qt-opensource-mac-x64-clang-5.4.1
+	$(V1) /tmp/qt-installer/qt-opensource-mac-x64-clang-5.4.2.app/Contents/MacOS/qt-opensource-mac-x64-clang-5.4.2
 	$(V1) hdiutil detach -quiet /tmp/qt-installer
 endif
- 
+
 ifneq (,$(filter $(UNAME), Linux))
         #installer is an executable, make it executable and run it
 	$(V1) chmod u+x "$(DL_DIR)/$(QT_SDK_FILE)"
@@ -104,7 +104,7 @@ ifneq (,$(filter $(UNAME), Linux))
 endif
 
 ifdef WINDOWS
-	$(V1) ./downloads/qt-opensource-windows-x86-mingw491_opengl-5.4.1.exe
+	$(V1) ./downloads/qt-opensource-windows-x86-mingw491_opengl-5.4.2.exe
 endif
 
 .PHONY: qt_sdk_clean
@@ -556,7 +556,7 @@ endif
 # OPENSSL download URL
 ifdef WINDOWS
   openssl_install: OPENSSL_URL  := http://slproweb.com/download/Win32OpenSSL-1_0_2c.exe
-  
+
 openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl
 # order-only prereq on directory existance:


### PR DESCRIPTION
This is supposed to include a fix for:
* qtbug-42954 (https://bugreports.qt.io/browse/QTBUG-42954)
* qtbug-42952 (https://bugreports.qt.io/browse/QTBUG-42952)
which broke packaging on mac.

Builds and runs (no board attached yet) on Linux 64-bit.

Needs testing on Windows and (especially) OSX.
