### PR TITLE
sparky2: remove 250Hz gyro LPF.

### DIFF
--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -1219,7 +1219,6 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_mpu9250_dlpf;
 	HwSparky2MPU9250GyroLPFGet(&hw_mpu9250_dlpf);
 	enum pios_mpu9250_gyro_filter mpu9250_gyro_lpf = \
-	    (hw_mpu9250_dlpf == HWSPARKY2_MPU9250GYROLPF_250) ? PIOS_MPU9250_GYRO_LOWPASS_250_HZ : \
 	    (hw_mpu9250_dlpf == HWSPARKY2_MPU9250GYROLPF_184) ? PIOS_MPU9250_GYRO_LOWPASS_184_HZ : \
 	    (hw_mpu9250_dlpf == HWSPARKY2_MPU9250GYROLPF_92) ? PIOS_MPU9250_GYRO_LOWPASS_92_HZ : \
 	    (hw_mpu9250_dlpf == HWSPARKY2_MPU9250GYROLPF_41) ? PIOS_MPU9250_GYRO_LOWPASS_41_HZ : \

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -77,7 +77,7 @@
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="2000"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
 		<field name="MPU9250Rate" units="Hz" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="500"/>
-		<field name="MPU9250GyroLPF" units="Hz" type="enum" elements="1" options="250,184,92,41,20,10,5" defaultvalue="184"/>
+		<field name="MPU9250GyroLPF" units="Hz" type="enum" elements="1" options="184,92,41,20,10,5" defaultvalue="184"/>
 		<field name="MPU9250AccelLPF" units="Hz" type="enum" elements="1" options="460,184,92,41,20,10,5" defaultvalue="184"/>
 
 		<field name="VTX_Ch" units="Hz" type="enum" elements="1" options="1,2,3,4,5,6,7,8" defaultvalue="1"/>


### PR DESCRIPTION
Issue #1724 / From pios_mpu9250_spi.c:
    int32_t PIOS_MPU9250_SetSampleRate(uint16_t samplerate_hz)
    {
            // mpu9250 ODR divider is unable to run from 8kHz clock like mpu60x0 :(
            // check if someone want to use 250Hz DLPF and don't want 8kHz sampling
            // and politely refuse him

I don't know if this is true or not-- the datasheet is ambiguous in its wording and I have not tested on bare hardware.  But in any case the current 250Hz DLPF code is broken, doesn't respect the user-configured sample rate, and trying to run the flight loop at 8KHz is unreasonable.