### PR TITLE
gcs: change export to fix build on windows

### DIFF
--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mappointitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mappointitem.h
@@ -54,7 +54,7 @@ struct TLMAPWIDGET_EXPORT distBearingAltitude
 *
 * @class MapPointItem mappointitem.h "mappointitem.h"
 */
-class MapPointItem: public QObject,public QGraphicsItem
+class TLMAPWIDGET_EXPORT MapPointItem: public QObject,public QGraphicsItem
 {
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)


### PR DESCRIPTION
Corrects Windows build regression introduced in #1739.