### PR TITLE
ManualControl: Use rising edge to detect switch arming

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -621,15 +621,22 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 	{
 		set_armed_if_changed(FLIGHTSTATUS_ARMED_DISARMED);
 
+		// last_arm used for detecting a rising edge to trigger switch arming
+		static bool last_arm = false;
 		bool arm = arming_position(cmd, settings) && valid;
 
 		if (arm && (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCH ||
 				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE)) {
-			arm_state = ARM_STATE_ARMED;
+			if (!last_arm) {
+				armedDisarmStart = lastSysTime;
+				arm_state = ARM_STATE_ARMED;
+			}
 		} else if (arm) {
 			armedDisarmStart = lastSysTime;
 			arm_state = ARM_STATE_ARMING;
 		}
+
+		last_arm = arm;
 	}
 		break;
 


### PR DESCRIPTION
Currently when using switch arming (switch or switch+throttle) with an arming timeout delay set, the arming state will toggle between armed and disarmed every time the inputs are processed while the throttle is low (throttle command less than 0, i.e. below neutral). This is because the disarm timeout is not initialised for switch arming.

This PR fixes that by detecting a rising edge on the arming position and initialising the disarm timeout correctly (Note: it is necessary to use a rising edge as otherwise every time the disarm timeout caused a disarm, the switch would cause a re-arm on the next iteration). Perhaps there is a better name for the last_arm and I can change it if there's already a convention in the code.