### PR TITLE
Naze: Hack to make firmware info work correctly

### DIFF
--- a/flight/targets/naze32/fw/Makefile
+++ b/flight/targets/naze32/fw/Makefile
@@ -516,3 +516,12 @@ LDFLAGS += -T$(LINKERSCRIPTPATH)/link_$(BOARD)_sections.ld
 
 include ./UAVObjects.inc
 include $(MAKE_INC_DIR)/firmware-common.mk
+
+# Hack to place firmware info at correct location in flash
+$(OUTDIR)/$(TARGET).padded.bin: FW_DESC_BASE := $(shell echo $$(($(FW_BANK_BASE)+$(FW_BANK_SIZE)-$(FW_DESC_SIZE))))
+$(OUTDIR)/$(TARGET).padded.bin: $(OUTDIR)/$(TARGET).elf
+	$(V1) $(OBJCOPY) --pad-to=$(FW_DESC_BASE) -O binary $< $@
+
+$(OUTDIR)/$(TARGET).tlfw: $(OUTDIR)/$(TARGET).padded.bin $(OUTDIR)/$(TARGET).bin.firmwareinfo.bin
+	@echo $(MSG_TLFIRMWARE) $(call toprel, $@)
+	$(V1) cat $^ > $@

--- a/flight/targets/naze32/link_STM32103CB_Naze32_memory.ld
+++ b/flight/targets/naze32/link_STM32103CB_Naze32_memory.ld
@@ -1,7 +1,9 @@
 MEMORY
 {
-    FLASH (rx)    : ORIGIN = 0x08000000,        LENGTH = 0x1CF9C
-    VERSION (rx)  : ORIGIN = 0x0801CF9C,        LENGTH = 0x00064
-    EEPROM (rx)   : ORIGIN = 0x0801D000,        LENGTH = 0x03000
-    SRAM (rwx)    : ORIGIN = 0x20000000,        LENGTH = 0x05000
+    FLASH         : ORIGIN = 0x08000000,        LENGTH = 128K - 100 - 12K
+    /* FW_INFO should be filled when the tlfw is generated */
+    FW_INFO       : ORIGIN = 0x0801D000 - 100,  LENGTH = 100
+    /* Putting anything in EEPROM will overwrite saved settings */
+    EEPROM        : ORIGIN = 0x0801D000,        LENGTH = 12K
+    SRAM          : ORIGIN = 0x20000000,        LENGTH = 20K
 }

--- a/flight/targets/naze32/link_STM32103CB_Naze32_sections.ld
+++ b/flight/targets/naze32/link_STM32103CB_Naze32_sections.ld
@@ -71,13 +71,6 @@ SECTIONS
     _sidata = .;
 
     /*
-     */
-    .fw_version_blob :
-    {
-        KEEP(*(.fw_version_blob))
-    } > VERSION
-
-    /*
      * This stack is used both as the initial sp during early init as well as ultimately
      * being used as the STM32's MSP (Main Stack Pointer) which is the same stack that
      * is used for _all_ interrupt handlers.  The end of this stack should be placed

--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -141,9 +141,12 @@ $(1).firmwareinfo.c: $(1) $(ROOT_DIR)/make/templates/firmwareinfotemplate.c FORC
 
 $(eval $(call COMPILE_C_TEMPLATE, $(1).firmwareinfo.c))
 
+# Hack to place Naze firmware info at correct location in flash TODO: fix properly
+ifeq (,$(findstring naze32,$(TARGET)))
 $(OUTDIR)/$(notdir $(basename $(1))).tlfw : $(1) $(1).firmwareinfo.bin
 	@echo $(MSG_TLFIRMWARE) $$(call toprel, $$@)
 	$(V1) cat $(1) $(1).firmwareinfo.bin > $$@
+endif
 endef
 
 # Assemble: create object files from assembler source files.


### PR DESCRIPTION
Currently the Makefile just concatenates the 100 byte firmware info blob onto the end of the bin file to make the tlfw. When flashing GCS chops the last 100 bytes off and flashes them separately at the correct location in flash. As the GCS uploader plugin is currently unable to speak ST bootloader protocol this method doesn't work for the Naze target. This PR pads the firmware bin up to the FW info location and then concatenates the info blob. By doing this we can flash the tlfw with standard ST bootloader tools (like stm32flash) and still have the firmware info blob in the correct location.