### PR TITLE
VtolPathFollower: fix a regression that resulted in landing halting

### DIFF
--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -426,7 +426,7 @@ int32_t vtol_follower_control_endpoint(const float dT, const float *hold_pos_ned
 int32_t vtol_follower_control_land(const float dT, const float *hold_pos_ned,
 	bool *landed)
 {
-	return vtol_follower_control_simple(dT, hold_pos_ned, false, true);
+	return vtol_follower_control_simple(dT, hold_pos_ned, true, true);
 }
 
 /**


### PR DESCRIPTION
This fixes a regression from #1543 that did not enable the landing mode flag
during the landing phase of RTH. This results in the motors not properly
spooling down and sometimes the multi rotor not hitting the ground.