### PR TITLE
Implemented DSM resolution override

### DIFF
--- a/flight/PiOS/Common/pios_dsm.c
+++ b/flight/PiOS/Common/pios_dsm.c
@@ -32,6 +32,7 @@
 /* Project Includes */
 #include "pios.h"
 #include "pios_dsm_priv.h"
+#include "manualcontrolsettings.h"
 
 #if defined(PIOS_INCLUDE_DSM)
 
@@ -229,7 +230,24 @@ int PIOS_DSM_UnrollChannels(struct pios_dsm_dev *dsm_dev)
 	// If no stream type has yet been detected, then try to probe for it
 	// this should only happen once per power cycle
 	if (dsm_dev->resolution == DSM_UNKNOWN) {
-		dsm_dev->resolution = PIOS_DSM_DetectResolution(state->received_data);
+
+		// check user settings to determine which resolution mode to use
+		uint8_t dsm_resolution_mode;
+		ManualControlSettingsDSMResolutionModeGet( &dsm_resolution_mode );
+
+		switch( dsm_resolution_mode )
+		{
+		case MANUALCONTROLSETTINGS_DSMRESOLUTIONMODE_AUTODETECT:
+			dsm_dev->resolution = PIOS_DSM_DetectResolution(state->received_data);
+			break;
+		case MANUALCONTROLSETTINGS_DSMRESOLUTIONMODE_FORCE10BIT:
+			dsm_dev->resolution = DSM_10BIT;
+			break;
+		case MANUALCONTROLSETTINGS_DSMRESOLUTIONMODE_FORCE11BIT:
+			dsm_dev->resolution = DSM_11BIT;
+			break;
+		}
+
 	}
 
 	/* Stream type still not detected */

--- a/flight/PiOS/Common/pios_dsm.c
+++ b/flight/PiOS/Common/pios_dsm.c
@@ -32,7 +32,8 @@
 /* Project Includes */
 #include "pios.h"
 #include "pios_dsm_priv.h"
-#include "manualcontrolsettings.h"
+#include <uavobjectmanager.h>
+#include <manualcontrolsettings.h>
 
 #if defined(PIOS_INCLUDE_DSM)
 

--- a/flight/PiOS/Common/pios_dsm.c
+++ b/flight/PiOS/Common/pios_dsm.c
@@ -319,6 +319,11 @@ int32_t PIOS_DSM_Init(uintptr_t *dsm_id,
 	uint8_t num_pulses = 0;
 
 	// check user settings to determine which resolution mode to use
+	// if invalid mode selected, bail
+	if (mode > HWSHARED_DSMXMODE_BIND10PULSES)
+		return -1;
+
+	// set resolution or bind mode depending on user selection
 	switch (mode)
 	{
 	case HWSHARED_DSMXMODE_AUTODETECT:
@@ -340,8 +345,6 @@ int32_t PIOS_DSM_Init(uintptr_t *dsm_id,
 	case HWSHARED_DSMXMODE_BIND10PULSES:
 		num_pulses = 3 + mode - HWSHARED_DSMXMODE_BIND3PULSES;
 		break;
-	default:
-		return -1;
 	}
 
 	/* Bind the receiver if requested */

--- a/flight/PiOS/Common/pios_dsm.c
+++ b/flight/PiOS/Common/pios_dsm.c
@@ -32,8 +32,6 @@
 /* Project Includes */
 #include "pios.h"
 #include "pios_dsm_priv.h"
-#include <uavobjectmanager.h>
-#include <manualcontrolsettings.h>
 
 #if defined(PIOS_INCLUDE_DSM)
 
@@ -104,7 +102,7 @@ static bool PIOS_DSM_Validate(struct pios_dsm_dev *dsm_dev)
 }
 
 /* Try to bind DSMx satellite using specified number of pulses */
-static void PIOS_DSM_Bind(struct pios_dsm_dev *dsm_dev, uint8_t bind)
+static void PIOS_DSM_Bind(struct pios_dsm_dev *dsm_dev, uint8_t num_pulses)
 {
 	const struct pios_dsm_cfg *cfg = dsm_dev->cfg;
 
@@ -116,8 +114,8 @@ static void PIOS_DSM_Bind(struct pios_dsm_dev *dsm_dev, uint8_t bind)
 #endif
 
 	/* just to limit bind pulses */
-	if (bind > 10)
-		bind = 10;
+	if (num_pulses > 10)
+		num_pulses = 10;
 
 	GPIO_Init(cfg->bind.gpio, (GPIO_InitTypeDef*)&cfg->bind.init);
 
@@ -127,7 +125,7 @@ static void PIOS_DSM_Bind(struct pios_dsm_dev *dsm_dev, uint8_t bind)
 	/* on CC works up to 140ms, guess bind window is around 20-140ms after power up */
 	while (((float) PIOS_DELAY_GetRaw() / (float) PIOS_SYSCLK) < 0.02f);
 
-	for (int i = 0; i < bind ; i++) {
+	for (int i = 0; i < num_pulses ; i++) {
 		/* RX line, drive low for 120us */
 		GPIO_ResetBits(cfg->bind.gpio, cfg->bind.init.GPIO_Pin);
 		PIOS_DELAY_WaituS(120);
@@ -231,24 +229,7 @@ int PIOS_DSM_UnrollChannels(struct pios_dsm_dev *dsm_dev)
 	// If no stream type has yet been detected, then try to probe for it
 	// this should only happen once per power cycle
 	if (dsm_dev->resolution == DSM_UNKNOWN) {
-
-		// check user settings to determine which resolution mode to use
-		uint8_t dsm_resolution_mode;
-		ManualControlSettingsDSMResolutionModeGet( &dsm_resolution_mode );
-
-		switch( dsm_resolution_mode )
-		{
-		case MANUALCONTROLSETTINGS_DSMRESOLUTIONMODE_AUTODETECT:
-			dsm_dev->resolution = PIOS_DSM_DetectResolution(state->received_data);
-			break;
-		case MANUALCONTROLSETTINGS_DSMRESOLUTIONMODE_FORCE10BIT:
-			dsm_dev->resolution = DSM_10BIT;
-			break;
-		case MANUALCONTROLSETTINGS_DSMRESOLUTIONMODE_FORCE11BIT:
-			dsm_dev->resolution = DSM_11BIT;
-			break;
-		}
-
+		dsm_dev->resolution = PIOS_DSM_DetectResolution(state->received_data);
 	}
 
 	/* Stream type still not detected */
@@ -320,7 +301,7 @@ int32_t PIOS_DSM_Init(uintptr_t *dsm_id,
 		      const struct pios_dsm_cfg *cfg,
 		      const struct pios_com_driver *driver,
 		      uintptr_t lower_id,
-		      uint8_t bind)
+		      HwSharedDSMxModeOptions mode)
 {
 	PIOS_DEBUG_Assert(dsm_id);
 	PIOS_DEBUG_Assert(cfg);
@@ -335,9 +316,37 @@ int32_t PIOS_DSM_Init(uintptr_t *dsm_id,
 	/* Bind the configuration to the device instance */
 	dsm_dev->cfg = cfg;
 
+	uint8_t num_pulses = 0;
+
+	// check user settings to determine which resolution mode to use
+	switch (mode)
+	{
+	case HWSHARED_DSMXMODE_AUTODETECT:
+		dsm_dev->resolution = DSM_UNKNOWN;
+		break;
+	case HWSHARED_DSMXMODE_FORCE10BIT:
+		dsm_dev->resolution = DSM_10BIT;
+		break;
+	case HWSHARED_DSMXMODE_FORCE11BIT:
+		dsm_dev->resolution = DSM_11BIT;
+		break;
+	case HWSHARED_DSMXMODE_BIND3PULSES:
+	case HWSHARED_DSMXMODE_BIND4PULSES:
+	case HWSHARED_DSMXMODE_BIND5PULSES:
+	case HWSHARED_DSMXMODE_BIND6PULSES:
+	case HWSHARED_DSMXMODE_BIND7PULSES:
+	case HWSHARED_DSMXMODE_BIND8PULSES:
+	case HWSHARED_DSMXMODE_BIND9PULSES:
+	case HWSHARED_DSMXMODE_BIND10PULSES:
+		num_pulses = 3 + mode - HWSHARED_DSMXMODE_BIND3PULSES;
+		break;
+	default:
+		return -1;
+	}
+
 	/* Bind the receiver if requested */
-	if (bind)
-		PIOS_DSM_Bind(dsm_dev, bind);
+	if (num_pulses > 0)
+		PIOS_DSM_Bind(dsm_dev, num_pulses);
 
 	PIOS_DSM_ResetState(dsm_dev);
 

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -220,12 +220,12 @@ void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
  * @param[in] usart_dsm_cfg Configuration for the USART for DSM mode.
  * @param[in] dsm_cfg Configuration for DSM on this target
  * @param[in] usart_com_driver The COM driver for this USART
- * @param[in] bind A number of binding pulses to transmit on this port.
+ * @param[in] mode Mode in which to operate DSM driver; encapsulates binding
  */
 static void PIOS_HAL_ConfigureDSM(const struct pios_usart_cfg *usart_dsm_cfg,
-                const struct pios_dsm_cfg *dsm_cfg,
-                const struct pios_com_driver *usart_com_driver,
-		int bind)
+	const struct pios_dsm_cfg *dsm_cfg,
+	const struct pios_com_driver *usart_com_driver,
+	HwSharedDSMxModeOptions mode)
 {
         uintptr_t usart_dsm_id;
         if (PIOS_USART_Init(&usart_dsm_id, usart_dsm_cfg)) {
@@ -234,7 +234,7 @@ static void PIOS_HAL_ConfigureDSM(const struct pios_usart_cfg *usart_dsm_cfg,
         
         uintptr_t dsm_id;
         if (PIOS_DSM_Init(&dsm_id, dsm_cfg, usart_com_driver,
-                        usart_dsm_id, bind)) {
+                        usart_dsm_id, mode)) {
                 PIOS_Assert(0);
         }
         
@@ -298,7 +298,7 @@ static void PIOS_HAL_ConfigureHSUM(const struct pios_usart_cfg *usart_hsum_cfg,
  * @param[in] led_id LED to blink when there's panics
  * @param[in] usart_dsm_hsum_cfg usart configuration for DSM/HSUM modes
  * @param[in] dsm_cfg DSM configuration for this port
- * @param[in] dsm_bind Number of DSM binding pulses to issue
+ * @param[in] dsm_mode Mode in which to operate DSM driver; encapsulates binding
  * @param[in] sbus_rcvr_cfg usart configuration for SBUS modes
  * @param[in] sbus_cfg SBUS configuration for this port
  * @param[in] sbus_toggle Whether there is SBUS inverters to touch on this port
@@ -313,7 +313,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 /* TODO: future work to factor most of these away */
 	const struct pios_usart_cfg *usart_dsm_hsum_cfg,
 	const struct pios_dsm_cfg *dsm_cfg,
-	int dsm_bind,
+	HwSharedDSMxModeOptions dsm_mode,
 	const struct pios_usart_cfg *sbus_rcvr_cfg,
 	const struct pios_sbus_cfg *sbus_cfg,
 	bool sbus_toggle
@@ -363,7 +363,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		case HWSHARED_PORTTYPES_DSM:
 #if defined(PIOS_INCLUDE_DSM)
 			if (dsm_cfg && usart_dsm_hsum_cfg) {
-				PIOS_HAL_ConfigureDSM(usart_dsm_hsum_cfg, dsm_cfg, com_driver, dsm_bind);
+				PIOS_HAL_ConfigureDSM(usart_dsm_hsum_cfg, dsm_cfg, com_driver, dsm_mode);
 			}
 #endif  /* PIOS_INCLUDE_DSM */
 			break;

--- a/flight/PiOS/inc/pios_dsm_priv.h
+++ b/flight/PiOS/inc/pios_dsm_priv.h
@@ -37,6 +37,10 @@
 #include <pios_stm32.h>
 #include <pios_usart_priv.h>
 
+// for HwSharedDSMxModeOptions
+#include <uavobjectmanager.h>
+#include <hwshared.h>
+
 /*
  * Currently known DSMx (DSM2, DSMJ, DSMX) satellite serial port settings:
  *  115200bps serial stream, 8 bits, no parity, 1 stop bit
@@ -122,7 +126,7 @@ extern int32_t PIOS_DSM_Init(uintptr_t *dsm_id,
 			     const struct pios_dsm_cfg *cfg,
 			     const struct pios_com_driver *driver,
 			     uintptr_t lower_id,
-			     uint8_t bind);
+			     HwSharedDSMxModeOptions mode);
 
 #endif /* PIOS_DSM_PRIV_H */
 

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -47,7 +47,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		/* TODO: future work to factor most of these away */
 		const struct pios_usart_cfg *usart_dsm_hsum_cfg,
 		const struct pios_dsm_cfg *dsm_cfg,
-		int dsm_bind,
+		HwSharedDSMxModeOptions dsm_mode,
 		const struct pios_usart_cfg *sbus_rcvr_cfg,
 		const struct pios_sbus_cfg *sbus_cfg,
 		bool sbus_toggle

--- a/flight/targets/aq32/fw/pios_board.c
+++ b/flight/targets/aq32/fw/pios_board.c
@@ -252,7 +252,7 @@ static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cf
 #ifdef PIOS_INCLUDE_DSM
 static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
 		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,uint8_t *bind)
+		ManualControlSettingsChannelGroupsOptions channelgroup,HwAQ32DSMxModeOptions *mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -261,7 +261,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm
 
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *bind)) {
+			pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -618,8 +618,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwAQ32DSMxBindGet(&hw_DSMxBind);
+	HwAQ32DSMxModeOptions hw_DSMxMode;
+	HwAQ32DSMxModeGet(&hw_DSMxMode);
 
 	/* init sensor queue registration */
 	PIOS_SENSORS_Init();
@@ -828,7 +828,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart4_dsm_hsum_cfg, &pios_usart4_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -923,7 +923,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart6_dsm_hsum_cfg, &pios_usart6_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;

--- a/flight/targets/colibri/fw/pios_board.c
+++ b/flight/targets/colibri/fw/pios_board.c
@@ -258,7 +258,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg
 				     const struct pios_com_driver
 				     *pios_usart_com_driver,
 				     ManualControlSettingsChannelGroupsOptions
-				     channelgroup, uint8_t * bind)
+				     channelgroup, HwColibriDSMxModeOptions * mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -268,7 +268,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init
 	    (&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-	     pios_usart_dsm_id, *bind)) {
+	     pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -652,8 +652,8 @@ void PIOS_Board_Init(void)
 #endif /* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwColibriDSMxBindGet(&hw_DSMxBind);
+	HwColibriDSMxModeOptions hw_DSMxMode;
+	HwColibriDSMxModeGet(&hw_DSMxMode);
 
 	/* init sensor queue registration */
 	PIOS_SENSORS_Init();
@@ -720,7 +720,7 @@ void PIOS_Board_Init(void)
 						 &pios_usart1_dsm_aux_cfg,
 						 &pios_usart_com_driver,
 						 MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM,
-						 &hw_DSMxBind);
+						 &hw_DSMxMode);
 		}
 #endif /* PIOS_INCLUDE_DSM */
 		break;
@@ -876,7 +876,7 @@ void PIOS_Board_Init(void)
 						 &pios_usart2_dsm_aux_cfg,
 						 &pios_usart_com_driver,
 						 MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM,
-						 &hw_DSMxBind);
+						 &hw_DSMxMode);
 		}
 #endif /* PIOS_INCLUDE_DSM */
 		break;
@@ -1039,7 +1039,7 @@ void PIOS_Board_Init(void)
 						 &pios_usart3_dsm_aux_cfg,
 						 &pios_usart_com_driver,
 						 MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM,
-						 &hw_DSMxBind);
+						 &hw_DSMxMode);
 		}
 #endif /* PIOS_INCLUDE_DSM */
 		break;
@@ -1168,7 +1168,7 @@ void PIOS_Board_Init(void)
 						 &pios_usart4_dsm_aux_cfg,
 						 &pios_usart_com_driver,
 						 MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM,
-						 &hw_DSMxBind);
+						 &hw_DSMxMode);
 		}
 #endif /* PIOS_INCLUDE_DSM */
 		break;

--- a/flight/targets/coptercontrol/fw/pios_board.c
+++ b/flight/targets/coptercontrol/fw/pios_board.c
@@ -397,8 +397,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the main IO port */
-	uint8_t hw_DSMxBind;
-	HwCopterControlDSMxBindGet(&hw_DSMxBind);
+	HwCopterControlDSMxModeOptions hw_DSMxMode;
+	HwCopterControlDSMxModeGet(&hw_DSMxMode);
 	uint8_t hw_mainport;
 	HwCopterControlMainPortGet(&hw_mainport);
 
@@ -473,11 +473,15 @@ void PIOS_Board_Init(void) {
 				PIOS_Assert(0);
 			}
 
+			if (hw_DSMxMode >= HWCOPTERCONTROL_DSMXMODE_BIND3PULSES) {
+				hw_DSMxMode = HWCOPTERCONTROL_DSMXMODE_AUTODETECT; /* Do not try to bind through XOR */
+			}
+
 			uintptr_t pios_dsm_id;
 			if (PIOS_DSM_Init(&pios_dsm_id,
 					  &pios_dsm_main_cfg,
 					  &pios_usart_com_driver,
-					  pios_usart_dsm_id, 0)) {
+					  pios_usart_dsm_id, hw_DSMxMode)) {
 				PIOS_Assert(0);
 			}
 
@@ -704,7 +708,7 @@ void PIOS_Board_Init(void) {
 			if (PIOS_DSM_Init(&pios_dsm_id,
 					  &pios_dsm_flexi_cfg,
 					  &pios_usart_com_driver,
-					  pios_usart_dsm_id, hw_DSMxBind)) {
+					  pios_usart_dsm_id, hw_DSMxMode)) {
 				PIOS_Assert(0);
 			}
 

--- a/flight/targets/flyingf3/fw/pios_board.c
+++ b/flight/targets/flyingf3/fw/pios_board.c
@@ -240,7 +240,7 @@ static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cf
 #ifdef PIOS_INCLUDE_DSM
 static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
 		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,uint8_t *bind)
+		ManualControlSettingsChannelGroupsOptions channelgroup,HwFlyingF3DSMxModeOptions *mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -249,7 +249,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm
 
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *bind)) {
+			pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -577,8 +577,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwFlyingF3DSMxBindGet(&hw_DSMxBind);
+	HwFlyingF3DSMxModeOptions hw_DSMxMode;
+	HwFlyingF3DSMxModeGet(&hw_DSMxMode);
 
 	/* UART1 Port */
 	uint8_t hw_uart1;
@@ -619,7 +619,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart1_dsm_hsum_cfg, &pios_usart1_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -728,7 +728,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart2_dsm_hsum_cfg, &pios_usart2_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -836,7 +836,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart3_dsm_hsum_cfg, &pios_usart3_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -944,7 +944,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart4_dsm_hsum_cfg, &pios_usart4_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -1052,7 +1052,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart5_dsm_hsum_cfg, &pios_usart5_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;

--- a/flight/targets/flyingf4/fw/pios_board.c
+++ b/flight/targets/flyingf4/fw/pios_board.c
@@ -210,7 +210,7 @@ static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cf
 #ifdef PIOS_INCLUDE_DSM
 static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
 		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,uint8_t *bind)
+		ManualControlSettingsChannelGroupsOptions channelgroup,HwFlyingF4DSMxModeOptions *mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -219,7 +219,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm
 
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *bind)) {
+			pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -530,8 +530,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwFlyingF4DSMxBindGet(&hw_DSMxBind);
+	HwFlyingF4DSMxModeOptions hw_DSMxMode;
+	HwFlyingF4DSMxModeGet(&hw_DSMxMode);
 
 	/* init sensor queue registration */
 	PIOS_SENSORS_Init();
@@ -571,7 +571,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart1_dsm_hsum_cfg, &pios_usart1_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -624,7 +624,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart2_dsm_hsum_cfg, &pios_usart2_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -714,7 +714,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart3_dsm_hsum_cfg, &pios_usart3_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 	case HWFLYINGF4_UART3_HOTTSUMD:

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -379,8 +379,8 @@ void PIOS_Board_Init(void) {
 		{
 			uint8_t hw_rcvrserial;
 			HwNazeRcvrSerialGet(&hw_rcvrserial);
-			uint8_t hw_DSMxBind;
-			HwNazeDSMxBindGet(&hw_DSMxBind);
+			HwNazeDSMxModeOptions hw_DSMxMode;
+			HwNazeDSMxModeGet(&hw_DSMxMode);
 			PIOS_HAL_ConfigurePort(hw_rcvrserial, 
 					&pios_usart_rcvrserial_cfg,
 					&pios_usart_com_driver,
@@ -388,7 +388,7 @@ void PIOS_Board_Init(void) {
 					PIOS_LED_ALARM,
 					&pios_usart_dsm_hsum_rcvrserial_cfg,
 					&pios_dsm_rcvrserial_cfg,
-					hw_DSMxBind,
+					hw_DSMxMode,
 					NULL, NULL, false);
 		}
 

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -253,7 +253,7 @@ static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cf
 #ifdef PIOS_INCLUDE_DSM
 static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
 		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,uint8_t *bind)
+		ManualControlSettingsChannelGroupsOptions channelgroup,HwQuantonDSMxModeOptions *mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -262,7 +262,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm
 
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *bind)) {
+			pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -594,8 +594,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwQuantonDSMxBindGet(&hw_DSMxBind);
+	HwQuantonDSMxModeOptions hw_DSMxMode;
+	HwQuantonDSMxModeGet(&hw_DSMxMode);
 
 	/* init sensor queue registration */
 	PIOS_SENSORS_Init();
@@ -645,7 +645,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart1_dsm_hsum_cfg, &pios_usart1_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -758,7 +758,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart2_dsm_hsum_cfg, &pios_usart2_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -880,7 +880,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart3_dsm_hsum_cfg, &pios_usart3_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -973,7 +973,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart4_dsm_hsum_cfg, &pios_usart4_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -1066,7 +1066,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_usart5_dsm_hsum_cfg, &pios_usart5_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -320,8 +320,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure IO ports */
-	uint8_t hw_DSMxBind;
-	HwRevoMiniDSMxBindGet(&hw_DSMxBind);
+	HwRevoMiniDSMxModeOptions hw_DSMxMode;
+	HwRevoMiniDSMxModeGet(&hw_DSMxMode);
 	
 	/* Configure main USART port */
 	uint8_t hw_mainport;
@@ -330,7 +330,7 @@ void PIOS_Board_Init(void) {
 	PIOS_HAL_ConfigurePort(hw_mainport, &pios_usart_main_cfg,
 			&pios_usart_com_driver, NULL, NULL, NULL, PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
-			0 /* No bind on main port */, &pios_usart_sbus_main_cfg,
+			hw_DSMxMode >= HWREVOMINI_DSMXMODE_BIND3PULSES ? HWREVOMINI_DSMXMODE_AUTODETECT : hw_DSMxMode /* No bind on main port */, &pios_usart_sbus_main_cfg,
 			&pios_sbus_cfg, true);
 
 	/* Configure FlexiPort */
@@ -341,7 +341,7 @@ void PIOS_Board_Init(void) {
 			&pios_usart_com_driver, &pios_i2c_flexiport_adapter_id,
 			&pios_i2c_flexiport_adapter_cfg, NULL, PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxBind, NULL, NULL, false);
+			hw_DSMxMode, NULL, NULL, false);
 
 	HwRevoMiniData hwRevoMini;
 	HwRevoMiniGet(&hwRevoMini);

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -263,7 +263,7 @@ static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cf
 #ifdef PIOS_INCLUDE_DSM
 static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
 		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,uint8_t *bind)
+		ManualControlSettingsChannelGroupsOptions channelgroup,HwSparkyDSMxModeOptions *mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -272,7 +272,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm
 
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *bind)) {
+			pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -591,8 +591,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwSparkyDSMxBindGet(&hw_DSMxBind);
+	HwSparkyDSMxModeOptions hw_DSMxMode;
+	HwSparkyDSMxModeGet(&hw_DSMxMode);
 
 	/* UART1 Port */
 	uint8_t hw_flexi;
@@ -643,7 +643,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -731,7 +731,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -805,7 +805,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_rcvr_dsm_hsum_cfg, &pios_rcvr_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -426,8 +426,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure IO ports */
-	uint8_t hw_DSMxBind;
-	HwSparky2DSMxBindGet(&hw_DSMxBind);
+	HwSparky2DSMxModeOptions hw_DSMxMode;
+	HwSparky2DSMxModeGet(&hw_DSMxMode);
 	
 	/* Configure main USART port */
 	uint8_t hw_mainport;
@@ -437,7 +437,7 @@ void PIOS_Board_Init(void) {
 			&pios_usart_com_driver, NULL, NULL, NULL,
 			PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
-			0, NULL, NULL, false);
+			hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
@@ -449,7 +449,7 @@ void PIOS_Board_Init(void) {
 			&pios_i2c_flexiport_adapter_cfg, NULL,
 			PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxBind, NULL, NULL, false);
+			hw_DSMxMode, NULL, NULL, false);
 
 #if defined(PIOS_INCLUDE_RFM22B)
 	HwSparky2Data hwSparky2;
@@ -472,8 +472,8 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_rcvrport;
 	HwSparky2RcvrPortGet(&hw_rcvrport);
 
-	if (bdinfo->board_rev != BRUSHEDSPARKY_V0_2) {
-		hw_DSMxBind = 0; /* Do not try to bind through XOR */
+	if (bdinfo->board_rev != BRUSHEDSPARKY_V0_2 && hw_DSMxMode >= HWSPARKY2_DSMXMODE_BIND3PULSES) {
+		hw_DSMxMode = HWSPARKY2_DSMXMODE_AUTODETECT; /* Do not try to bind through XOR */
 	}
 
 	PIOS_HAL_ConfigurePort(hw_rcvrport,
@@ -484,7 +484,7 @@ void PIOS_Board_Init(void) {
 			PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_rcvr_cfg,
 			&pios_dsm_rcvr_cfg,
-			hw_DSMxBind, get_sbus_rcvr_cfg(bdinfo->board_rev),
+			hw_DSMxMode, get_sbus_rcvr_cfg(bdinfo->board_rev),
 			&pios_sbus_cfg, get_sbus_toggle(bdinfo->board_rev));
 
 #if defined(PIOS_INCLUDE_GCSRCVR)

--- a/flight/targets/sparkybgc/fw/pios_board.c
+++ b/flight/targets/sparkybgc/fw/pios_board.c
@@ -180,7 +180,7 @@ static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cf
 #ifdef PIOS_INCLUDE_DSM
 static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
 		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,uint8_t *bind)
+		ManualControlSettingsChannelGroupsOptions channelgroup,HwSparkyBGCDSMxModeOptions *mode)
 {
 	uintptr_t pios_usart_dsm_id;
 	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
@@ -189,7 +189,7 @@ static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm
 
 	uintptr_t pios_dsm_id;
 	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *bind)) {
+			pios_usart_dsm_id, *mode)) {
 		PIOS_Assert(0);
 	}
 
@@ -473,8 +473,8 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
-	uint8_t hw_DSMxBind;
-	HwSparkyBGCDSMxBindGet(&hw_DSMxBind);
+	HwSparkyBGCDSMxModeOptions hw_DSMxMode;
+	HwSparkyBGCDSMxModeGet(&hw_DSMxMode);
 
 	/* UART1 Port */
 	uint8_t hw_flexi;
@@ -515,7 +515,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_flexi_dsm_cfg, &pios_flexi_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;
@@ -569,7 +569,7 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_DSM)
 		{
 			PIOS_Board_configure_dsm(&pios_rcvr_dsm_cfg, &pios_rcvr_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxBind);
+				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
 		}
 #endif	/* PIOS_INCLUDE_DSM */
 		break;

--- a/shared/uavobjectdefinition/hwaq32.xml
+++ b/shared/uavobjectdefinition/hwaq32.xml
@@ -96,7 +96,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" options="USBTelemetry,Disabled" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" options="USBTelemetry,ComBridge,DebugConsole,PicoC,Disabled" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwcolibri.xml
+++ b/shared/uavobjectdefinition/hwcolibri.xml
@@ -87,7 +87,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" defaultvalue="USBTelemetry" parent="HwShared.USB_HIDPort"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" defaultvalue="Disabled" parent="HwShared.USB_VCPPort"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="2000"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwcoptercontrol.xml
+++ b/shared/uavobjectdefinition/hwcoptercontrol.xml
@@ -9,7 +9,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwflyingf3.xml
+++ b/shared/uavobjectdefinition/hwflyingf3.xml
@@ -106,7 +106,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		

--- a/shared/uavobjectdefinition/hwflyingf4.xml
+++ b/shared/uavobjectdefinition/hwflyingf4.xml
@@ -71,7 +71,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -5,7 +5,7 @@
 		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Serial,PPM+Outputs,Outputs" defaultvalue="PPM"/>
 
 		<field name="RcvrSerial" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,DSM,DebugConsole,ComBridge,MavLinkTX,FrSKY Sensor Hub,LighttelemetryTx,HoTT SUMD,HoTT SUMH" parent="HwShared.PortTypes" defaultvalue="Disabled"/>
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -110,7 +110,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -56,7 +56,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<!-- select the function for the radio port -->
 		<!--  1. Telem - telemetry connection -->

--- a/shared/uavobjectdefinition/hwshared.xml
+++ b/shared/uavobjectdefinition/hwshared.xml
@@ -33,6 +33,7 @@
 		<!-- these must match the ordering of options in the rfm22b module -->
 		<field name="MaxRfSpeed" units="bps" type="enum" elements="1" options="9600,19200,32000,64000,100000,192000" defaultvalue="64000"/>
 		<field name="MaxRfPower" units="mW" type="enum" elements="1" options="0,1.25,1.6,3.16,6.3,12.6,25,50,100" defaultvalue="1.25"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" options="Autodetect,Force 10-bit,Force 11-bit,Bind 3 pulses,Bind 4 pulses,Bind 5 pulses,Bind 6 pulses,Bind 7 pulses,Bind 8 pulses,Bind 9 pulses,Bind 10 pulses" defaultvalue="Autodetect"/>
 
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/hwsparky.xml
+++ b/shared/uavobjectdefinition/hwsparky.xml
@@ -63,7 +63,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -58,7 +58,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled"/>
 		<!-- ID of the coordinator to allow binding to. 0 indicates allow all connections -->

--- a/shared/uavobjectdefinition/hwsparkybgc.xml
+++ b/shared/uavobjectdefinition/hwsparkybgc.xml
@@ -34,7 +34,7 @@
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
 
-		<field name="DSMxBind" units=""  type="uint8"  elements="1" defaultvalue="0"/>
+		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -28,6 +28,14 @@
 				<option>None</option>
 			</options>
 		</field>
+
+		<field name="DSMResolutionMode" units="Resolution Mode" type="enum" elements="1" defaultvalue="Autodetect">
+			<options>
+				<option>Autodetect</option>
+				<option>Force 10-Bit</option>
+				<option>Force 11-Bit</option>
+			</options>
+		</field>
 		
 		<field name="RssiType" units="Rssi Type" type="enum" elements="1" defaultvalue="None">
 			<options>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -29,14 +29,6 @@
 			</options>
 		</field>
 
-		<field name="DSMResolutionMode" units="Resolution Mode" type="enum" elements="1" defaultvalue="Autodetect">
-			<options>
-				<option>Autodetect</option>
-				<option>Force 10-Bit</option>
-				<option>Force 11-Bit</option>
-			</options>
-		</field>
-		
 		<field name="RssiType" units="Rssi Type" type="enum" elements="1" defaultvalue="None">
 			<options>
 				<option>None</option>


### PR DESCRIPTION
DSM: Fix issue #1848 
- Added new DSMResolutionMode field to manualcontrolsettings; options are Autodetect, Force 10-bit, Force 11-bit (default Autodetect)
- Implemented resolution mode switch in pios_dsm.c | dsm_resolution()