### PR TITLE
GPS: Change GPS error when no port is assigned to GPS

### DIFF
--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -100,7 +100,7 @@ int32_t GPSStart(void)
 			return 0;
 		}
 
-		AlarmsSet(SYSTEMALARMS_ALARM_GPS, SYSTEMALARMS_ALARM_CRITICAL);
+		AlarmsSet(SYSTEMALARMS_ALARM_GPS, SYSTEMALARMS_ALARM_ERROR);
 	}
 	return -1;
 }

--- a/ground/gcs/src/plugins/systemhealth/html/GPS-Error.html
+++ b/ground/gcs/src/plugins/systemhealth/html/GPS-Error.html
@@ -7,7 +7,7 @@
   <body style="color: black">
     <h1>GPS: Error</h1>
     <p>
-    The GPS has timed out; either there is no GPS plugged in, the GPS has locked up or there is some other hardware fault.
+    The GPS has timed out; either there is no GPS plugged in, the GPS has locked up, there is no port assigned to GPS, or there is some other hardware fault.
     </p>
   </body>
 </html>


### PR DESCRIPTION
When no port is assigned to GPS but the GPS module is enabled, the GPS alarm is set to Critical (filled red box), which gives the user the indication that the GPS is receiving data but has zero satellites. This request changes the alarm to Error, which is indicated with a red X, and the tooltip is updated to include this case.