### PR TITLE
Actuator: Fix magic numbers relating to number of actuators

### DIFF
--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
@@ -38,8 +38,8 @@
 #include <math.h>
 #include <QMessageBox>
 
-#include "mixersettings.h"
 #include "actuatorcommand.h"
+#include "mixersettings.h"
 
 ConfigCcpmWidget::ConfigCcpmWidget(QWidget *parent) : VehicleConfig(parent)
 {
@@ -223,7 +223,7 @@ QStringList ConfigCcpmWidget::getChannelDescriptions()
     QStringList channelDesc;
 
     // init a channel_numelem list of channel desc defaults
-    for (i=0; i < (int)(ConfigCcpmWidget::CHANNEL_NUMELEM); i++)
+    for (i=0; i < (int)(ActuatorCommand::CHANNEL_NUMELEM); i++)
     {
         channelDesc.append(QString("-"));
     }

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configfixedwingwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configfixedwingwidget.cpp
@@ -24,6 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
+#include "actuatorcommand.h"
 #include "configfixedwingwidget.h"
 #include "configvehicletypewidget.h"
 #include "mixersettings.h"
@@ -143,7 +144,7 @@ QStringList ConfigFixedWingWidget::getChannelDescriptions()
     QStringList channelDesc;
 
     // init a channel_numelem list of channel desc defaults
-    for (i=0; i < (int)(ConfigFixedWingWidget::CHANNEL_NUMELEM); i++)
+    for (i=0; i < (int)(ActuatorCommand::CHANNEL_NUMELEM); i++)
     {
         channelDesc.append(QString("-"));
     }

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configgroundvehiclewidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configgroundvehiclewidget.cpp
@@ -25,6 +25,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
+#include "actuatorcommand.h"
 #include "configgroundvehiclewidget.h"
 #include "configvehicletypewidget.h"
 #include "mixersettings.h"
@@ -164,7 +165,7 @@ QStringList ConfigGroundVehicleWidget::getChannelDescriptions()
     QStringList channelDesc;
 
     // init a channel_numelem list of channel desc defaults
-    for (i=0; i < (int)(ConfigGroundVehicleWidget::CHANNEL_NUMELEM); i++)
+    for (i=0; i < (int)(ActuatorCommand::CHANNEL_NUMELEM); i++)
     {
         channelDesc.append(QString("-"));
     }

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
@@ -37,6 +37,7 @@
 #include <math.h>
 #include <QMessageBox>
 
+#include "actuatorcommand.h"
 #include "mixersettings.h"
 
 const QString ConfigMultiRotorWidget::CHANNELBOXNAME = QString("multiMotorChannelBox");
@@ -283,7 +284,7 @@ QStringList ConfigMultiRotorWidget::getChannelDescriptions()
     QStringList channelDesc;
 
     // init a channel_numelem list of channel desc defaults
-    for (int i=0; i < (int)(ConfigMultiRotorWidget::CHANNEL_NUMELEM); i++)
+    for (int i=0; i < (int)(ActuatorCommand::CHANNEL_NUMELEM); i++)
     {
         channelDesc.append(QString("-"));
     }
@@ -292,23 +293,23 @@ QStringList ConfigMultiRotorWidget::getChannelDescriptions()
     GUIConfigDataUnion configData = GetConfigData();
     multiGUISettingsStruct multi = configData.multi;
 
-    if (multi.VTOLMotorN > 0 && multi.VTOLMotorN <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorN > 0 && multi.VTOLMotorN <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorN-1] = QString("VTOLMotorN");
-    if (multi.VTOLMotorNE > 0 && multi.VTOLMotorNE <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorNE > 0 && multi.VTOLMotorNE <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorNE-1] = QString("VTOLMotorNE");
-    if (multi.VTOLMotorNW > 0 && multi.VTOLMotorNW <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorNW > 0 && multi.VTOLMotorNW <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorNW-1] = QString("VTOLMotorNW");
-    if (multi.VTOLMotorS > 0 && multi.VTOLMotorS <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorS > 0 && multi.VTOLMotorS <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorS-1] = QString("VTOLMotorS");
-    if (multi.VTOLMotorSE > 0 && multi.VTOLMotorSE <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorSE > 0 && multi.VTOLMotorSE <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorSE-1] = QString("VTOLMotorSE");
-    if (multi.VTOLMotorSW > 0 && multi.VTOLMotorSW <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorSW > 0 && multi.VTOLMotorSW <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorSW-1] = QString("VTOLMotorSW");
-    if (multi.VTOLMotorW > 0 && multi.VTOLMotorW <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorW > 0 && multi.VTOLMotorW <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorW-1] = QString("VTOLMotorW");
-    if (multi.VTOLMotorE > 0 && multi.VTOLMotorE <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.VTOLMotorE > 0 && multi.VTOLMotorE <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.VTOLMotorE-1] = QString("VTOLMotorE");
-    if (multi.TRIYaw > 0 && multi.TRIYaw <= ConfigMultiRotorWidget::CHANNEL_NUMELEM)
+    if (multi.TRIYaw > 0 && multi.TRIYaw <= ActuatorCommand::CHANNEL_NUMELEM)
         channelDesc[multi.TRIYaw-1] = QString("Tri-Yaw");
 
     return channelDesc;

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/vehicleconfig.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/vehicleconfig.cpp
@@ -30,13 +30,15 @@
 #include "uavobjectmanager.h"
 #include "uavobject.h"
 
+#include "actuatorcommand.h"
+
 #include <QDebug>
 
 VehicleConfig::VehicleConfig(QWidget *parent) : ConfigTaskWidget(parent)
 {
     //Generate lists of mixerTypeNames, mixerVectorNames, channelNames
     channelNames << "None";
-    for (int i = 0; i < (int)(VehicleConfig::CHANNEL_NUMELEM); i++) {
+    for (int i = 0; i < (int)(ActuatorCommand::CHANNEL_NUMELEM); i++) {
         mixerTypes << QString("Mixer%1Type").arg(i+1);
         mixerVectors << QString("Mixer%1Vector").arg(i+1);
         channelNames << QString("Channel%1").arg(i+1);
@@ -179,7 +181,7 @@ void VehicleConfig::resetMixerVector(UAVDataObject* mixer, int channel)
 // Disable all servo/motor mixers (but keep camera and accessory ones)
 void VehicleConfig::resetMixers(UAVDataObject *mixer)
 {
-    for (int channel = 0; channel < (int)VehicleConfig::CHANNEL_NUMELEM; channel++) {
+    for (int channel = 0; channel < (int)ActuatorCommand::CHANNEL_NUMELEM; channel++) {
         QString type = getMixerType(mixer, channel);
         if ((type == mixerTypeDescriptions[MixerSettings::MIXER1TYPE_DISABLED]) || (type == mixerTypeDescriptions[MixerSettings::MIXER1TYPE_MOTOR]) || (type == mixerTypeDescriptions[MixerSettings::MIXER1TYPE_SERVO])) {
             setMixerType(mixer, channel, MixerSettings::MIXER1TYPE_DISABLED);

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/vehicleconfig.h
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/vehicleconfig.h
@@ -143,8 +143,6 @@ class VehicleConfig: public ConfigTaskWidget
         QStringList mixerVectors;
         QStringList mixerTypeDescriptions;
 
-        static const quint32 CHANNEL_NUMELEM = 10;
-
     private:
 
         static UAVObjectManager* getUAVObjectManager();

--- a/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
+++ b/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
@@ -42,6 +42,7 @@
 
 #include "systemsettings.h"
 #include "mixersettings.h"
+#include "actuatorcommand.h"
 #include "actuatorsettings.h"
 #include "vehicletrim.h"
 #include <extensionsystem/pluginmanager.h>
@@ -185,14 +186,14 @@ ConfigVehicleTypeWidget::ConfigVehicleTypeWidget(QWidget *parent) : ConfigTaskWi
     UAVDataObject* obj = dynamic_cast<UAVDataObject*>(getObjectManager()->getObject(QString("MixerSettings")));
     UAVObjectField* field = obj->getField(QString("Mixer1Type"));
     QStringList list = field->getOptions();
-    for (int i=0; i<(int)(VehicleConfig::CHANNEL_NUMELEM); i++) {
+    for (int i=0; i<(int)(ActuatorCommand::CHANNEL_NUMELEM); i++) {
         QComboBox* qb = new QComboBox(m_aircraft->customMixerTable);
         qb->addItems(list);
         m_aircraft->customMixerTable->setCellWidget(0,i,qb);
     }
 
     SpinBoxDelegate *sbd = new SpinBoxDelegate();
-    for (int i=1; i<(int)(VehicleConfig::CHANNEL_NUMELEM); i++) {
+    for (int i=1; i<(int)(ActuatorCommand::CHANNEL_NUMELEM); i++) {
         m_aircraft->customMixerTable->setItemDelegateForRow(i, sbd);
     }
 
@@ -314,7 +315,7 @@ QStringList ConfigVehicleTypeWidget::getChannelDescriptions()
 
         default:
         {
-            for (i=0; i < (int)(VehicleConfig::CHANNEL_NUMELEM); i++)
+            for (i=0; i < (int)(ActuatorCommand::CHANNEL_NUMELEM); i++)
                 channelDesc.append(QString("-"));
         }
         break;
@@ -340,7 +341,7 @@ void ConfigVehicleTypeWidget::switchAirframeType(int index)
         break;
     case AIRFRAME_CUSTOM:
         m_aircraft->customMixerTable->resizeColumnsToContents();
-        for (int i=0;i<(int)(VehicleConfig::CHANNEL_NUMELEM);i++) {
+        for (int i=0;i<(int)(ActuatorCommand::CHANNEL_NUMELEM);i++) {
             m_aircraft->customMixerTable->setColumnWidth(i,(m_aircraft->customMixerTable->width()-
                                                             m_aircraft->customMixerTable->verticalHeader()->width())/10);
         }
@@ -364,7 +365,7 @@ void ConfigVehicleTypeWidget::showEvent(QShowEvent *event)
     // the result is usually a ahrsbargraph that is way too small.
     m_aircraft->quadShape->fitInView(quad, Qt::KeepAspectRatio);
     m_aircraft->customMixerTable->resizeColumnsToContents();
-    for (int i=0;i<(int)(VehicleConfig::CHANNEL_NUMELEM);i++) {
+    for (int i=0;i<(int)(ActuatorCommand::CHANNEL_NUMELEM);i++) {
         m_aircraft->customMixerTable->setColumnWidth(i,(m_aircraft->customMixerTable->width()-
                                                         m_aircraft->customMixerTable->verticalHeader()->width())/ 10);
     }
@@ -379,7 +380,7 @@ void ConfigVehicleTypeWidget::resizeEvent(QResizeEvent* event)
     m_aircraft->quadShape->fitInView(quad, Qt::KeepAspectRatio);
     // Make the custom table columns autostretch:
     m_aircraft->customMixerTable->resizeColumnsToContents();
-    for (int i=0;i<(int)(VehicleConfig::CHANNEL_NUMELEM);i++) {
+    for (int i=0;i<(int)(ActuatorCommand::CHANNEL_NUMELEM);i++) {
         m_aircraft->customMixerTable->setColumnWidth(i,(m_aircraft->customMixerTable->width()-
                                                         m_aircraft->customMixerTable->verticalHeader()->width())/ 10);
     }
@@ -652,7 +653,7 @@ void ConfigVehicleTypeWidget::updateCustomAirframeUI()
     }
 
     // Update the mixer table:
-    for (int channel=0; channel<(int)(VehicleConfig::CHANNEL_NUMELEM); channel++) {
+    for (int channel=0; channel<(int)(ActuatorCommand::CHANNEL_NUMELEM); channel++) {
         UAVObjectField* field = mixerSettings->getField(mixerTypes.at(channel));
         if (field)
         {
@@ -713,7 +714,7 @@ void ConfigVehicleTypeWidget::updateObjectsFromWidgets()
         vconfig->setThrottleCurve(mixerSettings, MixerSettings::MIXER1VECTOR_THROTTLECURVE2, m_aircraft->customThrottle2Curve->getCurve());
 
         // Update the table:
-        for (int channel=0; channel<(int)(VehicleConfig::CHANNEL_NUMELEM); channel++) {
+        for (int channel=0; channel<(int)(ActuatorCommand::CHANNEL_NUMELEM); channel++) {
             QComboBox* q = (QComboBox*)m_aircraft->customMixerTable->cellWidget(0,channel);
             if(q->currentText()=="Disabled")
                 vconfig->setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_DISABLED);


### PR DESCRIPTION
Previously, several sections of code depended on magic numbers. These code segments were replaced with strict dependencies on the UAVOs.

Note: If we want the children to be able to overwrite this value, then a faster and easier solution is simply to change static ```const quint32 CHANNEL_NUMELEM = 10;``` to use the value in ```ActuatorCommand::CHANNEL_NUMELEM```. I don't particularly see the reason for it, though.