### PR TITLE
Remove  timeutils while() clause that always evaluates to false

### DIFF
--- a/flight/Libraries/timeutils.c
+++ b/flight/Libraries/timeutils.c
@@ -57,11 +57,7 @@ void date_from_timestamp(uint32_t timestamp, DateTimeT *date_time)
 
 	days = timestamp / SECS_PER_DAY;
 	rem = timestamp % SECS_PER_DAY;
-	while (rem >= SECS_PER_DAY)
-	{
-		rem -= SECS_PER_DAY;
-		++days;
-	}
+
 	date_time->hour = rem / SECS_PER_HOUR;
 	rem %= SECS_PER_HOUR;
 	date_time->min = rem / 60;

--- a/flight/Libraries/timeutils.c
+++ b/flight/Libraries/timeutils.c
@@ -57,11 +57,6 @@ void date_from_timestamp(uint32_t timestamp, DateTimeT *date_time)
 
 	days = timestamp / SECS_PER_DAY;
 	rem = timestamp % SECS_PER_DAY;
-	while (rem < 0)
-	{
-		rem += SECS_PER_DAY;
-		--days;
-	}
 	while (rem >= SECS_PER_DAY)
 	{
 		rem -= SECS_PER_DAY;


### PR DESCRIPTION
The time utilities has a value which is a uint, and thus can never be < 0, but is compared to < 0. This causes the unit tests on OSX to fail (but not on the others, which is strange because it's all ARM-GCC.)

This is not the only solution which would resolve the problem, but since it's unlikely that we'll have a GPS reporting negative unix time (zero day for GPS is ten years after Unix zero time) this seemed the best solution.