### PR TITLE
UAVOGen: Add max UAVO size limit

### DIFF
--- a/ground/uavobjgenerator/uavobjectparser.cpp
+++ b/ground/uavobjgenerator/uavobjectparser.cpp
@@ -404,6 +404,15 @@ QString UAVObjectParser::parseXML(QString& xml, QString& filename)
         // Calculate size
         calculateSize(info);
 
+        /**
+         * The maximum size of UAVOs is limited by the FlashFS filesystem in the flight code
+         * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes)
+         * and the UAVO. This leaves a maximum of 244 bytes for the UAVO.
+         */
+        if(info->numBytes > 244)
+            return genErrorMsg(filename, QString("total object size(%1 bytes) exceeds maximum limit (244 bytes)")
+                    .arg(QString::number(info->numBytes)), 0, 0);
+
         // Add object
         objInfo.append(info);
 

--- a/ground/uavobjgenerator/uavobjectparser.cpp
+++ b/ground/uavobjgenerator/uavobjectparser.cpp
@@ -404,14 +404,10 @@ QString UAVObjectParser::parseXML(QString& xml, QString& filename)
         // Calculate size
         calculateSize(info);
 
-        /**
-         * The maximum size of UAVOs is limited by the FlashFS filesystem in the flight code
-         * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes)
-         * and the UAVO. This leaves a maximum of 244 bytes for the UAVO.
-         */
-        if(info->numBytes > 244)
-            return genErrorMsg(filename, QString("total object size(%1 bytes) exceeds maximum limit (244 bytes)")
-                    .arg(QString::number(info->numBytes)), 0, 0);
+        // Check size against max allowed
+        if(info->numBytes > UAVO_MAX_SIZE)
+            return genErrorMsg(filename, QString("total object size(%1 bytes) exceeds maximum limit (%2 bytes)")
+                    .arg(QString::number(info->numBytes), QString::number(UAVO_MAX_SIZE)), 0, 0);
 
         // Add object
         objInfo.append(info);

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -36,6 +36,13 @@
 #include <QDomNode>
 #include <QByteArray>
 
+/**
+ * The maximum size of UAVOs is limited by the FlashFS filesystem in the flight code
+ * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes)
+ * and the UAVO. This leaves a maximum of 244 bytes for the UAVO.
+ */
+#define UAVO_MAX_SIZE 244
+
 // Types
 typedef enum {
     FIELDTYPE_INT8 = 0,


### PR DESCRIPTION
Fixes #1841. I think my overhead math is correct based on what is stored and it certainly lines up with #1841 which I was able to reproduce and confirm this fix with.