### PR TITLE
GCS: Clean up some compiler warnings

### DIFF
--- a/ground/gcs/src/libs/glc_lib/glc_lib.pro
+++ b/ground/gcs/src/libs/glc_lib/glc_lib.pro
@@ -504,7 +504,7 @@ INSTALLS += include_lib3ds include_glext include_quazip include_glc_maths includ
 INSTALLS += include_glc_scengraph include_glc_geometry include_glc_shading include_glc_viewport
 INSTALLS += include_glc_3dwidget include_glc_glu
 
-INSTALLS += target
+!contains(INSTALLS,target):INSTALLS += target
 INSTALLS +=include
 
 OTHER_FILES += \

--- a/ground/gcs/src/libs/glc_lib/glc_lib.pro
+++ b/ground/gcs/src/libs/glc_lib/glc_lib.pro
@@ -504,6 +504,7 @@ INSTALLS += include_lib3ds include_glext include_quazip include_glc_maths includ
 INSTALLS += include_glc_scengraph include_glc_geometry include_glc_shading include_glc_viewport
 INSTALLS += include_glc_3dwidget include_glc_glu
 
+# workaround to avoid target being added a second time due to ../../taulabslibrary.pri
 !contains(INSTALLS,target):INSTALLS += target
 INSTALLS +=include
 

--- a/ground/gcs/src/libs/qwt/src/src.pro
+++ b/ground/gcs/src/libs/qwt/src/src.pro
@@ -42,12 +42,6 @@ CONFIG(lib_bundle) {
     FRAMEWORK_HEADERS.path = Headers
     QMAKE_BUNDLE_DATA += FRAMEWORK_HEADERS
 }
-else {
-
-    headers.files  = $${HEADERS}
-    headers.path   = $${QWT_INSTALL_HEADERS}
-    INSTALLS += headers
-}
 
 contains(QWT_CONFIG, QwtPkgConfig) {
 

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -905,7 +905,7 @@
       <attribute name="title">
        <string>Geofence</string>
       </attribute>
-      <layout class="QFormLayout" name="formLayout_10">
+      <layout class="QFormLayout" name="formLayout_1">
        <item row="2" column="0">
         <widget class="QLabel" name="label_21">
          <property name="text">
@@ -957,7 +957,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer_1">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -973,7 +973,7 @@
         </spacer>
        </item>
        <item row="4" column="0">
-        <spacer name="verticalSpacer_7">
+        <spacer name="verticalSpacer_8">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/ground/gcs/src/plugins/config/textbubbleslider.h
+++ b/ground/gcs/src/plugins/config/textbubbleslider.h
@@ -29,7 +29,7 @@
 #define TEXTBUBBLESLIDER_H
 
 #include <QSlider>
-#include <QtDesigner/QDesignerExportWidget>
+#include <QtUiPlugin/QDesignerExportWidget>
 
 class TextBubbleSlider : public QSlider
 {

--- a/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
+++ b/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
@@ -470,7 +470,7 @@ void FlightDataModel::pauseValidation(bool pausing) {
 
 void FlightDataModel::fixupValidationErrors()
 {
-    struct FlightDataModel::NED prevNED = {};
+    struct FlightDataModel::NED prevNED = {0.0, 0.0, 0.0};
 
     // Skip validation when there's a download from firmware in process.
     if (valPaused) { return; }

--- a/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c
+++ b/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c
@@ -1298,6 +1298,7 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
+	(void) dev;
 	return NULL;
 }
 

--- a/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c
+++ b/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c
@@ -867,7 +867,7 @@ static void *read_thread(void *param)
 }
 
 
-hid_device * HID_API_EXPORT hid_open_path(const char *path)
+HID_API_EXPORT hid_device * hid_open_path(const char *path)
 {
 	hid_device *dev = NULL;
 

--- a/ground/gcs/src/plugins/rawhid/rawhid.cpp
+++ b/ground/gcs/src/plugins/rawhid/rawhid.cpp
@@ -326,11 +326,10 @@ bool RawHID::open(OpenMode mode)
 {
     QMutexLocker locker(m_mutex);
 
-    int res;
     hid_device *handle;
 
     // Initialize the hidapi library (safe to call multiple times)
-    res = hid_init();
+    hid_init();
 
     // Open the device using the VID, PID
     handle = hid_open(m_deviceInfo->getVendorID(), m_deviceInfo->getProductID(), NULL);

--- a/ground/gcs/src/plugins/uploader/tl_dfu.cpp
+++ b/ground/gcs/src/plugins/uploader/tl_dfu.cpp
@@ -637,7 +637,7 @@ quint32 DFUObject::CRCFromQBArray(QByteArray array, quint32 Size)
         array.append( QByteArray(pad, 255) );
     }
 
-    int maxSize = (array.length() > Size) ? Size : array.length();
+    int maxSize = ((quint32) array.length() > Size) ? Size : array.length();
     // Large firmwares require defining super large arrays,
     // so better to malloc them. I did run into stack overflows here
     // with devices with large firmwares (1MB) (E. Lafargue), hence


### PR DESCRIPTION
This cleans up almost all compiler warnings when building on my Linux machine with g++ 4.9.2. 

Warnings before this changeset after make all_clean:
```
WARNING: headers.path is not defined: install target not created

Project MESSAGE: tlfw_resource.qrc not found.  Automatically firmware updates disabled.
Makefile:56551: warning: overriding recipe for target 'install_target'
Makefile:56213: warning: ignoring old recipe for target 'install_target'
Makefile:56558: warning: overriding recipe for target 'uninstall_target'
Makefile:56220: warning: ignoring old recipe for target 'uninstall_target'
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/rawhid/rawhid.cpp: In member function ‘virtual bool RawHID::open(QIODevice::OpenMode)’:
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/rawhid/rawhid.cpp:329:9: warning: variable ‘res’ set but not used [-Wunused-but-set-variable]
     int res;
         ^
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c:871:1: warning: ‘visibility’ attribute ignored on non-class types [-Wattributes]
 {
 ^
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c: In function ‘hid_error’:
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c:1299:68: warning: unused parameter ‘dev’ [-Wunused-parameter]
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
                                                                    ^
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp: In member function ‘void FlightDataModel::fixupValidationErrors()’:
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp:473:44: warning: missing initializer for member ‘FlightDataModel::NED::North’ [-Wmissing-field-initializers]
     struct FlightDataModel::NED prevNED = {};
                                            ^
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp:473:44: warning: missing initializer for member ‘FlightDataModel::NED::East’ [-Wmissing-field-initializers]
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp:473:44: warning: missing initializer for member ‘FlightDataModel::NED::Down’ [-Wmissing-field-initializers]
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/uploader/tl_dfu.cpp: In static member function ‘static quint32 tl_dfu::DFUObject::CRCFromQBArray(QByteArray, quint32)’:
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/uploader/tl_dfu.cpp:640:35: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     int maxSize = (array.length() > Size) ? Size : array.length();
                                   ^
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/modules.ui: Warning: The name 'verticalSpacer_2' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_21'.
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/modules.ui: Warning: The name 'formLayout_10' (QFormLayout) is already in use, defaulting to 'formLayout_101'.
/home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/modules.ui: Warning: The name 'verticalSpacer_7' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_71'.
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_inputchannelform.h:23,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/configinputwidget.h:39,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/inputchannelform.h:5,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/inputchannelform.cpp:1:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_outputchannelform.h:25,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/outputchannelform.h:31,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/outputchannelform.cpp:31:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.cpp:33:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_inputchannelform.h:23,
                 from .moc/debug-shared/../../../../../../../../ground/gcs/src/plugins/config/configinputwidget.h:39,
                 from .moc/debug-shared/moc_configinputwidget.cpp:9:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_inputchannelform.h:23,
                 from .moc/debug-shared/../../../../../../../../ground/gcs/src/plugins/config/configinputwidget.h:39,
                 from .moc/debug-shared/../../../../../../../../ground/gcs/src/plugins/config/inputchannelform.h:5,
                 from .moc/debug-shared/moc_inputchannelform.cpp:9:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_outputchannelform.h:25,
                 from .moc/debug-shared/../../../../../../../../ground/gcs/src/plugins/config/outputchannelform.h:31,
                 from .moc/debug-shared/moc_outputchannelform.cpp:9:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from .moc/debug-shared/../../../../../../../../ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .moc/debug-shared/moc_textbubbleslider.cpp:9:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_inputchannelform.h:23,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/configinputwidget.h:39,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/configgadgetwidget.cpp:32:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_outputchannelform.h:25,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/outputchannelform.h:31,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/configoutputwidget.cpp:29:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
In file included from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/textbubbleslider.h:32:0,
                 from .uic/ui_inputchannelform.h:23,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/configinputwidget.h:39,
                 from /home/mike/Dev/TauLabs/TauLabs/ground/gcs/src/plugins/config/configinputwidget.cpp:29:
/home/mike/Dev/TauLabs/TauLabs/tools/Qt5.5.0/5.5/gcc_64/include/QtDesigner/QDesignerExportWidget:4:4: warning: #warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead. [-Wcpp]
 #  warning Header <QtDesigner/QDesignerExportWidget> is deprecated. Please include <QtUiPlugin/QDesignerExportWidget> instead.
    ^
```

The remaining warnings after this changeset:
```
WARNING: headers.path is not defined: install target not created

Project MESSAGE: tlfw_resource.qrc not found.  Automatically firmware updates disabled.
Makefile:56551: warning: overriding recipe for target 'install_target'
Makefile:56213: warning: ignoring old recipe for target 'install_target'
Makefile:56558: warning: overriding recipe for target 'uninstall_target'
Makefile:56220: warning: ignoring old recipe for target 'uninstall_target'
```