### PR TITLE
FrSky telemetry: make accelerometers data configurable

### DIFF
--- a/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
+++ b/flight/Modules/UAVOFrSKYSensorHubBridge/UAVOFrSKYSensorHubBridge.c
@@ -321,7 +321,7 @@ static void uavoFrSKYSensorHubBridgeTask(void *parameters)
 				}
 				break;
 			}
-
+#ifndef SMALLF1
 			case MODULESETTINGS_FRSKYACCELDATA_NEDACCELS: {
 				if (NedAccelHandle() != NULL) {
 					NedAccelNorthGet(&accX);
@@ -341,7 +341,7 @@ static void uavoFrSKYSensorHubBridgeTask(void *parameters)
 				}
 				break;
 			}
-
+#endif
 			case MODULESETTINGS_FRSKYACCELDATA_ATTITUDEANGLES: {
 				if (AttitudeActualHandle() != NULL) {
 					AttitudeActualRollGet(&accX);

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -92,6 +92,8 @@
 		<!-- LightTelemetry Module Settings -->
 		<field name="LightTelemetrySpeed" units="bps" type="enum" elements="1" options="1200,2400,4800,9600,19200,38400,57600,115200" defaultvalue="2400"/>
 
+		<!-- FrSky telemetry Module Settings -->
+		<field name="FrskyAccelData" units="" type="enum" elements="1" options="Accels,NEDAccels, NEDVelocity, AttitudeAngles" defaultvalue="Accels"/>
 
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
This changeset allows user to select which values he want to be sended as accelerometer values. As I mentioned in #1742 raw accelerometers values sended at relatively slow rate aren't much useful.  

You can select between
- Accels: raw unfiltered accelerometer values. This is original behavior and will stay as default.
- NEDAccels: LPFed accelerations in earth frame of reference
- NEDVelocity: velocity of aircraft in all three axis
- AttitudeAngles: attitude angles (roll, pitch, yaw) in degrees

This should work with both Sensor Hub and SmartPort telemetries. I tested it with SmartPort only, because I don't have any other FrSky receivers.