### PR TITLE
GCS: Enable halt for non-USB devices

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1171,12 +1171,21 @@ void UploaderGadgetWidget::onResetButtonClick()
         }
         timeout.stop();
     }
-    setUploaderStatus(uploader::BOOTING);
-    conMngr->disconnectDevice();
-    timeout.start(200);
-    loop.exec();
-    conMngr->suspendPolling();
-    bootTimeoutTimer.start();
+    if(conMngr->getCurrentDevice().connection->shortName() == "USB")
+    {
+        setUploaderStatus(uploader::BOOTING);
+        conMngr->disconnectDevice();
+        timeout.start(200);
+        loop.exec();
+        conMngr->suspendPolling();
+        bootTimeoutTimer.start();
+    }
+    else
+    {
+        setUploaderStatus(uploader::DISCONNECTED);
+        conMngr->disconnectDevice();
+    }
+
     return;
 }
 
@@ -1235,11 +1244,19 @@ void UploaderGadgetWidget::onHaltButtonClick()
         }
         timeout.stop();
     }
-    conMngr->disconnectDevice();
-    timeout.start(200);
-    loop.exec();
-    conMngr->suspendPolling();
-    onRescueTimer(true);
+    if(conMngr->getCurrentDevice().connection->shortName() == "USB")
+    {
+        conMngr->disconnectDevice();
+        timeout.start(200);
+        loop.exec();
+        conMngr->suspendPolling();
+        onRescueTimer(true);
+    }
+    else
+    {
+        setUploaderStatus(uploader::DISCONNECTED);
+        conMngr->disconnectDevice();
+    }
     return;
 }
 

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1341,10 +1341,7 @@ void UploaderGadgetWidget::setUploaderStatus(const uploader::UploaderStatus &val
     case uploader::CONNECTED_TO_TELEMETRY:
         m_widget->rescueButton->setVisible(false);
         m_widget->openButton->setVisible(true);
-        if(conMngr->getCurrentDevice().connection->shortName() == "USB")
-            m_widget->haltButton->setVisible(true);
-        else
-            m_widget->haltButton->setVisible(false);
+        m_widget->haltButton->setVisible(true);
         m_widget->bootButton->setVisible(false);
         m_widget->safeBootButton->setVisible(false);
         m_widget->resetButton->setVisible(true);


### PR DESCRIPTION
Currently the GCS uploader widget only shows the halt button when connected via USB. I imagine the original intent of this was to stop boards from being halted unless connected by USB. This check is ineffective though as the board is still able to be halted when connected via PipXtreme/OPLink, since that device is connected via USB. This PR removes the check and always shows the halt button. Additionally the device disconnection is handled gracefully for non-USB connections (previously the connect dropdown and button would be left disabled when resetting via non-USB connection).

Benefits:
* Naze target is able to be put into bootloader mode by GCS (even if the uploader can't speak ST bootloader protocol yet, this is still very helpful),
* Ineffective check removed,
* Reset disconnection handled gracefully on non-USB connections.

Downsides:
* Boards can be halted (put into bootloader mode) by serial connection even though the bootloader cannot use this interface (except Naze).
* No automatic reconnect after reset on non-USB connections.

Future work:
* Add a check on flight side to prevent IAP commands working over radio links.
* Add automatic reconnect after reset for non-USB connections.