### PR TITLE
flight/PIOS: SPI speed enhancements for MPU6000 & MPU9250_SPI

### DIFF
--- a/flight/PiOS/Common/pios_mpu6000.c
+++ b/flight/PiOS/Common/pios_mpu6000.c
@@ -47,7 +47,7 @@
 #ifdef PIOS_MPU6000_SPI_HIGH_SPEED
 #define MPU6000_SPI_HIGH_SPEED              PIOS_MPU6000_SPI_HIGH_SPEED
 #else
-#define MPU6000_SPI_HIGH_SPEED              21100000	// slightly higher then 21MHz so that it is really 21MHz after prescaler calculations
+#define MPU6000_SPI_HIGH_SPEED              20000000	// should result in 10.5MHz clock on F4 targets like Quanton, and 18MHz on F1 targets like CC3D
 #endif
 #define MPU6000_SPI_LOW_SPEED               1000000
 

--- a/flight/PiOS/Common/pios_mpu9250_spi.c
+++ b/flight/PiOS/Common/pios_mpu9250_spi.c
@@ -50,7 +50,7 @@
 #ifdef PIOS_MPU9250_SPI_HIGH_SPEED
 #define MPU9250_SPI_HIGH_SPEED              PIOS_MPU9250_SPI_HIGH_SPEED
 #else
-#define MPU9250_SPI_HIGH_SPEED              20000000
+#define MPU9250_SPI_HIGH_SPEED              21100000	// slightly higher then 21MHz so that it is really 21MHz after prescaler calculations
 #endif
 #define MPU9250_SPI_LOW_SPEED               300000
 

--- a/flight/PiOS/Common/pios_mpu9250_spi.c
+++ b/flight/PiOS/Common/pios_mpu9250_spi.c
@@ -50,7 +50,7 @@
 #ifdef PIOS_MPU9250_SPI_HIGH_SPEED
 #define MPU9250_SPI_HIGH_SPEED              PIOS_MPU9250_SPI_HIGH_SPEED
 #else
-#define MPU9250_SPI_HIGH_SPEED              21100000	// slightly higher then 21MHz so that it is really 21MHz after prescaler calculations
+#define MPU9250_SPI_HIGH_SPEED              20000000	// should result in 10.5MHz clock on F4 targets like Sparky2
 #endif
 #define MPU9250_SPI_LOW_SPEED               300000
 


### PR DESCRIPTION
Enhancement for the SPI clock to speed up data transfer after the configuration is done.
The data register in MPU can be read up to 20MHz +-10%.
For F4 µC based FC (e.g. Quanton, Sparky 2) this should result in 21MHz SPI clock, for F1 based µC it should result in 18MHz.

First tests on Quanton were successful.
CC3D and Sparky 2 need testing.

This will also be included when the new sub-samlping / filter functionality is done and might get merged sometime: https://github.com/TauLabs/TauLabs/issues/1730

But it maybe helps also with other problems, and should reduce CPU load in general. So i extracted the enhancement from the other work (https://github.com/Trex4Git/TauLabs/commit/0a46d5748eec4fa38b504d7efc5420f2a525d277), to have a small PR with this enhancement already available.

The enhancement on CPU load can be seen in the table there: https://github.com/TauLabs/TauLabs/issues/1730#issuecomment-123429613

When there is no interest yet, i can close this PR.
