### PR TITLE
Settings: Workaround for sporadic corruption of settings files.

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -263,12 +263,17 @@ int main(int argc, char **argv)
     // Must be done before any QSettings class is created
     QSettings::setPath(XmlConfig::XmlSettingsFormat, QSettings::SystemScope,
             QCoreApplication::applicationDirPath()+QLatin1String(SHARE_PATH));
-    // keep this in sync with the MainWindow ctor in coreplugin/mainwindow.cpp
-    QSettings settings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
-                                 QLatin1String("TauLabs"), QLatin1String("TauLabs_config"));
 
-    overrideSettings(settings, argc, argv);
-    locale = settings.value("General/OverrideLanguage", locale).toString();
+    // Scope this so that we are guaranteed that the QSettings file is closed immediately. This
+    // prevents corruption.
+    {
+        // keep this in sync with the MainWindow ctor in coreplugin/mainwindow.cpp
+        QSettings settings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
+                           QLatin1String("TauLabs"), QLatin1String("TauLabs_config"));
+
+        overrideSettings(settings, argc, argv);
+        locale = settings.value("General/OverrideLanguage", locale).toString();
+    }
 
     QTranslator translator;
     QTranslator qtTranslator;

--- a/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
+++ b/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
@@ -133,8 +133,6 @@ MainWindow::MainWindow() :
     // keep this in sync with main() in app/main.cpp
     m_settings = new QSettings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
                              QLatin1String("TauLabs"), QLatin1String("TauLabs_config.autosave"), this);
-    m_globalSettings = new QSettings(XmlConfig::XmlSettingsFormat, QSettings::SystemScope,
-                                 QLatin1String("TauLabs"), QLatin1String("TauLabs_config.autosave"), this);
     m_settingsDatabase = new SettingsDatabase(QFileInfo(m_settings->fileName()).path(),
                                             QLatin1String("TauLabs_config"),
                                             this);

--- a/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
+++ b/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
@@ -103,14 +103,6 @@ MainWindow::MainWindow() :
     m_uniqueIDManager(new UniqueIDManager()),
     m_globalContext(QList<int>() << Constants::C_GLOBAL_ID),
     m_additionalContexts(m_globalContext),
-    // keep this in sync with main() in app/main.cpp
-    m_settings(new QSettings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
-                             QLatin1String("TauLabs"), QLatin1String("TauLabs_config"), this)),
-    m_globalSettings(new QSettings(XmlConfig::XmlSettingsFormat, QSettings::SystemScope,
-                                 QLatin1String("TauLabs"), QLatin1String("TauLabs_config"), this)),
-    m_settingsDatabase(new SettingsDatabase(QFileInfo(m_settings->fileName()).path(),
-                                            QLatin1String("TauLabs_config"),
-                                            this)),
     m_dontSaveSettings(false),
     m_actionManager(new ActionManagerPrivate(this)),
     m_variableManager(new VariableManager(this)),
@@ -138,6 +130,31 @@ MainWindow::MainWindow() :
 #endif /* Q_OS_MAC */
     m_toggleFullScreenAction(0)
 {
+    // keep this in sync with main() in app/main.cpp
+    m_settings = new QSettings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
+                             QLatin1String("TauLabs"), QLatin1String("TauLabs_config.autosave"), this);
+    m_globalSettings = new QSettings(XmlConfig::XmlSettingsFormat, QSettings::SystemScope,
+                                 QLatin1String("TauLabs"), QLatin1String("TauLabs_config.autosave"), this);
+    m_settingsDatabase = new SettingsDatabase(QFileInfo(m_settings->fileName()).path(),
+                                            QLatin1String("TauLabs_config"),
+                                            this);
+
+    // Copy original settings file to working settings. Do this in scope so that
+    // we are guaranteed that the originalSettings file is closed. This prevents corruption
+    // since the QSettings being used are copies of the original file.
+    {
+        QSettings originalSettings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
+                                   QLatin1String("TauLabs"), QLatin1String("TauLabs_config"), this);
+
+        // There is no copy constructor for QSettings, so we have to do it manually
+        m_settings->clear();
+        QStringList keys = originalSettings.allKeys();
+        for( QStringList::iterator i = keys.begin(); i != keys.end(); i++ )
+        {
+            m_settings->setValue( *i, originalSettings.value( *i ) );
+        }
+    }
+
     setWindowTitle(QLatin1String(Core::Constants::GCS_NAME));
     if (!Utils::HostOsInfo::isMacHost())
         QApplication::setWindowIcon(QIcon(Core::Constants::ICON_TAULABS));
@@ -235,6 +252,23 @@ MainWindow::~MainWindow()
     m_generalSettings = 0;
     delete m_workspaceSettings;
     m_workspaceSettings = 0;
+
+    // Copy working settings back to original settings file. Do this in scope so that
+    // we are guaranteed that the originalSettings file is closed. This minimizes the risk
+    // of corruption since the QSettings are saved (almost) atomically.
+    {
+        QSettings originalSettings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
+                                   QLatin1String("TauLabs"), QLatin1String("TauLabs_config"), this);
+
+        // There is no copy constructor for QSettings, so we have to do it manually
+        originalSettings.clear();
+        QStringList keys = m_settings->allKeys();
+        for( QStringList::iterator i = keys.begin(); i != keys.end(); i++ )
+        {
+            originalSettings.setValue( *i, m_settings->value( *i ) );
+        }
+    }
+
     delete m_settings;
     m_settings = 0;
     delete m_uniqueIDManager;
@@ -1302,8 +1336,17 @@ void MainWindow::saveSettings(IConfigurablePlugin* plugin, QSettings* qs)
 
 void MainWindow::deleteSettings()
 {
+    // Clear the in-memory settings
     m_settings->clear();
     m_settings->sync();
+
+    // Clear the on-disk settings
+    QSettings originalSettings(XmlConfig::XmlSettingsFormat, QSettings::UserScope,
+                               QLatin1String("TauLabs"), QLatin1String("TauLabs_config"), this);
+    originalSettings.clear();
+    originalSettings.sync();
+
+    // Don't save the settings when exiting
     m_dontSaveSettings = true;
 }
 


### PR DESCRIPTION
GCS is known to crash frequently on certain platforms, and some of those crashes cause user settings file corruption. This provides a workaround by loading a copy of settings into local memory and then closing the QSettings object. Upon close, the new settings are copied back onto the old settings file in an (almost) atomic operation. This minimizes the window when settings can be corrupted by undefined behavior during a crash.

Note: This has been in operation for a year. It's been a wonderful fix!