### PR TITLE
UAVObject: Fix for multiinstance metadata object initialization

### DIFF
--- a/flight/UAVObjects/uavobjecttemplate.c
+++ b/flight/UAVObjects/uavobjecttemplate.c
@@ -74,7 +74,6 @@ int32_t $(NAME)Initialize(void)
 void $(NAME)SetDefaults(UAVObjHandle obj, uint16_t instId)
 {
 	$(NAME)Data data;
-	UAVObjMetadata metadata;
 
 	// Initialize object fields to their default values
 	UAVObjGetInstanceData(obj, instId, &data);
@@ -83,17 +82,20 @@ $(INITFIELDS)
 	UAVObjSetInstanceData(obj, instId, &data);
 
 	// Initialize object metadata to their default values
-	metadata.flags =
-		$(FLIGHTACCESS) << UAVOBJ_ACCESS_SHIFT |
-		$(GCSACCESS) << UAVOBJ_GCS_ACCESS_SHIFT |
-		$(FLIGHTTELEM_ACKED) << UAVOBJ_TELEMETRY_ACKED_SHIFT |
-		$(GCSTELEM_ACKED) << UAVOBJ_GCS_TELEMETRY_ACKED_SHIFT |
-		$(FLIGHTTELEM_UPDATEMODE) << UAVOBJ_TELEMETRY_UPDATE_MODE_SHIFT |
-		$(GCSTELEM_UPDATEMODE) << UAVOBJ_GCS_TELEMETRY_UPDATE_MODE_SHIFT;
-	metadata.telemetryUpdatePeriod = $(FLIGHTTELEM_UPDATEPERIOD);
-	metadata.gcsTelemetryUpdatePeriod = $(GCSTELEM_UPDATEPERIOD);
-	metadata.loggingUpdatePeriod = $(LOGGING_UPDATEPERIOD);
-	UAVObjSetMetadata(obj, &metadata);
+	if (instId == 0) {
+		UAVObjMetadata metadata;
+		metadata.flags =
+			$(FLIGHTACCESS) << UAVOBJ_ACCESS_SHIFT |
+			$(GCSACCESS) << UAVOBJ_GCS_ACCESS_SHIFT |
+			$(FLIGHTTELEM_ACKED) << UAVOBJ_TELEMETRY_ACKED_SHIFT |
+			$(GCSTELEM_ACKED) << UAVOBJ_GCS_TELEMETRY_ACKED_SHIFT |
+			$(FLIGHTTELEM_UPDATEMODE) << UAVOBJ_TELEMETRY_UPDATE_MODE_SHIFT |
+			$(GCSTELEM_UPDATEMODE) << UAVOBJ_GCS_TELEMETRY_UPDATE_MODE_SHIFT;
+		metadata.telemetryUpdatePeriod = $(FLIGHTTELEM_UPDATEPERIOD);
+		metadata.gcsTelemetryUpdatePeriod = $(GCSTELEM_UPDATEPERIOD);
+		metadata.loggingUpdatePeriod = $(LOGGING_UPDATEPERIOD);
+		UAVObjSetMetadata(obj, &metadata);
+	}
 }
 
 /**


### PR DESCRIPTION
Inspired by http://git.openpilot.org/cru/OPReview-693. (Unfortunately this link is currently dead since OPNG took down the public git server. I am placing it here because 1) the original work should be credited and 2) I am hopeful that OPNG's git server will become open once again.)

From the original review (which IIRC was started by CorvusCorvax):
"When a UAVO with instance id > 1 is read from flash it will cause the metadata to be set to default values. The metadata is correctly saved to flash but if there are more than one instance it will be reset to default when second instance is loaded."

This has been tested and works as expected.