### PR TITLE
pfd_qml: try the workaround for upstream QT bug again

### DIFF
--- a/ground/gcs/share/taulabs/pfd/default/PfdIndicators.qml
+++ b/ground/gcs/share/taulabs/pfd/default/PfdIndicators.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import "convertint8.js" as CInt8
 
 Item {
     id: sceneItem
@@ -14,8 +15,7 @@ Item {
         elementName: "gcstelemetry-"+statusName
         sceneSize: sceneItem.sceneSize
 
-        // charCodeAt is a workaround for QT bug 37241
-        property string statusName : ["Disconnected","HandshakeReq","HandshakeAck","Connected"][GCSTelemetryStats.Status.charCodeAt(0)]
+        property string statusName : ["Disconnected","HandshakeReq","HandshakeAck","Connected"][CInt8.ConvertInt8(GCSTelemetryStats.Status)]
 
         // Force refresh of the arrow image when elementName changes
         onElementNameChanged: { generateSource() }
@@ -40,13 +40,12 @@ Item {
     // GPS status text
     Text {
         id: gps_text
-        text: "GPS: " + GPSPosition.Satellites.charCodeAt(0) + "\nPDP: " + GPSPosition.PDOP.toFixed(2) + "\nACC: " + GPSPosition.Accuracy.toFixed(2)
+        text: "GPS: " + CInt8.ConvertInt8(GPSPosition.Satellites) + "\nPDP: " + GPSPosition.PDOP.toFixed(2) + "\nACC: " + GPSPosition.Accuracy.toFixed(2)
         color: "white"
         font.family: "Arial"
         font.pixelSize: telemetry_status.height * 0.55
 
-        // charCodeAt to work around QTBUG-37241.
-        visible: GPSPosition.Satellites.charCodeAt(0) > 0
+        visible: CInt8.ConvertInt8(GPSPosition.Satellites)
 
         property variant scaledBounds: svgRenderer.scaledElementBounds("pfd.svg", "gps-txt")
         x: Math.floor(scaledBounds.x * sceneItem.width)

--- a/ground/gcs/share/taulabs/pfd/default/convertint8.js
+++ b/ground/gcs/share/taulabs/pfd/default/convertint8.js
@@ -1,0 +1,7 @@
+.pragma library
+
+// workaround for QT bug 37241
+function ConvertInt8(a) {
+	if (a.length < 1) { return 0; }
+	return a.charCodeAt(0);
+}

--- a/ground/gcs/share/taulabs/pfd/default/convertint8.js
+++ b/ground/gcs/share/taulabs/pfd/default/convertint8.js
@@ -2,6 +2,21 @@
 
 // workaround for QT bug 37241
 function ConvertInt8(a) {
-	if (a.length < 1) { return 0; }
+	if (!a.hasOwnProperty("length")) {
+		// Doesn't seem like a string.  Let's see if it's a number
+		// (e.g. upstream 37241 has been fixed)
+
+		if (!isNaN(a)) {
+			return a;
+		}
+
+		// Nope.  Don't know what to do here.
+		return 0;
+	}
+
+	if (a.length < 1) {
+		return 0;
+	}
+
 	return a.charCodeAt(0);
 }


### PR DESCRIPTION
So, this is a slight variant of the previous workaround for the int8-in-qml issue.

@pug398 has seen intermittent issues with the previous workaround, where he got errors about the charCodeAt property.  They spontaneously resolved.

At a minimum, this change is slightly cleaner.  It possibly fixes it if it's about what happens when the value is 0.  Opening for evaluation/consideration, but it's a bit of a hail mary.