### PR TITLE
GCS: Detect TL official releases

### DIFF
--- a/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
@@ -35,6 +35,7 @@
 #include <QDebug>
 #include <QEventLoop>
 #include <QTimer>
+#include <QRegularExpression>
 #include <objectpersistence.h>
 
 #include "firmwareiapobj.h"
@@ -703,7 +704,10 @@ bool UAVObjectUtilManager::descriptionToStructure(QByteArray desc, deviceDescrip
        struc.fwHash=desc.mid(40,20);
        struc.uavoHash.clear();
        struc.uavoHash=desc.mid(60,20);
-       if (struc.gitTag.startsWith("RELEASE",Qt::CaseSensitive))
+
+       // The git tag format used for releases is yyyymmdd
+       QRegularExpression certifiedPattern("^20[0-9]{6}$");
+       if (certifiedPattern.match(struc.gitTag).hasMatch())
            struc.certified = true;
        else
            struc.certified = false;


### PR DESCRIPTION
Our release tag pattern is yyyymmdd, but the GCS looks for RELEASE* to detect official builds. Official builds show a little certificate instead of an exclamation mark in the firmware info box on the uploader. 

I have modified the GCS plugin to match our tag format. Unfortunately our last couple of releases don't seem to be tagged correctly/tagged after the builds were done so I compiled a [firmware to test this from the 20150713 tag](http://git.bertie.nz:81/stuffs/fw_sparky2.tlfw). It is important that the release be tagged and THEN built for this to work correctly.