### PR TITLE
do not panic on external i2c errors

### DIFF
--- a/flight/targets/colibri/fw/pios_board.c
+++ b/flight/targets/colibri/fw/pios_board.c
@@ -692,7 +692,7 @@ void PIOS_Board_Init(void)
 		}
 
 		if (PIOS_I2C_CheckClear(pios_i2c_usart1_adapter_id) != 0)
-			panic(6);
+			AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 #if defined(PIOS_INCLUDE_HMC5883)
 		{
@@ -705,9 +705,9 @@ void PIOS_Board_Init(void)
 				if (PIOS_HMC5883_Init
 				    (pios_i2c_usart1_adapter_id,
 				     &pios_hmc5883_external_cfg) != 0)
-					panic(8);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 				if (PIOS_HMC5883_Test() != 0)
-					panic(8);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 		}
 #endif /* PIOS_INCLUDE_HMC5883 */
@@ -1012,7 +1012,7 @@ void PIOS_Board_Init(void)
 			PIOS_Assert(0);
 		}
 		if (PIOS_I2C_CheckClear(pios_i2c_usart3_adapter_id) != 0)
-			panic(7);
+			AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 #if defined(PIOS_INCLUDE_HMC5883)
 		{
@@ -1025,9 +1025,9 @@ void PIOS_Board_Init(void)
 				if (PIOS_HMC5883_Init
 				    (pios_i2c_usart3_adapter_id,
 				     &pios_hmc5883_external_cfg) != 0)
-					panic(9);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 				if (PIOS_HMC5883_Test() != 0)
-					panic(9);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 		}
 #endif /* PIOS_INCLUDE_HMC5883 */

--- a/flight/targets/flyingf3/fw/pios_board.c
+++ b/flight/targets/flyingf3/fw/pios_board.c
@@ -344,13 +344,13 @@ void PIOS_Board_Init(void) {
 		PIOS_DEBUG_Assert(0);
 	}
 	if (PIOS_I2C_CheckClear(pios_i2c_internal_id) != 0)
-		panic(3);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 	if (PIOS_I2C_Init(&pios_i2c_external_id, &pios_i2c_external_cfg)) {
 		PIOS_DEBUG_Assert(0);
 	}
 	if (PIOS_I2C_CheckClear(pios_i2c_external_id) != 0)
-		panic(4);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 #endif
 
 #if defined(PIOS_INCLUDE_CAN)
@@ -1275,11 +1275,11 @@ void PIOS_Board_Init(void) {
 
 #if defined(PIOS_INCLUDE_LSM303) && defined(PIOS_INCLUDE_I2C)
 	if (PIOS_LSM303_Init(pios_i2c_internal_id, &pios_lsm303_cfg) != 0)
-		panic(2);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 	if (PIOS_LSM303_Accel_Test() != 0)
-		panic(2);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 	if (PIOS_LSM303_Mag_Test() != 0)
-		panic(2);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 	uint8_t hw_accel_range;
 	HwFlyingF3AccelRangeGet(&hw_accel_range);
@@ -1356,9 +1356,9 @@ void PIOS_Board_Init(void) {
 	case HWFLYINGF3_SHIELD_BMP085:
 #if defined(PIOS_INCLUDE_BMP085) && defined(PIOS_INCLUDE_I2C)
 	if (PIOS_BMP085_Init(&pios_bmp085_cfg, pios_i2c_external_id) != 0)
-		panic(5);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 	if (PIOS_BMP085_Test() != 0)
-		panic(5);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 #endif /* PIOS_INCLUDE_BMP085 && PIOS_INCLUDE_I2C */
 		break;
 	case HWFLYINGF3_SHIELD_NONE:

--- a/flight/targets/flyingf4/fw/pios_board.c
+++ b/flight/targets/flyingf4/fw/pios_board.c
@@ -920,14 +920,14 @@ void PIOS_Board_Init(void) {
 	}
 
 	if (PIOS_I2C_CheckClear(pios_i2c_10dof_adapter_id) != 0)
-		panic(5);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 #if defined(PIOS_INCLUDE_MPU6050)
 
 	if (PIOS_MPU6050_Init(pios_i2c_10dof_adapter_id, PIOS_MPU6050_I2C_ADD_A0_LOW, &pios_mpu6050_cfg) != 0)
-		panic(2);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 	if (PIOS_MPU6050_Test() != 0)
-		panic(2);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 	// To be safe map from UAVO enum to driver enum
 	uint8_t hw_gyro_range;
@@ -1007,9 +1007,9 @@ void PIOS_Board_Init(void) {
 		if (Magnetometer == HWFLYINGF4_MAGNETOMETER_EXTERNALI2C) {
 
 			if (PIOS_HMC5883_Init(pios_i2c_10dof_adapter_id, &pios_hmc5883_external_cfg) != 0)
-				panic(3);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			if (PIOS_HMC5883_Test() != 0)
-				panic(3);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 			// setup sensor orientation
 			uint8_t ExtMagOrientation;
@@ -1035,9 +1035,9 @@ void PIOS_Board_Init(void) {
 
 #if defined(PIOS_INCLUDE_MS5611)
 	if (PIOS_MS5611_Init(&pios_ms5611_cfg, pios_i2c_10dof_adapter_id) != 0)
-		panic(4);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 	if (PIOS_MS5611_Test() != 0)
-		panic(4);
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 #endif
 
 	//I2C is slow, sensor init as well, reset watchdog to prevent reset here

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -624,7 +624,7 @@ void PIOS_Board_Init(void) {
 		}
 
 		if (PIOS_I2C_CheckClear(pios_i2c_usart1_adapter_id) != 0)
-			panic(6);
+			AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 #if defined(PIOS_INCLUDE_HMC5883)
 		{
@@ -634,9 +634,9 @@ void PIOS_Board_Init(void) {
 			if (Magnetometer == HWQUANTON_MAGNETOMETER_EXTERNALI2CUART1) {
 				// init sensor
 				if (PIOS_HMC5883_Init(pios_i2c_usart1_adapter_id, &pios_hmc5883_external_cfg) != 0)
-					panic(8);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 				if (PIOS_HMC5883_Test() != 0)
-					panic(8);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 		}
 #endif /* PIOS_INCLUDE_HMC5883 */
@@ -859,7 +859,7 @@ void PIOS_Board_Init(void) {
 			PIOS_Assert(0);
 		}
 		if (PIOS_I2C_CheckClear(pios_i2c_usart3_adapter_id) != 0)
-			panic(7);
+			AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 
 #if defined(PIOS_INCLUDE_HMC5883)
 		{
@@ -869,9 +869,9 @@ void PIOS_Board_Init(void) {
 			if (Magnetometer == HWQUANTON_MAGNETOMETER_EXTERNALI2CUART3) {
 				// init sensor
 				if (PIOS_HMC5883_Init(pios_i2c_usart3_adapter_id, &pios_hmc5883_external_cfg) != 0)
-					panic(9);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 				if (PIOS_HMC5883_Test() != 0)
-					panic(9);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 		}
 #endif /* PIOS_INCLUDE_HMC5883 */

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -617,7 +617,7 @@ void PIOS_Board_Init(void) {
 			}
 
 			if (PIOS_I2C_CheckClear(pios_i2c_flexi_id) != 0)
-				panic(11);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 #endif /* PIOS_INCLUDE_I2C */
                break;
 	case HWSPARKY_FLEXIPORT_SBUS:
@@ -1097,9 +1097,9 @@ void PIOS_Board_Init(void) {
 				PIOS_WDG_Clear();
 
 				if (PIOS_HMC5883_Init(pios_i2c_flexi_id, &pios_hmc5883_external_cfg) != 0)
-					panic(11);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 				if (PIOS_HMC5883_Test() != 0)
-					panic(11);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 
 			enum pios_hmc5883_orientation hmc5883_orientation = \

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -782,7 +782,7 @@ void PIOS_Board_Init(void) {
 					PIOS_Assert(0);
 				}
 				if (PIOS_I2C_CheckClear(pios_i2c_flexiport_adapter_id) != 0)
-					panic(6);
+					AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 #endif	/* PIOS_INCLUDE_I2C */
 			break;
@@ -1264,14 +1264,14 @@ void PIOS_Board_Init(void) {
 		if (Magnetometer == HWSPARKY2_MAGNETOMETER_EXTERNALI2CFLEXIPORT)
 		{
 			if (PIOS_HMC5883_Init(pios_i2c_flexiport_adapter_id, &pios_hmc5883_external_cfg) != 0)
-				panic(6);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			if (PIOS_HMC5883_Test() != 0)
-				panic(6);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 		} else if (Magnetometer == HWSPARKY2_MAGNETOMETER_EXTERNALAUXI2C) {
 			if (PIOS_HMC5883_Init(pios_i2c_mag_pressure_adapter_id, &pios_hmc5883_external_cfg) != 0)
-				panic(6);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			if (PIOS_HMC5883_Test() != 0)
-				panic(6);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 		}
 
 		if (Magnetometer != HWSPARKY2_MAGNETOMETER_INTERNAL) {


### PR DESCRIPTION
I'm using an ATtiny as a I2C slave. My quanton panics when the attiny is not powered (when the FC is only powered by the usb port)

16:25 < peabody124> laurent: yeah i agree throwing error instead of panic makes more sense for external sensors

I took your words for it ;-) here is a proposal I tested with one quanton.
I'm not too sure about flyingf3/f4, by definition i think all sensors are external ones on these platforms.