### PR TITLE
GCS: PFD: Fix telemetry status arrow (QT bug 37241)

### DIFF
--- a/ground/gcs/share/taulabs/pfd/default/PfdIndicators.qml
+++ b/ground/gcs/share/taulabs/pfd/default/PfdIndicators.qml
@@ -14,7 +14,8 @@ Item {
         elementName: "gcstelemetry-"+statusName
         sceneSize: sceneItem.sceneSize
 
-        property string statusName : ["Disconnected","HandshakeReq","HandshakeAck","Connected"][GCSTelemetryStats.Status]
+        // charCodeAt is a workaround for QT bug 37241
+        property string statusName : ["Disconnected","HandshakeReq","HandshakeAck","Connected"][GCSTelemetryStats.Status.charCodeAt(0)]
 
         // Force refresh of the arrow image when elementName changes
         onElementNameChanged: { generateSource() }


### PR DESCRIPTION
The telemetry Status property is currently not copied into the QML object properly due to [QT bug 37241](https://bugreports.qt.io/browse/QTBUG-37241). This works around the bug to display the arrow correctly, and avoid spamming the debug gadget with errors. Fixes #1768. 