### PR TITLE
UAVOFrSkySPortBridge: left only one device ID

### DIFF
--- a/flight/Modules/UAVOFrSKYSPortBridge/UAVOFrSKYSPortBridge.c
+++ b/flight/Modules/UAVOFrSKYSPortBridge/UAVOFrSKYSPortBridge.c
@@ -142,7 +142,7 @@ static const struct frsky_value_item frsky_value_items[] = {
 	{FRSKY_AIR_SPEED_ID,   100,   frsky_encode_airspeed,   0}, // airspeed
 };
 
-static const uint8_t frsky_sensor_ids[] = {0x1b, 0x0d, 0x34, 0x67};
+static const uint8_t frsky_sensor_ids[] = {0x1b};
 struct frsky_sport_telemetry {
 	struct pios_thread *task;
 	uintptr_t com;


### PR DESCRIPTION
With newer FrSky receiver firmwares there is no longer significant bandwidth
penalty when using only single one sensor device ID. It also makes new OpenTx (>=2.1.0)
happy, because when there is multiple sensor devices it treats each as separate
instance, which causes difficulties and also quickly fill all available telemetry slots on Taranis.