### PR TITLE
Produce and process code coverage data from the GCS

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -133,3 +133,15 @@ win32 {
 	# http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
 	QMAKE_CXXFLAGS += -mno-ms-bitfields
 }
+
+unix {
+GEN_GCOV {
+QMAKE_CXXFLAGS += -g -Wall -fprofile-arcs -ftest-coverage -O0
+QMAKE_LFLAGS += -g -Wall -fprofile-arcs -ftest-coverage  -O0
+LIBS += \
+    -lgcov
+unix:OBJECTS_DIR = ./Build
+unix:MOC_DIR = ./Build
+unix:UI_DIR = ./Build
+}
+}

--- a/ground/gcs/src/plugins/coreplugin/coreplugin.pro
+++ b/ground/gcs/src/plugins/coreplugin/coreplugin.pro
@@ -5,7 +5,6 @@ DEFINES += CORE_LIBRARY
 QT += widgets
 QT += xml \
     network \
-    script \
     svg \
     sql
 include(../../taulabsgcsplugin.pri)


### PR DESCRIPTION
Also created a small script https://gist.github.com/guilhermito/842e0dc215fb3a64a8f5 to make it simpler to use.
Code coverage is usually used with unit tests but it is also good to find stale unused code.