### PR TITLE
PID Library: Remove unnecessary scaling

### DIFF
--- a/flight/Libraries/math/pid.c
+++ b/flight/Libraries/math/pid.c
@@ -53,9 +53,8 @@ float pid_apply(struct pid *pid, const float err, float dT)
 		// If Ki is zero, do not change the integrator. We do not reset to zero
 		// because sometimes the accumulator term is set externally
 	} else {
-		// Scale up accumulator by 1000 while computing to avoid losing precision
-		pid->iAccumulator += err * (pid->i * dT * 1000.0f);
-		pid->iAccumulator = bound_sym(pid->iAccumulator, pid->iLim * 1000.0f);
+		pid->iAccumulator += err * (pid->i * dT);
+		pid->iAccumulator = bound_sym(pid->iAccumulator, pid->iLim);
 	}
 
 	// Calculate DT1 term
@@ -68,7 +67,7 @@ float pid_apply(struct pid *pid, const float err, float dT)
 		pid->lastDer = dterm;            //   ^ set constant to 1/(2*pi*f_cutoff)
 	}	                                 //   7.9577e-3  means 20 Hz f_cutoff
  
-	return ((err * pid->p) + pid->iAccumulator / 1000.0f + dterm);
+	return ((err * pid->p) + pid->iAccumulator + dterm);
 }
 
 /**
@@ -90,8 +89,7 @@ float pid_apply_antiwindup(struct pid *pid, const float err,
 		// If Ki is zero, do not change the integrator. We do not reset to zero
 		// because sometimes the accumulator term is set externally
 	} else {
-		// Scale up accumulator by 1000 while computing to avoid losing precision
-		pid->iAccumulator += err * (pid->i * dT * 1000.0f);
+		pid->iAccumulator += err * (pid->i * dT);
 	}
 
 	// Calculate DT1 term
@@ -105,7 +103,7 @@ float pid_apply_antiwindup(struct pid *pid, const float err,
 	}	                                 //   7.9577e-3  means 20 Hz f_cutoff
  
  	// Compute how much (if at all) the output is saturating
-	float ideal_output = ((err * pid->p) + pid->iAccumulator / 1000.0f + dterm);
+	float ideal_output = ((err * pid->p) + pid->iAccumulator + dterm);
 	float saturation = 0;
 	if (ideal_output > max_bound) {
 		saturation = max_bound - ideal_output;
@@ -115,8 +113,8 @@ float pid_apply_antiwindup(struct pid *pid, const float err,
 		ideal_output = min_bound;
 	}
 	// Use Kt 10x Ki
-	pid->iAccumulator += saturation * (pid->i * 10.0f * dT * 1000.0f);
-	pid->iAccumulator = bound_sym(pid->iAccumulator, pid->iLim * 1000.0f);
+	pid->iAccumulator += saturation * (pid->i * 10.0f * dT);
+	pid->iAccumulator = bound_sym(pid->iAccumulator, pid->iLim);
 
 	return ideal_output;
 }
@@ -140,9 +138,8 @@ float pid_apply_setpoint(struct pid *pid, const float setpoint, const float meas
 		// If Ki is zero, do not change the integrator. We do not reset to zero
 		// because sometimes the accumulator term is set externally
 	} else {
-		// Scale up accumulator by 1000 while computing to avoid losing precision
-		pid->iAccumulator += err * (pid->i * dT * 1000.0f);
-		pid->iAccumulator = bound_sym(pid->iAccumulator, pid->iLim * 1000.0f);
+		pid->iAccumulator += err * (pid->i * dT);
+		pid->iAccumulator = bound_sym(pid->iAccumulator, pid->iLim);
 	}
 
 	// Calculate DT1 term,
@@ -155,7 +152,7 @@ float pid_apply_setpoint(struct pid *pid, const float setpoint, const float meas
 		pid->lastDer = dterm;            //   ^ set constant to 1/(2*pi*f_cutoff)
 	}	                                 //   7.9577e-3  means 20 Hz f_cutoff
  
-	return ((err * pid->p) + pid->iAccumulator / 1000.0f + dterm);
+	return ((err * pid->p) + pid->iAccumulator + dterm);
 }
 
 /**

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -160,7 +160,6 @@ static void altitudeHoldTask(void *parameters)
 			if (flight_mode == FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD && !engaged) {
 				// Copy the current throttle as a starting point for integral
 				StabilizationDesiredThrottleGet(&velocity_pid.iAccumulator);
-				velocity_pid.iAccumulator *= 1000.0f; // pid library scales up accumulator by 1000
 				engaged = true;
 
 				// Make sure this uses a valid AltitudeHoldDesired. No delay is really required here
@@ -211,7 +210,7 @@ static void altitudeHoldTask(void *parameters)
 
 			AltitudeHoldStateData altitudeHoldState;
 			altitudeHoldState.VelocityDesired = velocity_desired;
-			altitudeHoldState.Integral = velocity_pid.iAccumulator / 1000.0f;
+			altitudeHoldState.Integral = velocity_pid.iAccumulator;
 			altitudeHoldState.AngleGain = 1.0f;
 
 			if (altitudeHoldSettings.AttitudeComp > 0) {

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -396,7 +396,7 @@ static int32_t vtol_follower_control_accel(float dT)
 static float vtol_follower_control_altitude(float downCommand) {
 	AltitudeHoldStateData altitudeHoldState;
 	altitudeHoldState.VelocityDesired = downCommand;
-	altitudeHoldState.Integral = vtol_pids[DOWN_VELOCITY].iAccumulator / 1000.0f;
+	altitudeHoldState.Integral = vtol_pids[DOWN_VELOCITY].iAccumulator;
 	altitudeHoldState.AngleGain = 1.0f;
 
 	if (altitudeHoldSettings.AttitudeComp > 0) {

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -210,9 +210,8 @@ static void vtolPathFollowerTask(void *parameters)
 		
 			// Track throttle before engaging this mode.  Cheap system ident
 			StabilizationDesiredThrottleGet(&vtol_pids[DOWN_VELOCITY].iAccumulator);
-			// pid library scales up accumulator by 1000. Note the negative sign because this
-			// is the accumulation for down.
-			vtol_pids[DOWN_VELOCITY].iAccumulator *= -1000.0f;
+			// Note the negative sign because this is the accumulation for down.
+			vtol_pids[DOWN_VELOCITY].iAccumulator *= -1;
 		}
 
 		AlarmsClear(SYSTEMALARMS_ALARM_PATHFOLLOWER);


### PR DESCRIPTION
The justification for the scaling does not seem to be valid. The original commit, a09642675cf66650f1cccaf7567878d2f514822b, says "Tweak the integral calculation so it is scaled in ms internally.  This avoids a loss of  precision on the accumulation." However, no additional support for the claim is made in the code or commit, and is seemingly contrary to the theory of floating point precision.

If there is some justification in IEEE-754, it's not immediately obvious. If dynamic range is a problem, a cleaner solution is to add more bits. It's dangerous to expect that the all compilers will play nice and make the multiplication and division by 1000 a worthwhile operation.

Note to reviewers: This needs coverage on several targets, I've only flight-tested on LVL 1. It would also be helpful to double-check that I haven't missed any divide/multiply operations hidden elsewhere in the code. (Bloody magic numbers!)