### PR TITLE
vtol_follower: New tuning.

### DIFF
--- a/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
@@ -57,7 +57,7 @@
 
 // Various navigation constants
 const static float RTH_MIN_ALTITUDE = 15.f;  //!< Hover at least 15 m above home */
-const static float RTH_VELOCITY     = 2.5f;  //!< Return home at 2.5 m/s */
+const static float RTH_VELOCITY     = 3.0f;  //!< Return home at 3.0 m/s */
 const static float RTH_ALT_ERROR    = 1.0f;  //!< The altitude to come within for RTH */
 const static float DT               = 0.05f; // TODO: make the self monitored
 

--- a/shared/uavobjectdefinition/vtolpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/vtolpathfollowersettings.xml
@@ -4,7 +4,7 @@
 		<field name="HorizontalVelMax" units="m/s" type="uint16" elements="1" defaultvalue="10"/>
 		<field name="VerticalVelMax" units="m/s" type="uint16" elements="1" defaultvalue="2"/>
 		<field name="HorizontalPosPI" units="(m/s)/m" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="1,0,2"/>
-		<field name="HorizontalVelPID" units="deg/(m/s)" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="3,0,0,0"/>
+		<field name="HorizontalVelPID" units="deg/(m/s)" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="2.6,0.4,0,5.0"/>
 		<field name="VelocityFeedforward" units="deg/(m/s)" type="float" elements="1" defaultvalue="0"/>
 		<field name="ThrottleControl" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
 		<!-- 0.4-0.6 seconds seems like a good value in most cases, this is conservative -->


### PR DESCRIPTION
Based on @pug398 flight test experience.  Also increase target RTH speed
from 2.5 m/s to 3.0 m/s.  Many platforms will not hit the target vel
because of the weak (previously nonexistant) integral.

Previous was 3.0/0/0/0.  @pug398 saw good behavior at 2.5/0.5/0.0/5.0.  New
settings are velkP=2.6, velkI=0.4, velkD=0, velILimit=5deg.  (doing
slightly less than recommended out of conservatism).