### PR TITLE
[RFC] Make: Add option to pad firmware description in TLFW

### DIFF
--- a/flight/targets/naze32/board-info/board-info.mk
+++ b/flight/targets/naze32/board-info/board-info.mk
@@ -3,6 +3,8 @@ BOARD_REVISION      := 0x01
 BOOTLOADER_VERSION  := 0x80
 HW_TYPE             := 0x01
 
+PAD_TLFW_FW_DESC    := yes
+
 MCU                 := cortex-m3
 CHIP                := STM32F103CBT
 BOARD               := STM32103CB_Naze32

--- a/flight/targets/naze32/fw/Makefile
+++ b/flight/targets/naze32/fw/Makefile
@@ -516,12 +516,3 @@ LDFLAGS += -T$(LINKERSCRIPTPATH)/link_$(BOARD)_sections.ld
 
 include ./UAVObjects.inc
 include $(MAKE_INC_DIR)/firmware-common.mk
-
-# Hack to place firmware info at correct location in flash
-$(OUTDIR)/$(TARGET).padded.bin: FW_DESC_BASE := $(shell echo $$(($(FW_BANK_BASE)+$(FW_BANK_SIZE)-$(FW_DESC_SIZE))))
-$(OUTDIR)/$(TARGET).padded.bin: $(OUTDIR)/$(TARGET).elf
-	$(V1) $(OBJCOPY) --pad-to=$(FW_DESC_BASE) -O binary $< $@
-
-$(OUTDIR)/$(TARGET).tlfw: $(OUTDIR)/$(TARGET).padded.bin $(OUTDIR)/$(TARGET).bin.firmwareinfo.bin
-	@echo $(MSG_TLFIRMWARE) $(call toprel, $@)
-	$(V1) cat $^ > $@

--- a/make/firmware-common.mk
+++ b/make/firmware-common.mk
@@ -139,7 +139,15 @@ $(eval $(call PARTIAL_COMPILE_TEMPLATE, SRC))
 
 $(OUTDIR)/$(TARGET).bin.o: $(OUTDIR)/$(TARGET).bin
 
-$(eval $(call TLFW_TEMPLATE,$(OUTDIR)/$(TARGET).bin,$(BOARD_TYPE),$(BOARD_REVISION)))
+# Allows the bin to be padded up to the firmware description blob base
+# Required for boards which don't use the TL bootloader to put
+# the blob at the correct location
+ifdef PAD_TLFW_FW_DESC
+FW_DESC_BASE := $(shell echo $$(($(FW_BANK_BASE)+$(FW_BANK_SIZE)-$(FW_DESC_SIZE))))
+else 
+FW_DESC_BASE = 0
+endif
+$(eval $(call TLFW_TEMPLATE,$(OUTDIR)/$(TARGET).bin,$(BOARD_TYPE),$(BOARD_REVISION),$(FW_DESC_BASE)))
 
 # Add jtag targets (program and wipe)
 $(eval $(call JTAG_TEMPLATE,$(OUTDIR)/$(TARGET).bin,$(FW_BANK_BASE),$(FW_BANK_SIZE),$(OPENOCD_JTAG_CONFIG),$(OPENOCD_CONFIG)))
@@ -179,6 +187,7 @@ clean_list :
 	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).elf
 	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).hex
 	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).bin
+	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).padded.bin
 	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).sym
 	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).lss
 	$(V1) $(REMOVE) $(OUTDIR)/$(TARGET).bin.o


### PR DESCRIPTION
The motivation for this is that my previous workaround for the naze breaks @jihlein's out-of-tree naze32pro build as it is not specific enough (matches all targets with naze32 in the name). This is a much cleaner general solution which can be easily used for other targets in future. In particular it is useful for others doing out-of-tree branches for boards with CP2102 instead of USB. The side effect when building a .tlfw is that a `$(TARGET).padded.bin` will be created in the build directory for every target, but will be identical to the regular `$(TARGET).bin` unless the padded option is enabled.

Replaces #1890 .