### PR TITLE
stabilization: turn up default outer loop Kp

### DIFF
--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -14,9 +14,9 @@
 	<field name="RollRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.002,0.0015,0,0.3" limits="%BE:0:0.01,%BE:0:0.01,, "/>
 	<field name="PitchRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.002,0.0015,0,0.3" limits="%BE:0:0.01,%BE:0:0.01,, "/>
 	<field name="YawRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.0035,0.0035,0,0.3" limits="%BE:0:0.01,%BE:0:0.01,, "/>
-	<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2,0,50" limits="%BE:0:10,%BE:0:10,"/>
-	<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2,0,50" limits="%BE:0:10,%BE:0:10,"/>
-	<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2,0,50" limits="%BE:0:10,%BE:0:10,"/>
+	<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:10,%BE:0:10,"/>
+	<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:10,%BE:0:10,"/>
+	<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:10,%BE:0:10,"/>
 
 	<field name="RollRateTPA" units="" type="uint8" elementnames="Threshold,Attenuation" defaultvalue="75,0" limits="%BE:0:100,%BE:0:100"/>
 	<field name="PitchRateTPA" units="" type="uint8" elementnames="Threshold,Attenuation" defaultvalue="75,0" limits="%BE:0:100,%BE:0:100"/>


### PR DESCRIPTION
Rationale:  Rate PI is still lower than almost all autotunes.

This outer loop P will be lower than all autotune output, but increased by 20%.  It should improve user experience.

No complaints of oscillation with default settings yet.