### PR TITLE
simulation/posix: port to architectures besides x86.

### DIFF
--- a/flight/PiOS.posix/posix/library_chibios.mk
+++ b/flight/PiOS.posix/posix/library_chibios.mk
@@ -19,6 +19,5 @@ PIOS_DEVLIB			:=	$(dir $(lastword $(MAKEFILE_LIST)))
 #
 # Compiler options implied by posix
 #
-ARCHFLAGS			+= -DARCH_POSIX
+ARCHFLAGS			+= -DARCH_POSIX -pthread
 ARCHFLAGS			+= -D_GNU_SOURCE
-ARCHFLAGS			+= -m32

--- a/flight/PiOS.posix/posix/library_chibios.mk
+++ b/flight/PiOS.posix/posix/library_chibios.mk
@@ -1,6 +1,8 @@
 #
-# Rules to (help) build the F4xx device support.
+# Rules to (help) build the Posix-targeted code.
 #
+
+include $(MAKE_INC_DIR)/system-id.mk
 
 #
 # Directory containing this makefile
@@ -19,5 +21,22 @@ PIOS_DEVLIB			:=	$(dir $(lastword $(MAKEFILE_LIST)))
 #
 # Compiler options implied by posix
 #
-ARCHFLAGS			+= -DARCH_POSIX -pthread
+ARCHFLAGS			+= -DARCH_POSIX
 ARCHFLAGS			+= -D_GNU_SOURCE
+
+# The posix code is not threaded but it is possibly re-entrant into the
+# system libraries because of task switching.  As a result, request the
+# re-entrant libraries and -D_REENTRANT
+ifdef MACOSX
+# If we are building with clang, it doesn't like the pthread argument being
+# passed at link time.  Annoying.
+CONLYFLAGS			+= -pthread
+else
+ARCHFLAGS			+= -pthread
+endif
+
+# Build 32 bit code.
+ifdef AMD64
+ARCHFLAGS                      += -m32
+endif
+

--- a/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/SIMIA32/chcore.h
+++ b/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/SIMIA32/chcore.h
@@ -77,7 +77,7 @@
  *          @p extctx is known to be zero.
  */
 #if !defined(PORT_INT_REQUIRED_STACK) || defined(__DOXYGEN__)
-#define PORT_INT_REQUIRED_STACK        32768 
+#define PORT_INT_REQUIRED_STACK        262144
 #endif
 
 /**

--- a/flight/targets/simulation/fw/main.c
+++ b/flight/targets/simulation/fw/main.c
@@ -45,11 +45,7 @@ extern void Stack_Change(void);
 
 /* Local Variables */
 #define INIT_TASK_PRIORITY	PIOS_THREAD_PRIO_HIGHEST
-#if defined(SIM_POSIX) 
-#define INIT_TASK_STACK		32768
-#else
-#define INIT_TASK_STACK		1024
-#endif /* defined(SIM_POSIX) */
+#define INIT_TASK_STACK		262144
 static struct pios_thread *initTaskHandle;
 
 /* Function Prototypes */


### PR DESCRIPTION
This is work towards Raspberry Pi2 target support.  Verified that simulation works / flies nav successfully on RPi2.