### PR TITLE
PFD: Add magnetic compass indicator. 

### DIFF
--- a/ground/gcs/share/taulabs/pfd/default/pfd.svg
+++ b/ground/gcs/share/taulabs/pfd/default/pfd.svg
@@ -4052,6 +4052,26 @@
     </g>
     <g
        inkscape:groupmode="layer"
+       id="layer34"
+       inkscape:label="unfiltered-compass-bearing"
+       style="display:inline"
+       sodipodi:insensitive="true">
+      <g
+         transform="translate(230.4171,-2.5493514)"
+         style="display:inline"
+         id="unfiltered-compass-bearing"
+         inkscape:label="#g8509">
+        <rect
+           style="fill:#ff0000;fill-opacity:1;stroke:none;display:inline"
+           id="rect3967-7"
+           width="3"
+           height="37.5"
+           x="191.92456"
+           y="21.661144" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
        id="layer33"
        inkscape:label="homewaypoint"
        style="display:inline"

--- a/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/pfdqml/pfdqmlgadgetwidget.cpp
@@ -63,6 +63,7 @@ PfdQmlGadgetWidget::PfdQmlGadgetWidget(QWidget *parent) :
                        "AttitudeActual" <<
                        "AirspeedActual" <<
                        "Accels" <<
+                       "Magnetometer" <<
                        "VelocityDesired" <<
                        "PositionDesired" <<
                        "AttitudeHoldDesired" <<


### PR DESCRIPTION
This has been very nice for the last 18 months. It shows the calculated magnetic heading on the PFD  (corrected for magnetic inclination). It provides a true "compass" reading and we've used it for a variety of uses, such as determining that the heading initialization is wrong when the board is inclined.

Ideally, the red line should always be in the middle of the box on the compass ticker, although it will bounce around due to error.
<img width="717" alt="screen shot 2015-09-03 at 8 44 41 pm" src="https://cloud.githubusercontent.com/assets/1118185/9674263/9b102db2-527c-11e5-83c7-9e2811e2f715.png">