### PR TITLE
Nan fixes

### DIFF
--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -255,6 +255,18 @@ void cubic_deadband_setup(float w, float b, float *m, float *r)
 	*r = *m * powf(w, 3) + b * w;
 }
 
+
+/* NOTE: Interesting problem regarding NaN and Inf checks. The compile optimization --fast-math
+ * does many useful things, but it also removes the ability to check if a number is a Nan, even
+ * if the check is the classic `x == x`. Thus we need to add this back in, and we do it as a
+ * function which has the optimizations turned off.
+ *
+ * Souce: http://stackoverflow.com/questions/22931147/stdisinf-does-not-work-with-ffast-math-how-to-check-for-infinity
+ */
+bool IS_NOT_FINITE(float x) {
+	return (!isfinite(x));
+}
+
 /**
  * @}
  * @}

--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -32,6 +32,7 @@
 #define MISC_MATH_H
 
 #include "stdint.h"
+#include "stdbool.h"
 
 // Max/Min macros. Taken from http://stackoverflow.com/questions/3437404/min-and-max-in-c
 #define MAX(a, b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a > _b ? _a : _b; })
@@ -62,6 +63,12 @@ void vector2_clip(float *vels, float limit);
 void vector2_rotate(const float *original, float *out, float angle);
 float cubic_deadband(float in, float w, float b, float m, float r);
 void cubic_deadband_setup(float w, float b, float *m, float *r);
+
+#if defined (__clang__) // Clang can't turn off specific optimizations, so turn them all off. This is currently only useful when compiling the simulator with Clang
+bool IS_NOT_FINITE(float x) __attribute__((optnone()));
+#else
+bool IS_NOT_FINITE(float x) __attribute__((optimize("no-finite-math-only")));
+#endif
 
 #endif /* MISC_MATH_H */
 

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -34,6 +34,7 @@
 #include "physical_constants.h"
 #include "pios_thread.h"
 #include "pios_queue.h"
+#include "misc_math.h"
 
 // UAVOs
 #include "accels.h"
@@ -392,7 +393,8 @@ static void update_mags(struct pios_sensor_mag_data *mag)
  */
 static void update_baro(struct pios_sensor_baro_data *baro)
 {
-	if (isnan(baro->altitude) || isnan(baro->temperature) || isnan(baro->pressure)){
+	// Check for Nan or infinity
+	if (IS_NOT_FINITE(baro->altitude) || IS_NOT_FINITE(baro->temperature) || IS_NOT_FINITE(baro->pressure)) {
 		AlarmsSet(SYSTEMALARMS_ALARM_TEMPBARO, SYSTEMALARMS_ALARM_WARNING);
 		return;
 	}


### PR DESCRIPTION
Interesting problem regarding NaN and Inf checks. The compile optimization ```--fast-math``` does many useful things, but it also removes the ability to check if a number is a ```Nan```, even if the check is the classic ```x == x```. Thus we need to add this back in, and we do it as a function which has the optimizations turned off.

Souce: http://stackoverflow.com/questions/22931147/stdisinf-does-not-work-with-ffast-math-how-to-check-for-infinity