### PR TITLE
misc_math: remove optimizer attribute on IS_NOT_FINITE

### DIFF
--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -65,19 +65,13 @@ void vector2_rotate(const float *original, float *out, float angle);
 float cubic_deadband(float in, float w, float b, float m, float r);
 void cubic_deadband_setup(float w, float b, float *m, float *r);
 
-/* NOTE: Interesting problem regarding NaN and Inf checks. The compile optimization --fast-math
- * does many useful things, but it also removes the ability to check if a number is a Nan, even
- * if the check is the classic `x == x`. Thus we need to add this back in, and we do it as a
- * function which has the optimizations turned off.
- *
- * Souce: http://stackoverflow.com/questions/22931147/stdisinf-does-not-work-with-ffast-math-how-to-check-for-infinity
+/* Note--- current compiler chain has been verified to produce proper call
+ * to fpclassify even when compiling with -ffast-math / -ffinite-math.
+ * Previous attempts were made here to limit scope of disabling those
+ * optimizations to this function, but were infectious and increased
+ * stack usage across unrelated code because of compiler limitations.
+ * See TL issue #1879.
  */
-#if defined (__clang__) // Clang can't turn off specific optimizations, so turn them all off. This is currently only useful when compiling the simulator with Clang
-static inline bool IS_NOT_FINITE(float x) __attribute__((optnone()));
-#else
-static inline bool IS_NOT_FINITE(float x) __attribute__((optimize("no-finite-math-only")));
-#endif
-
 static inline bool IS_NOT_FINITE(float x) {
 	return (!isfinite(x));
 }


### PR DESCRIPTION
Discussion in #1879 .  This is an attempt at the minimal change.  It does come with some long term risk if the compiler chain gets smarter.