### PR TITLE
Notify: Port to Qt5 and reenable

### DIFF
--- a/ground/gcs/src/plugins/notify/notify.pro
+++ b/ground/gcs/src/plugins/notify/notify.pro
@@ -1,5 +1,5 @@
 TEMPLATE = lib 
-QT += widgets
+QT += multimedia
 TARGET = NotifyPlugin 
  
 include(../../taulabsgcsplugin.pri) 

--- a/ground/gcs/src/plugins/notify/notifyplugin.cpp
+++ b/ground/gcs/src/plugins/notify/notifyplugin.cpp
@@ -40,9 +40,6 @@
 #include <extensionsystem/pluginmanager.h>
 
 #include <iostream>
-#include "qxttimer.h"
-#include <phonon/BackendCapabilities>
-#include <phonon/phonon>
 
 static const QString VERSION = "1.0.0";
 
@@ -221,16 +218,10 @@ void SoundNotifyPlugin::connectNotifications()
 
     if (_notificationList.isEmpty()) return;
     // set notification message to current event
-    phonon.mo = Phonon::createPlayer(Phonon::NotificationCategory);
-    phonon.mo->clearQueue();
+    phonon.mo = new QMediaPlayer;
     phonon.firstPlay = true;
-    QList<Phonon::AudioOutputDevice> audioOutputDevices =
-              Phonon::BackendCapabilities::availableAudioOutputDevices();
-    foreach(Phonon::AudioOutputDevice dev, audioOutputDevices) {
-        qNotifyDebug() << "Notify: Audio Output device: " << dev.name() << " - " << dev.description();
-    }
-    connect(phonon.mo, SIGNAL(stateChanged(Phonon::State,Phonon::State)),
-        this, SLOT(stateChanged(Phonon::State,Phonon::State)));
+    connect(phonon.mo, SIGNAL(stateChanged(QMediaPlayer::State)),
+        this, SLOT(stateChanged(QMediaPlayer::State)));
 }
 
 void SoundNotifyPlugin::on_arrived_Notification(UAVObject *object)
@@ -312,10 +303,8 @@ void SoundNotifyPlugin::on_expiredTimer_Notification()
     }
 }
 
-void SoundNotifyPlugin::stateChanged(Phonon::State newstate, Phonon::State oldstate)
+void SoundNotifyPlugin::stateChanged(QMediaPlayer::State newstate)
 {
-    Q_UNUSED(oldstate)
-
     //qNotifyDebug() << "File length (ms): " << phonon.mo->totalTime();
 
 #ifndef Q_OS_WIN
@@ -323,12 +312,8 @@ void SoundNotifyPlugin::stateChanged(Phonon::State newstate, Phonon::State oldst
     // wav file before moving to the next in the queue.
     // I wish I did not have to go through a #define, but I did not
     // manage to make this work on both platforms any other way!
-    if (phonon.mo->totalTime()>0)
-        phonon.mo->setTransitionTime(phonon.mo->totalTime());
 #endif
-    if ((newstate  == Phonon::PausedState) ||
-       (newstate  == Phonon::StoppedState))
-    {
+    if ((newstate == QMediaPlayer::PausedState) || (newstate == QMediaPlayer::StoppedState)) {
         qNotifyDebug() << "New State: " << QVariant(newstate).toString();
 
         // assignment to NULL needed to detect that palying is finished
@@ -342,13 +327,6 @@ void SoundNotifyPlugin::stateChanged(Phonon::State newstate, Phonon::State oldst
             qNotifyDebug_if(notification) << "play audioFree - " << notification->toString();
             playNotification(notification);
             qNotifyDebug()<<"end playNotification";
-        }
-    } else {
-        if (newstate  == Phonon::ErrorState) {
-            if (phonon.mo->errorType()==0) {
-                qDebug() << "Phonon::ErrorState: ErrorType = " << phonon.mo->errorType();
-                phonon.mo->clearQueue();
-            }
         }
     }
 }
@@ -465,6 +443,7 @@ void SoundNotifyPlugin::checkNotificationRule(NotificationItem* notification, UA
 
 bool SoundNotifyPlugin::playNotification(NotificationItem* notification)
 {
+    playlist = new QMediaPlaylist;
     if(!notification)
         return false;
 
@@ -474,8 +453,8 @@ bool SoundNotifyPlugin::playNotification(NotificationItem* notification)
 
     //qNotifyDebug() << "Phonon State: " << phonon.mo->state();
 
-    if ((phonon.mo->state()==Phonon::PausedState)
-        || (phonon.mo->state()==Phonon::StoppedState)
+    if ((phonon.mo->state()==QMediaPlayer::PausedState)
+        || (phonon.mo->state()==QMediaPlayer::StoppedState)
             || phonon.firstPlay)
     {
         _nowPlayingNotification = notification;
@@ -511,14 +490,13 @@ bool SoundNotifyPlugin::playNotification(NotificationItem* notification)
                         this, SLOT(on_timerRepeated_Notification()), Qt::UniqueConnection);
             }
         }
-        phonon.mo->clear();
+        phonon.mo->stop();
         qNotifyDebug() << "play: " << notification->toString();
         foreach (QString item, notification->toSoundList()) {
-            Phonon::MediaSource *ms = new Phonon::MediaSource(item);
-            ms->setAutoDelete(true);
-            phonon.mo->enqueue(*ms);
+            playlist->addMedia(QUrl::fromLocalFile(item));
         }
         qNotifyDebug()<<"begin play";
+        phonon.mo->setPlaylist(playlist);
         phonon.mo->play();
         qNotifyDebug()<<"end play";
         phonon.firstPlay = false; // On Linux, you sometimes have to nudge Phonon to play 1 time before

--- a/ground/gcs/src/plugins/notify/notifyplugin.h
+++ b/ground/gcs/src/plugins/notify/notifyplugin.h
@@ -38,15 +38,13 @@
 #include "notificationitem.h"
 
 #include <QSettings>
-#include <phonon/MediaObject>
-#include <phonon/Path>
-#include <phonon/AudioOutput>
-#include <phonon/Global>
+#include <QMediaPlayer>
+#include <QMediaPlaylist>
 
 class NotifyPluginOptionsPage;
 
 typedef struct {
-	Phonon::MediaObject* mo;
+	QMediaPlayer* mo;
 	NotificationItem* notify;
 	bool firstPlay;
 } PhononObject, *pPhononObject;
@@ -55,7 +53,7 @@ typedef struct {
 class SoundNotifyPlugin : public Core::IConfigurablePlugin
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "AboveGroundLabs.plugins.NotifyPlugin" FILE "NotifyPlugin.json")
+    Q_PLUGIN_METADATA(IID "TauLabs.plugins.NotifyPlugin" FILE "NotifyPlugin.json")
 public:
     SoundNotifyPlugin();
     ~SoundNotifyPlugin();
@@ -89,7 +87,7 @@ private slots:
     void on_arrived_Notification(UAVObject *object);
     void on_timerRepeated_Notification(void);
     void on_expiredTimer_Notification(void);
-    void stateChanged(Phonon::State newstate, Phonon::State oldstate);
+    void stateChanged(QMediaPlayer::State newstate);
 
 private:
     bool enableSound;
@@ -105,6 +103,7 @@ private:
     PhononObject phonon;
     NotifyPluginOptionsPage* mop;
     TelemetryManager* telMngr;
+    QMediaPlaylist *playlist;
 }; 
 
 #endif // SOUNDNOTIFYPLUGIN_H

--- a/ground/gcs/src/plugins/notify/notifypluginoptionspage.h
+++ b/ground/gcs/src/plugins/notify/notifypluginoptionspage.h
@@ -41,12 +41,10 @@
 #include <QItemSelectionModel>
 #include <QDebug>
 #include <QtCore/QSettings>
-#include <phonon/MediaObject>
-#include <phonon/Path>
-#include <phonon/AudioOutput>
-#include <phonon/Global>
 #include <QComboBox>
 #include <QSpinBox>
+#include <QSoundEffect>
+#include <QMediaPlayer>
 
 class NotifyTableModel;
 class NotificationItem;
@@ -97,8 +95,7 @@ private slots:
     void on_clicked_buttonSoundFolder(const QString& path);
     void on_changedIndex_UAVObject(QString val);
     void on_changedIndex_UAVField(QString val);
-    void on_changed_playButtonText(Phonon::State newstate, Phonon::State oldstate);
-    void on_toggled_checkEnableSound(bool state);
+    void on_changed_playButtonText(QMediaPlayer::State newstate);
 
     /**
      * Important when we change to or from "In range" value
@@ -138,7 +135,7 @@ private:
     SoundNotifyPlugin* _owner;
 
     //! Media object uses to test sound playing
-    QScopedPointer<Phonon::MediaObject> _testSound;
+    QMediaPlayer *_testSound;
 
     QScopedPointer<NotifyTableModel> _notifyRulesModel;
     QItemSelectionModel* _notifyRulesSelection;
@@ -185,6 +182,7 @@ private:
     //! if UAVObjectManager doesn't have such object, this field will be NULL
     UAVDataObject* _currUAVObject;
 
+    QMediaPlaylist *playlist;
 };
 
 #endif // NOTIFYPLUGINOPTIONSPAGE_H

--- a/ground/gcs/src/plugins/notify/notifytablemodel.cpp
+++ b/ground/gcs/src/plugins/notify/notifytablemodel.cpp
@@ -33,6 +33,7 @@
 #include "notifylogging.h"
 #include <qdebug.h>
 #include <QMimeData>
+#include <QDataStream>
 
 const char* mime_type_notify_table = "openpilot/notify_plugin_table";
 

--- a/ground/gcs/src/plugins/plugins.pro
+++ b/ground/gcs/src/plugins/plugins.pro
@@ -89,13 +89,13 @@ SUBDIRS += plugin_modelview
 }
 
 # Notify gadget NEEDS PHONON UPGRADED TO QT5
-#!disable_notify_plugin {
-#    plugin_notify.subdir = notify
-#    plugin_notify.depends = plugin_coreplugin
-#    plugin_notify.depends += plugin_uavobjects
-#    plugin_notify.depends += plugin_uavtalk
-#    SUBDIRS += plugin_notify
-#}
+!disable_notify_plugin {
+    plugin_notify.subdir = notify
+    plugin_notify.depends = plugin_coreplugin
+    plugin_notify.depends += plugin_uavobjects
+    plugin_notify.depends += plugin_uavtalk
+    SUBDIRS += plugin_notify
+}
 
 # Uploader gadget
 plugin_uploader.subdir = uploader


### PR DESCRIPTION
Remove Phonon and replace with QMediaPlayer. No (intentional) functional changes. (NOTE: on_toggled_checkEnableSound() was removed, as it was not doing useful work.)

Inspired by OpenPilot commit: a2ba33f28a76cd4e2e7e88200408c1d7cf842cb9

=========================
As an aside, it would be useful to set up defaults for sound. I suspect that this module hasn't been used because without default sounds most people didn't know it was there. Default sounds seem to work for ArduPilot, so there is precedence for which ones are useful to the community.