### PR TITLE
Fix fw naze32 tlfw target detection

### DIFF
--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -141,8 +141,9 @@ $(1).firmwareinfo.c: $(1) $(ROOT_DIR)/make/templates/firmwareinfotemplate.c FORC
 
 $(eval $(call COMPILE_C_TEMPLATE, $(1).firmwareinfo.c))
 
-# Hack to place Naze firmware info at correct location in flash TODO: fix properly
-ifeq (,$(findstring naze32,$(TARGET)))
+# This excludes the naze32 target from the standard tlfw rule
+# as the naze32 doesn't use the standard TL bootloader
+ifneq ($(TARGET), fw_naze32_tlfw)
 $(OUTDIR)/$(notdir $(basename $(1))).tlfw : $(1) $(1).firmwareinfo.bin
 	@echo $(MSG_TLFIRMWARE) $$(call toprel, $$@)
 	$(V1) cat $(1) $(1).firmwareinfo.bin > $$@


### PR DESCRIPTION
* Make it such that similarly named boards (e.g. @jihlein's naze32pro support) are able to build without the weird tlfw hax.