### PR TITLE
Fix internal sorting of XML in .uav files

### DIFF
--- a/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexport.pro
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexport.pro
@@ -2,6 +2,7 @@
 TEMPLATE = lib
 QT += xml
 QT += widgets
+QT += xmlpatterns
 TARGET = UAVSettingsImportExport
 DEFINES += UAVSETTINGSIMPORTEXPORT_LIBRARY
 include(../../taulabsgcsplugin.pri)

--- a/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportfactory.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportfactory.cpp
@@ -344,7 +344,7 @@ QString UAVSettingsImportExportFactory::createXMLDocument(const enum storedData 
     QString alphabetizedXMLDoc;
 
     QString xmlAlpheticalSorter(" \
-        <xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"> \
+        <xsl:stylesheet version=\"2.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"> \
           <xsl:output method=\"xml\" indent=\"yes\" omit-xml-declaration=\"no\"/> \
           <xsl:strip-space elements=\"*\"/> \
           \


### PR DESCRIPTION
It is currently difficult to visually compare two .uav settings files. The saved settings don't line up because in XML there is no guarantee that the output file will always have the same node order. This resolves that problem by having Qt sort the nodes by UAVObject name.

Solution inspired by http://stackoverflow.com/questions/14647638/xslt-sorting-how-to-sort-xml-childnodes-inside-a-parent-node-with-an-attribute