### PR TITLE
UAVObjectGenerator: Added NUMOPTS #define for options fields

### DIFF
--- a/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
+++ b/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
@@ -183,6 +183,12 @@ bool UAVObjectGeneratorFlight::process_object(ObjectInfo* info)
             enums.append( QString(" }  __attribute__((packed)) %1%2Options;\r\n")
                           .arg( info->name )
                           .arg( info->fields[n]->name ) );
+
+            enums.append(QString("/* Number of options for field %1 */\r\n").arg(info->fields[n]->name));
+            enums.append( QString("#define %1_%2_NUMOPTS %3\r\n")
+                          .arg( info->name.toUpper() )
+                          .arg( info->fields[n]->name.toUpper() )
+                          .arg( info->fields[n]->options.length() ) );
         }
         // Generate element names (only if field has more than one element)
         if (info->fields[n]->numElements > 1 && !info->fields[n]->defaultElementNames)

--- a/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
+++ b/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
@@ -97,8 +97,8 @@ bool UAVObjectGeneratorFlight::generate(UAVObjectParser* parser,QString template
     return true; // if we come here everything should be fine
 }
 
-QString UAVObjectGeneratorFlight::form_enum_name(QString& objName,
-        QString &fieldName, QString &option) {
+QString UAVObjectGeneratorFlight::form_enum_name(const QString& objName,
+        const QString &fieldName, const QString &option) {
     QString s = "%1_%2_%3";
 
     return s.arg( objName.toUpper() )

--- a/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
+++ b/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
@@ -163,6 +163,7 @@ bool UAVObjectGeneratorFlight::process_object(ObjectInfo* info)
             enums.append("typedef enum { ");
             // Go through each option
             QStringList options = info->fields[n]->options;
+            bool const has_parent = info->fields[n]->parent != NULL;
             for (int m = 0; m < options.length(); ++m) {
                 QString optionName = form_enum_name(info->name,
                         info->fields[n]->name, options[m]);
@@ -173,13 +174,18 @@ bool UAVObjectGeneratorFlight::process_object(ObjectInfo* info)
                             info->fields[n]->parent->name, options[m]);
                 }
 
-                QString s = (m == (options.length()-1)) ? "%1=%2" : "%1=%2, ";
+                // only need to add comma if this is a root options list and this isn't the last option
+                QString s = (!has_parent && m == (options.length()-1)) ? "%1=%2" : "%1=%2, ";
 
                 enums.append( s
                                 .arg( optionName )
                                 .arg( value ) );
 
             }
+
+            // if this is a child options list, add special enum value to prevent using switch() statements on the generated enum (use root enum instead)
+            if (has_parent) enums.append( QString("%1=%2").arg( form_enum_name(info->name, info->fields[n]->name, QString("DONTSWITCHONCHILDENUMS") ) ).arg( 255 ) );
+
             enums.append( QString(" }  __attribute__((packed)) %1%2Options;\r\n")
                           .arg( info->name )
                           .arg( info->fields[n]->name ) );

--- a/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
+++ b/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.cpp
@@ -184,11 +184,17 @@ bool UAVObjectGeneratorFlight::process_object(ObjectInfo* info)
                           .arg( info->name )
                           .arg( info->fields[n]->name ) );
 
-            enums.append(QString("/* Number of options for field %1 */\r\n").arg(info->fields[n]->name));
-            enums.append( QString("#define %1_%2_NUMOPTS %3\r\n")
+            // find topmost parent and get the length of its options field
+            FieldInfo_s * topmost_parent = info->fields[n];
+            while (topmost_parent->parent) {
+                topmost_parent = topmost_parent->parent;
+            }
+
+            enums.append(QString("/* Max value of any options in topmost parent of field %1 */\r\n").arg(info->fields[n]->name));
+            enums.append( QString("#define %1_%2_MAXOPTVAL %3\r\n")
                           .arg( info->name.toUpper() )
                           .arg( info->fields[n]->name.toUpper() )
-                          .arg( info->fields[n]->options.length() ) );
+                          .arg( topmost_parent->options.length() - 1 ) );
         }
         // Generate element names (only if field has more than one element)
         if (info->fields[n]->numElements > 1 && !info->fields[n]->defaultElementNames)

--- a/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.h
+++ b/ground/uavobjgenerator/generators/flight/uavobjectgeneratorflight.h
@@ -40,7 +40,7 @@ public:
 
 private:
     bool process_object(ObjectInfo* info);
-    QString form_enum_name(QString& objName, QString &fieldName, QString &option);
+    QString form_enum_name(const QString& objName, const QString &fieldName, const QString &option);
 
 };
 


### PR DESCRIPTION
Fixes #1886 
- Field `MyCoolUAVO->MyCoolField` with `options="Option1, Option2, Option3"` will now have `#define MYCOOLUAVO_MYCOOLFIELD_NUMOPTS=3` in `uavobject-synthetics/flight/mycooluavo.h`
- Also note that this should (and does) happen even if there's only one option