### PR TITLE
pios_hal: export PIOS_HAL_ConfigureCom.

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -178,7 +178,7 @@ static void PIOS_HAL_SetReceiver(int receiver_type, uintptr_t value) {
  * @param[in] com_driver communications driver
  * @param[out] com_id id of the PIOS_Com instance
  */
-static void PIOS_HAL_ConfigureCom (const struct pios_usart_cfg *usart_port_cfg,
+void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
 		size_t rx_buf_len, size_t tx_buf_len,
                 const struct pios_com_driver *com_driver, uintptr_t *com_id)
 {

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -32,6 +32,10 @@ extern uintptr_t pios_rcvr_group_map[];
 
 #endif
 
+void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
+		size_t rx_buf_len, size_t tx_buf_len,
+		const struct pios_com_driver *com_driver, uintptr_t *com_id);
+
 void PIOS_HAL_Panic(uint32_t led_id, int32_t code);
 void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		const struct pios_usart_cfg *usart_port_cfg,


### PR DESCRIPTION
Necessary for #1791 to avoid code duplication, and also helps out Naze
serial changes in progress.