### PR TITLE
Map: coord in homeitem shadows coord in mappointitem and interferes with setting home

### DIFF
--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/homeitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/homeitem.h
@@ -60,7 +60,6 @@ namespace mapcontrol
         TLMapWidget* mapwidget;
         QPixmap pic;
         core::Point localposition;
-        internals::PointLatLng coord;
         bool showsafearea;
         bool toggleRefresh;
         int safearea;


### PR DESCRIPTION
The presence of this variable prevented the map from correctly setting the home location, with regards to calculating the mouse cursor's NED position.

This fix can be verified by examining the NED field, as shown in the screenshot.

![screen shot 2015-08-26 at 5 48 31 pm](https://cloud.githubusercontent.com/assets/1118185/9507238/baa4af94-4c1a-11e5-81b9-0246154f664f.png)
