### PR TITLE
[WIP] flight/stabilization: enhancement of the gyro LPF functionality

### DIFF
--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -264,8 +264,8 @@ static void updatePIDs(UAVObjEvent* ev)
 			case TXPIDSETTINGS_PIDS_YAWATTITUDEILIMIT:
 				needsUpdate |= update(&stab.YawPI[STABILIZATIONSETTINGS_YAWPI_ILIMIT], value);
 				break;
-			case TXPIDSETTINGS_PIDS_GYROTAU:
-				needsUpdate |= update(&stab.GyroTau, value);
+			case TXPIDSETTINGS_PIDS_GYROCUTOFF:
+				needsUpdate |= update(&stab.GyroCutoff, value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLVBARSENSITIVITY: 
 				needsUpdate |= update(&stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_ROLL], value);

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -30,7 +30,7 @@
 	<field name="VbarPiroComp" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
 	<field name="VbarMaxAngle" units="deg" type="uint8" elements="1" defaultvalue="10"/>
 
-	<field name="GyroTau" units="" type="float" elements="1" defaultvalue="0.019"/>
+	<field name="GyroCutoff" units="Hz" type="float" elements="1" defaultvalue="40.6"/>
 	<field name="DerivativeCutoff" units="Hz" type="uint8" elements="1" defaultvalue="20"/>
 	<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="1"/>
 

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -30,7 +30,7 @@
 	<field name="VbarPiroComp" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
 	<field name="VbarMaxAngle" units="deg" type="uint8" elements="1" defaultvalue="10"/>
 
-	<field name="GyroTau" units="" type="float" elements="1" defaultvalue="0.005"/>
+	<field name="GyroTau" units="" type="float" elements="1" defaultvalue="0.019"/>
 	<field name="DerivativeCutoff" units="Hz" type="uint8" elements="1" defaultvalue="20"/>
 	<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="1"/>
 

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -30,7 +30,7 @@
 	<field name="VbarPiroComp" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
 	<field name="VbarMaxAngle" units="deg" type="uint8" elements="1" defaultvalue="10"/>
 
-	<field name="GyroCutoff" units="Hz" type="float" elements="1" defaultvalue="40.6"/>
+	<field name="GyroCutoff" units="Hz" type="float" elements="1" defaultvalue="45.0"/>
 	<field name="DerivativeCutoff" units="Hz" type="uint8" elements="1" defaultvalue="20"/>
 	<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="1"/>
 

--- a/shared/uavobjectdefinition/txpidsettings.xml
+++ b/shared/uavobjectdefinition/txpidsettings.xml
@@ -17,7 +17,7 @@
 			Roll Attitude.Kp, Pitch Attitude.Kp, Roll+Pitch Attitude.Kp, Yaw Attitude.Kp,
 			Roll Attitude.Ki, Pitch Attitude.Ki, Roll+Pitch Attitude.Ki, Yaw Attitude.Ki,
 			Roll Attitude.ILimit, Pitch Attitude.ILimit, Roll+Pitch Attitude.ILimit, Yaw Attitude.ILimit,
-			GyroTau,
+			GyroCutoff,
 			Roll VbarSensitivity, Pitch VbarSensitivity, Roll+Pitch VbarSensitivity, Yaw VbarSensitivity,
 			Roll Vbar.Kp, Pitch Vbar.Kp, Roll+Pitch Vbar.Kp, Yaw Vbar.Kp,
 			Roll Vbar.Ki,Pitch Vbar.Ki, Roll+Pitch Vbar.Ki, Yaw Vbar.Ki,


### PR DESCRIPTION
I noticed that the current gyro LPF in stabilization.c uses a constant fake delta Time (https://github.com/TauLabs/TauLabs/blob/next/flight/Modules/Stabilization/stabilization.c#L941-L950). From the comments it seems this was done because of jitter in the real dT, and different control rates at that time were 300Hz & 475Hz. 
Currently on many targets 500Hz is default rate, Quanton has 666Hz, and 1kHz and above is also possible on some targets.
And there is also work on higher rates.

Here are some results of the LPF magnitude response with 2kHz, 1kHz and 500Hz rate:
![taulabs_gyro_filter](https://cloud.githubusercontent.com/assets/9142182/8889618/fe47d4da-32e1-11e5-8610-d5896567b784.png) 

But i think that the principal behavior (cut off frequency) of the LPF should not change with the control loop rate. It should be adjusted depending of the noise in the UAV.

So i started with some initial work as a base for further discussion.

Thats what i have done so far:
- changed the calculation of the LPF coefficients, so that 1/settings.GyroTau is now equal to the cut off frequency of the filter
 - I think it would be easier to understand the functionality if we rename the Parameter in the UAVObject from GyroTau to GyroFcut. But for the first steps i didn't want to change to much, that might be not used later.
- using the real dT for the gyro LPF, otherwise the behavior (cut off frequency) is changed when rate of the control loop (e.g. MPU rate) is changed
 - in the comments at the source code it was said that using a constant fakeDt was because of jitter. I don't know how big this problem is. For first implementation i used the real(dynamic) dT. Is this really problematic?
 - when we really need a dT without any jitter, than it would be good to provide the information of the desired gyro sampling rate from the gyro driver (e.g. MPU6000/9250) to the stabilization module
- changed the default value of GyroTau in a way, that the LPF behaves for all rates now like the old default settings with 500Hz MPU rate (51Hz cut off)
