### PR TITLE
Fix wireshark UAVTALK plugins so they compile with latest version

### DIFF
--- a/ground/gcs/src/plugins/uavobjects/wireshark/op-uavobjects/Makefile.am
+++ b/ground/gcs/src/plugins/uavobjects/wireshark/op-uavobjects/Makefile.am
@@ -23,9 +23,10 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 
-INCLUDES = -I$(top_srcdir) -I$(includedir)
-
+include $(top_srcdir)/Makefile.am.inc
 include Makefile.common
+
+AM_CPPFLAGS = -I$(top_srcdir)
 
 if HAVE_WARNINGS_AS_ERRORS
 AM_CFLAGS = -Werror
@@ -81,17 +82,9 @@ LIBS =
 # a plugin.c file for a plugin.
 # All subsequent arguments are the files to scan.
 #
-plugin.c: $(DISSECTOR_SRC) Makefile.common $(top_srcdir)/tools/make-dissector-reg \
-    $(top_srcdir)/tools/make-dissector-reg.py
-	@if test -n "$(PYTHON)"; then \
-		echo Making plugin.c with python ; \
-		$(PYTHON) $(top_srcdir)/tools/make-dissector-reg.py $(srcdir) \
-		    plugin $(DISSECTOR_SRC) ; \
-	else \
-		echo Making plugin.c with shell script ; \
-		$(top_srcdir)/tools/make-dissector-reg $(srcdir) \
-		    $(plugin_src) plugin $(DISSECTOR_SRC) ; \
-	fi
+plugin.c: $(DISSECTOR_SRC) Makefile.common $(top_srcdir)/tools/make-dissector-reg.py
+	@echo Making plugin.c
+	@$(PYTHON) $(top_srcdir)/tools/make-dissector-reg.py $(srcdir) plugin $(DISSECTOR_SRC)
 
 #
 # Currently plugin.c can be included in the distribution because

--- a/ground/gcs/src/plugins/uavobjects/wireshark/op-uavobjects/packet-op-uavobjects-template.c
+++ b/ground/gcs/src/plugins/uavobjects/wireshark/op-uavobjects/packet-op-uavobjects-template.c
@@ -49,7 +49,7 @@ $(ENUMFIELDNAMES)
 
 void proto_reg_handoff_op_uavobjects_$(NAMELC)(void);
 
-static int dissect_uavo(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
+static int dissect_uavo(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data _U_)
 {
   int offset = 0;
 
@@ -108,5 +108,5 @@ void proto_reg_handoff_op_uavobjects_$(NAMELC)(void)
    uavo_handle = new_create_dissector_handle(dissect_uavo, proto_uavo);
 
    /* Bind this protocol to its UAV ObjID in UAVTalk */
-   dissector_add("uavtalk.objid", $(OBJIDHEX), uavo_handle);
+   dissector_add_uint("uavtalk.objid", $(OBJIDHEX), uavo_handle);
 }

--- a/ground/gcs/src/plugins/uavobjects/wireshark/op-uavtalk/Makefile.am
+++ b/ground/gcs/src/plugins/uavobjects/wireshark/op-uavtalk/Makefile.am
@@ -23,9 +23,11 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 
-INCLUDES = -I$(top_srcdir) -I$(includedir)
-
+include $(top_srcdir)/Makefile.am.inc
 include Makefile.common
+
+AM_CPPFLAGS = -I$(top_srcdir)
+
 
 if HAVE_WARNINGS_AS_ERRORS
 AM_CFLAGS = -Werror
@@ -81,17 +83,10 @@ LIBS =
 # a plugin.c file for a plugin.
 # All subsequent arguments are the files to scan.
 #
-plugin.c: $(DISSECTOR_SRC) Makefile.common $(top_srcdir)/tools/make-dissector-reg \
-    $(top_srcdir)/tools/make-dissector-reg.py
-	@if test -n "$(PYTHON)"; then \
-		echo Making plugin.c with python ; \
-		$(PYTHON) $(top_srcdir)/tools/make-dissector-reg.py $(srcdir) \
-		    plugin $(DISSECTOR_SRC) ; \
-	else \
-		echo Making plugin.c with shell script ; \
-		$(top_srcdir)/tools/make-dissector-reg $(srcdir) \
-		    $(plugin_src) plugin $(DISSECTOR_SRC) ; \
-	fi
+plugin.c: $(DISSECTOR_SRC) Makefile.common $(top_srcdir)/tools/make-dissector-reg.py
+	@echo Making plugin.c
+	@$(PYTHON) $(top_srcdir)/tools/make-dissector-reg.py $(srcdir) plugin $(DISSECTOR_SRC)
+
 
 #
 # Currently plugin.c can be included in the distribution because

--- a/ground/gcs/src/plugins/uavobjects/wireshark/op-uavtalk/packet-op-uavtalk.c
+++ b/ground/gcs/src/plugins/uavobjects/wireshark/op-uavtalk/packet-op-uavtalk.c
@@ -66,7 +66,7 @@ void proto_reg_handoff_op_uavtalk(void);
 
 #define UAVTALK_HEADER_SIZE 8
 #define UAVTALK_TRAILER_SIZE 1
-static int dissect_op_uavtalk(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
+static int dissect_op_uavtalk(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data _U_)
 {
   gint offset = 0;
 
@@ -191,7 +191,7 @@ void proto_register_op_uavtalk(void)
 
 void proto_reg_handoff_op_uavtalk(void)
 {
-   static dissector_handle_t op_uavtalk_handle;
+   dissector_handle_t op_uavtalk_handle;
 
    op_uavtalk_handle = new_create_dissector_handle(dissect_op_uavtalk, proto_op_uavtalk);
    dissector_add_handle("udp.port", op_uavtalk_handle);  /* for "decode as" */

--- a/ground/uavobjgenerator/generators/wireshark/uavobjectgeneratorwireshark.cpp
+++ b/ground/uavobjgenerator/generators/wireshark/uavobjectgeneratorwireshark.cpp
@@ -232,7 +232,7 @@ bool UAVObjectGeneratorWireshark::process_object(ObjectInfo* info, QDir outputpa
 	  } else if ( info->fields[n]->type == FIELDTYPE_FLOAT32 ) {
 	    headerfields.append( QString("\t     BASE_NONE, NULL, 0x0, NULL, HFILL \r\n") );
 	  } else {
-	    headerfields.append( QString("\t     BASE_DEC_HEX, NULL, 0x0, NULL, HFILL\r\n") );
+	    headerfields.append( QString("\t     BASE_DEC, NULL, 0x0, NULL, HFILL\r\n") );
 	  }
 	  headerfields.append( QString("\t   },\r\n") );
 	  headerfields.append( QString("\t },\r\n") );
@@ -267,7 +267,7 @@ bool UAVObjectGeneratorWireshark::process_object(ObjectInfo* info, QDir outputpa
 	  } else if ( info->fields[n]->type == FIELDTYPE_FLOAT32 ) {
 	    headerfields.append( QString("\t     BASE_NONE, NULL, 0x0, NULL, HFILL \r\n") );
 	  } else {
-	    headerfields.append( QString("\t     BASE_DEC_HEX, NULL, 0x0, NULL, HFILL\r\n") );
+	    headerfields.append( QString("\t     BASE_DEC, NULL, 0x0, NULL, HFILL\r\n") );
 	  }
 	  headerfields.append( QString("\t   },\r\n") );
 	  headerfields.append( QString("\t },\r\n") );


### PR DESCRIPTION
Fixes plugins so they compile again with the latest wireshark version (from git). Instructions are here:

https://wiki.openpilot.org/display/WIKI/Wireshark+Plugin+for+UAVTalk+and+UAVObject+Decode

===========================
Using wireshark from latest git, hash ```6aabad5```. On OSX I had to be a little sneaky. First I built it with

```
autogen.sh
configure --disable-wireshark
```

Next, I built the wireshark plugins by

```
make uavobjects_wireshark
```

Moving on, I copied the wireshark files to the ```.wireshark/plugins``` directory

```
mkdir -p ~/.wireshark/plugins
cp plugins/op-uavobjects/.libs/op_uavobjects.* ~/.wireshark/plugins
cp plugins/op-uavtalk/.libs/op_uavtalk.* ~/.wireshark/plugins
```

Finally, I downloaded a wireshark binary and copied the .app to Applications. Running it, I configured Wireshark to parse UAVTalk packets by going to **Analyze-->Decode As...** and configuring to parse UAVObjects.

Note that this will have to be recompiled periodically in order to have the latest UAVObject IDs.