### PR TITLE
20150718 - FrSky Sensor Hub Update

### DIFF
--- a/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
+++ b/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
@@ -410,7 +410,7 @@ static void uavoFrSKYSensorHubBridgeTask(void *parameters)
 			float hdop, vdop;
 
 			status = (flight_status.Armed == FLIGHTSTATUS_ARMED_ARMED) ? 200 : 100;
-	        status += flight_status.FlightMode;
+			status += flight_status.FlightMode;
 
 			msg_length += frsky_pack_rpm(status, serial_buf + msg_length);
 

--- a/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
+++ b/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
@@ -394,74 +394,74 @@ static void uavoFrSKYSensorHubBridgeTask(void *parameters)
 		if (frame_trigger(FRSKY_FRAME_GPS)) {
 			msg_length = 0;
 
-            /**
-             * Encodes ARM status and flight mode number as RPM value
-             * Since there is no RPM information in any UAVO available,
-             * we will intentionally misuse this item to encode other useful information.
-             * It will encode flight status as three-digit number as follow:
-             * most left digit encodes arm status (200=armed, 100=disarmed)
-             * two most right digits encode flight mode number (see FlightStatus UAVO FlightMode enum)
-             * To work properly on Taranis, you have to set Blades to "60" in telemetry setting
-             */
-            FlightStatusData flight_status;
-	        FlightStatusGet(&flight_status);
+			/**
+			 * Encodes ARM status and flight mode number as RPM value
+			 * Since there is no RPM information in any UAVO available,
+			 * we will intentionally misuse this item to encode other useful information.
+			 * It will encode flight status as three-digit number as follow:
+			 * most left digit encodes arm status (200=armed, 100=disarmed)
+			 * two most right digits encode flight mode number (see FlightStatus UAVO FlightMode enum)
+			 * To work properly on Taranis, you have to set Blades to "60" in telemetry setting
+			 */
+			FlightStatusData flight_status;
+			FlightStatusGet(&flight_status);
 
-	        uint16_t status = 0;
+			uint16_t status = 0;
 			float hdop, vdop;
 
 			status = (flight_status.Armed == FLIGHTSTATUS_ARMED_ARMED) ? 200 : 100;
 	        status += flight_status.FlightMode;
 
-        	msg_length += frsky_pack_rpm(status, serial_buf + msg_length);
+			msg_length += frsky_pack_rpm(status, serial_buf + msg_length);
 
-	        uint8_t hl_set = HOMELOCATION_SET_FALSE;
-	        
+			uint8_t hl_set = HOMELOCATION_SET_FALSE;
+			
 			if (GPSPositionHandle() != NULL)
 				GPSPositionGet(&gpsPosData);
 
 			if (HomeLocationHandle() != NULL)
-		        HomeLocationSetGet(&hl_set);
+				HomeLocationSetGet(&hl_set);
         
-		    /**
-             * Encode GPS status and visible satellites as T1 value
-             * We will intentionally misuse this item to encode other useful information.
-             * Right-most two digits encode visible satellite count, left-most digit has following meaning:
-             * 1 - no GPS connected
-             * 2 - no fix
-             * 3 - 2D fix
-             * 4 - 3D fix
-             * 5 - 3D fix and HomeLocation is SET - should be safe for navigation
-             */
-	        switch (gpsPosData.Status) {
-        	case GPSPOSITION_STATUS_NOGPS:
-        		status = 100;
-		        break;
-	        case GPSPOSITION_STATUS_NOFIX:
-		        status = 200;
-		        break;
-	        case GPSPOSITION_STATUS_FIX2D:
-		        status = 300;
-		        break;
-	        case GPSPOSITION_STATUS_FIX3D:
-	        case GPSPOSITION_STATUS_DIFF3D:
-		        if (hl_set == HOMELOCATION_SET_TRUE)
-			        status = 500;
-		        else
-			        status = 400;
-		        break;
-	        }
+			/**
+			 * Encode GPS status and visible satellites as T1 value
+			 * We will intentionally misuse this item to encode other useful information.
+			 * Right-most two digits encode visible satellite count, left-most digit has following meaning:
+			 * 1 - no GPS connected
+			 * 2 - no fix
+			 * 3 - 2D fix
+			 * 4 - 3D fix
+			 * 5 - 3D fix and HomeLocation is SET - should be safe for navigation
+			 */
+			switch (gpsPosData.Status) {
+			case GPSPOSITION_STATUS_NOGPS:
+			status = 100;
+				break;
+			case GPSPOSITION_STATUS_NOFIX:
+				status = 200;
+				break;
+			case GPSPOSITION_STATUS_FIX2D:
+				status = 300;
+				break;
+			case GPSPOSITION_STATUS_FIX3D:
+			case GPSPOSITION_STATUS_DIFF3D:
+				if (hl_set == HOMELOCATION_SET_TRUE)
+					status = 500;
+				else
+					status = 400;
+				break;
+			}
 	
-	        if (gpsPosData.Satellites > 0)
-		        status += gpsPosData.Satellites;
+			if (gpsPosData.Satellites > 0)
+				status += gpsPosData.Satellites;
 
-	        msg_length += frsky_pack_temperature_01((float)status, serial_buf + msg_length);
+			msg_length += frsky_pack_temperature_01((float)status, serial_buf + msg_length);
 			
-		    /**
-             * Encode GPS HDOP and VDOP as T2 value
-             * We will intentionally misuse this item to encode other useful information.
+			/**
+			 * Encode GPS HDOP and VDOP as T2 value
+			 * We will intentionally misuse this item to encode other useful information.
 			 * VDOP in the upper 16 bits, max 256 (2.56 * 100)
 			 * HDOP in the lower 16 bits, max 256 (2.56 * 100)
-             */
+			 */
 			hdop = gpsPosData.HDOP * 100.0f;
 			
 			if (hdop > 256.0f)


### PR DESCRIPTION
Encode arm state and flight mode into RPM, gps mode and satellite count into T1, and hdop/vdop into T2.  This drives the illustrated custom telemetry display on the Taranis.  Similar changes to the Sport Telem should also drive the telemetry display, although I can test that config.  Need to figure out how to distrubute the LUA script for those interested too.  The telemtry script was derived from one I found for DJI systems.

![image](https://cloud.githubusercontent.com/assets/3869782/8762114/879b56d2-2d2c-11e5-84ee-06c592071252.png)
