### PR TITLE
UAVOBrowser: Fix crash when using buttons on non-UAVObjects

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -342,7 +342,12 @@ void UAVObjectBrowserWidget::sendUpdate()
 {
     this->setFocus();
     ObjectTreeItem *objItem = findCurrentObjectTreeItem();
-    Q_ASSERT(objItem);
+
+    // This occurs when the selected item is not inside a UAVObject
+    if (objItem == NULL) {
+       return;
+    }
+
     UAVDataObject * dataObj=qobject_cast<UAVDataObject *>(objItem->object());
     if(dataObj && dataObj->isSettings())
         objItem->setUpdatedOnly(true);
@@ -362,7 +367,12 @@ void UAVObjectBrowserWidget::sendUpdate()
 void UAVObjectBrowserWidget::requestUpdate()
 {
     ObjectTreeItem *objItem = findCurrentObjectTreeItem();
-    Q_ASSERT(objItem);
+
+    // This occurs when the selected item is not inside a UAVObject
+    if (objItem == NULL) {
+       return;
+    }
+
     UAVObject *obj = objItem->object();
     Q_ASSERT(obj);
     obj->requestUpdate();
@@ -409,7 +419,12 @@ void UAVObjectBrowserWidget::saveObject()
     sendUpdate();
     // Save object
     ObjectTreeItem *objItem = findCurrentObjectTreeItem();
-    Q_ASSERT(objItem);
+
+    // This occurs when the selected item is not inside a UAVObject
+    if (objItem == NULL) {
+       return;
+    }
+
     UAVDataObject * dataObj=qobject_cast<UAVDataObject *>(objItem->object());
     if(dataObj && dataObj->isSettings())
         objItem->setUpdatedOnly(false);
@@ -429,7 +444,12 @@ void UAVObjectBrowserWidget::loadObject()
 {
     // Load object
     ObjectTreeItem *objItem = findCurrentObjectTreeItem();
-    Q_ASSERT(objItem);
+
+    // This occurs when the selected item is not inside a UAVObject
+    if (objItem == NULL) {
+       return;
+    }
+
     UAVObject *obj = objItem->object();
     Q_ASSERT(obj);
     updateObjectPersistance(ObjectPersistence::OPERATION_LOAD, obj);
@@ -447,7 +467,12 @@ void UAVObjectBrowserWidget::loadObject()
 void UAVObjectBrowserWidget::eraseObject()
 {
     ObjectTreeItem *objItem = findCurrentObjectTreeItem();
-    Q_ASSERT(objItem);
+
+    // This occurs when the selected item is not inside a UAVObject
+    if (objItem == NULL) {
+       return;
+    }
+
     UAVObject *obj = objItem->object();
     Q_ASSERT(obj);
     updateObjectPersistance(ObjectPersistence::OPERATION_DELETE, obj);


### PR DESCRIPTION
When a non-UAVObject is selected and any of the upload/download/save/erase buttons are used GCS crashes because the returned value is NULL. It is reasonable for an inexperienced user to click on the buttons without having first clicked on a UAVObject. Thus this crash seems unnecessary.

This removes the assert and adds an explicit return. There is no adverse consequence to directly returning, although it might be desirable to alert the user to the misuse of the buttons, since it is otherwise a silent failure.

The crash can be reproduced by clicking any of the buttons 1) without having selected any items (e.g. just after starting GCS), 2) with having selected one of the two top category ```Data``` or ```Settings``` items, or 3) having selected a category (which requires category view to be turned on).

This PR resolves the crash in all three of the above scenarios.