### PR TITLE
Make: Allow QT make spec to be set by env variable

### DIFF
--- a/make/linux.mk
+++ b/make/linux.mk
@@ -9,7 +9,7 @@
 # misc tools
 RM=rm
 
-QT_SPEC=linux-g++
+QT_SPEC ?= linux-g++
 
 # Check for and find Python 2
 

--- a/make/macosx.mk
+++ b/make/macosx.mk
@@ -38,6 +38,6 @@ endif
 export PYTHON
 
 
-QT_SPEC=macx-g++
+QT_SPEC ?= macx-g++
 
 UAVOBJGENERATOR="$(BUILD_DIR)/ground/uavobjgenerator/uavobjgenerator"

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -18,7 +18,7 @@ RM=rm
 PYTHON := python
 export PYTHON
 
-QT_SPEC := win32-g++
+QT_SPEC ?= win32-g++
 
 # this might need to switch on debug/release
 UAVOBJGENERATOR := "$(BUILD_DIR)/ground/uavobjgenerator/debug/uavobjgenerator.exe"


### PR DESCRIPTION
This allows gcs to be built by e.g. clang. 

Note: currently clang breaks the uploader plugin due to an undefined symbol in librawHID (_ZN10USBMonitorD1Ev).