### PR TITLE
Mixer maximum value abstraction

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -399,11 +399,11 @@ float ProcessMixer(const int index, const float curve1, const float curve2,
 	const Mixer_t * mixers = (Mixer_t *)&mixerSettings->Mixer1Type; //pointer to array of mixers in UAVObjects
 	const Mixer_t * mixer = &mixers[index];
 
-	float result = (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE1] / 128.0f) * curve1) +
-		       (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE2] / 128.0f) * curve2) +
-		       (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_ROLL] / 128.0f) * desired->Roll) +
-		       (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_PITCH] / 128.0f) * desired->Pitch) +
-		       (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_YAW] / 128.0f) * desired->Yaw);
+	float result = (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE1] * curve1) +
+	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE2] * curve2) +
+	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_ROLL] * desired->Roll) +
+	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_PITCH] * desired->Pitch) +
+	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_YAW] * desired->Yaw)) / 128.0f;
 
 	if((mixer->type == MIXERSETTINGS_MIXER1TYPE_MOTOR) && (result < 0.0f))
 	{

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -91,10 +91,9 @@ float ProcessMixer(const int index, const float curve1, const float curve2,
 		   const float period);
 
 //this structure allows easy access to the UAVObjects for one mixer.
-MixerSettingsData *tmp;
 typedef struct {
-	typeof(tmp->Mixer1Type) type;
-	typeof(tmp->Mixer1Vector[0]) *vector;
+	typeof(((MixerSettingsData *) NULL)->Mixer1Type) type;
+	typeof(((MixerSettingsData *) NULL)->Mixer1Vector[0]) *vector;
 } MixerTable;
 
 MixerTable MixerEntry_t[ACTUATORCOMMAND_CHANNEL_NUMELEM];

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -167,12 +167,12 @@ static void actuatorTask(void* parameters)
 
 	/* Read initial values of ActuatorSettings */
 	ActuatorSettingsData actuatorSettings;
-	actuator_settings_updated = false;
+	actuator_settings_updated = true;
 	ActuatorSettingsGet(&actuatorSettings);
 
 	/* Read initial values of MixerSettings */
 	MixerSettingsData mixerSettings;
-	mixer_settings_updated = false;
+	mixer_settings_updated = true;
 	MixerSettingsGet(&mixerSettings);
 
 	/* Force an initial configuration of the actuator update rates */

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -62,6 +62,7 @@
 #define TASK_PRIORITY PIOS_THREAD_PRIO_HIGHEST
 #define FAILSAFE_TIMEOUT_MS 100
 #define MAX_MIX_ACTUATORS ACTUATORCOMMAND_CHANNEL_NUMELEM
+#define MULTIROTOR_MIXER_UPPER_BOUND 128
 
 // Private types
 
@@ -453,7 +454,7 @@ float ProcessMixer(const int index, const float curve1, const float curve2,
 	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE2] * curve2) +
 	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_ROLL] * desired->Roll) +
 	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_PITCH] * desired->Pitch) +
-	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_YAW] * desired->Yaw)) / 128.0f
+	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_YAW] * desired->Yaw)) * (1.0f / MULTIROTOR_MIXER_UPPER_BOUND);
 
 	if((MixerEntry_t[index].type == MIXERSETTINGS_MIXER1TYPE_MOTOR) && (result < 0.0f))
 	{

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -89,11 +89,15 @@ float ProcessMixer(const int index, const float curve1, const float curve2,
 		   const MixerSettingsData* mixerSettings, ActuatorDesiredData* desired,
 		   const float period);
 
-//this structure is equivalent to the UAVObjects for one mixer.
+//this structure allows easy access to the UAVObjects for one mixer.
+MixerSettingsData *tmp;
 typedef struct {
-	uint8_t type;
-	int8_t matrix[5];
-} __attribute__((packed)) Mixer_t;
+	typeof(tmp->Mixer1Type) type;
+	typeof(tmp->Mixer1Vector[0]) *vector;
+} MixerTable;
+
+MixerTable MixerEntry_t[ACTUATORCOMMAND_CHANNEL_NUMELEM];
+
 
 /**
  * @brief Module initialization
@@ -199,6 +203,54 @@ static void actuatorTask(void* parameters)
 		if (mixer_settings_updated) {
 			mixer_settings_updated = false;
 			MixerSettingsGet (&mixerSettings);
+
+			for (int i=0; i<ACTUATORCOMMAND_CHANNEL_NUMELEM; i++) {
+				switch(i) {
+				case 0:
+					MixerEntry_t[i].type = mixerSettings.Mixer1Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer1Vector;
+					break;
+				case 1:
+					MixerEntry_t[i].type = mixerSettings.Mixer2Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer2Vector;
+					break;
+				case 2:
+					MixerEntry_t[i].type = mixerSettings.Mixer3Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer3Vector;
+					break;
+				case 3:
+					MixerEntry_t[i].type = mixerSettings.Mixer4Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer4Vector;
+					break;
+				case 4:
+					MixerEntry_t[i].type = mixerSettings.Mixer5Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer5Vector;
+					break;
+				case 5:
+					MixerEntry_t[i].type = mixerSettings.Mixer6Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer6Vector;
+					break;
+				case 6:
+					MixerEntry_t[i].type = mixerSettings.Mixer7Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer7Vector;
+					break;
+				case 7:
+					MixerEntry_t[i].type = mixerSettings.Mixer8Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer8Vector;
+					break;
+				case 8:
+					MixerEntry_t[i].type = mixerSettings.Mixer9Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer9Vector;
+					break;
+				case 9:
+					MixerEntry_t[i].type = mixerSettings.Mixer10Type;
+					MixerEntry_t[i].vector = mixerSettings.Mixer10Vector;
+					break;
+				default:
+					// We can never get here unless there are mixer channels not handled in the above. Fail out.
+					PIOS_Assert(0);
+				}
+			}
 		}
 
 		if (rc != true) {
@@ -221,7 +273,8 @@ static void actuatorTask(void* parameters)
 		MixerStatusGet(&mixerStatus);
 #endif
 		int nMixers = 0;
-		Mixer_t * mixers = (Mixer_t *)&mixerSettings.Mixer1Type;
+		MixerTable *mixers = MixerEntry_t;
+
 		for(int ct=0; ct < MAX_MIX_ACTUATORS; ct++)
 		{
 			if(mixers[ct].type != MIXERSETTINGS_MIXER1TYPE_DISABLED)
@@ -396,16 +449,13 @@ static void actuatorTask(void* parameters)
 float ProcessMixer(const int index, const float curve1, const float curve2,
 		   const MixerSettingsData* mixerSettings, ActuatorDesiredData* desired, const float period)
 {
-	const Mixer_t * mixers = (Mixer_t *)&mixerSettings->Mixer1Type; //pointer to array of mixers in UAVObjects
-	const Mixer_t * mixer = &mixers[index];
+	float result = (((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE1] * curve1) +
+	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE2] * curve2) +
+	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_ROLL] * desired->Roll) +
+	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_PITCH] * desired->Pitch) +
+	                ((float)MixerEntry_t[index].vector[MIXERSETTINGS_MIXER1VECTOR_YAW] * desired->Yaw)) / 128.0f
 
-	float result = (((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE1] * curve1) +
-	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE2] * curve2) +
-	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_ROLL] * desired->Roll) +
-	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_PITCH] * desired->Pitch) +
-	                ((float)mixer->matrix[MIXERSETTINGS_MIXER1VECTOR_YAW] * desired->Yaw)) / 128.0f;
-
-	if((mixer->type == MIXERSETTINGS_MIXER1TYPE_MOTOR) && (result < 0.0f))
+	if((MixerEntry_t[index].type == MIXERSETTINGS_MIXER1TYPE_MOTOR) && (result < 0.0f))
 	{
 			result = 0.0f; //idle throttle
 	}
@@ -485,22 +535,16 @@ static void setFailsafe(const ActuatorSettingsData * actuatorSettings, const Mix
 	float Channel[ACTUATORCOMMAND_CHANNEL_NUMELEM];
 	ActuatorCommandChannelGet(Channel);
 
-	const Mixer_t * mixers = (Mixer_t *)&mixerSettings->Mixer1Type; //pointer to array of mixers in UAVObjects
-
 	// Reset ActuatorCommand to safe values
 	for (int n = 0; n < ACTUATORCOMMAND_CHANNEL_NUMELEM; ++n)
 	{
 
-		if(mixers[n].type == MIXERSETTINGS_MIXER1TYPE_MOTOR)
-		{
+		if(MixerEntry_t[n].type == MIXERSETTINGS_MIXER1TYPE_MOTOR)	{
 			Channel[n] = actuatorSettings->ChannelMin[n];
 		}
-		else if(mixers[n].type == MIXERSETTINGS_MIXER1TYPE_SERVO)
-		{
+		else if(MixerEntry_t[n].type == MIXERSETTINGS_MIXER1TYPE_SERVO) {
 			Channel[n] = actuatorSettings->ChannelNeutral[n];
-		}
-		else
-		{
+		} else {
 			Channel[n] = 0.0f;
 		}
 		

--- a/flight/Modules/PicoC/picoc_library.c
+++ b/flight/Modules/PicoC/picoc_library.c
@@ -488,18 +488,51 @@ void SystemPWMOutSet(struct ParseState *Parser, struct Value *ReturnValue, struc
 	MixerSettingsData mixerSettings;
 	MixerSettingsGet(&mixerSettings);
 
-	// this structure is equivalent to the UAVObjects for one mixer.
-	typedef struct {
-		uint8_t type;
-		int8_t matrix[5];
-	} __attribute__((packed)) Mixer_t;
+#define PICOC_ACTUATOR_TYPE MIXERSETTINGS_MIXER1TYPE_DISABLED
 
-	// base pointer to mixer vectors and types
-	Mixer_t * mixers = (Mixer_t *)&mixerSettings.Mixer1Type;
+	// Initialize at !MIXERSETTINGS_MIXER1TYPE_DISABLED because then we're sure it will fail the ==MIXERSETTINGS_MIXER1TYPE_DISABLED test below
+	uint8_t mixer_type = (!PICOC_ACTUATOR_TYPE);
+
+	switch(channel) {
+	case 0:
+		mixer_type = mixerSettings.Mixer1Type;
+		break;
+	case 1:
+		mixer_type = mixerSettings.Mixer2Type;
+		break;
+	case 2:
+		mixer_type = mixerSettings.Mixer3Type;
+		break;
+	case 3:
+		mixer_type = mixerSettings.Mixer4Type;
+		break;
+	case 4:
+		mixer_type = mixerSettings.Mixer5Type;
+		break;
+	case 5:
+		mixer_type = mixerSettings.Mixer6Type;
+		break;
+	case 6:
+		mixer_type = mixerSettings.Mixer7Type;
+		break;
+	case 7:
+		mixer_type = mixerSettings.Mixer8Type;
+		break;
+	case 8:
+		mixer_type = mixerSettings.Mixer9Type;
+		break;
+	case 9:
+		mixer_type = mixerSettings.Mixer10Type;
+		break;
+	default:
+		// We can never get here unless there are mixer channels not handled in the above. Fail out.
+		PIOS_Assert(0);
+	}
 
 	// the mixer has to be disabled for this channel.
-	if (mixers[channel].type != MIXERSETTINGS_MIXER1TYPE_DISABLED)
+	if (mixer_type != PICOC_ACTUATOR_TYPE)
 		return;
+
 
 	// check actuator settings
 	ActuatorSettingsData actuatorSettings;

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
@@ -653,13 +653,13 @@ void ConfigCcpmWidget::UpdateMixer()
                 //Generate the mixer vector
                 if (i==0)
                 {//main motor-engine
-                    m_ccpm->ccpmAdvancedSettingsTable->item(i,1)->setText(QString("%1").arg(127));//ThrottleCurve1
+                    m_ccpm->ccpmAdvancedSettingsTable->item(i,1)->setText(QString("%1").arg(mixerRange));//ThrottleCurve1
                     m_ccpm->ccpmAdvancedSettingsTable->item(i,2)->setText(QString("%1").arg(0));//ThrottleCurve2
                     m_ccpm->ccpmAdvancedSettingsTable->item(i,3)->setText(QString("%1").arg(0));//Roll
                     m_ccpm->ccpmAdvancedSettingsTable->item(i,4)->setText(QString("%1").arg(0));//Pitch
 
                     if (TypeText.compare(QString::fromUtf8("Coax 2 Servo 90º"), Qt::CaseInsensitive)==0)
-                        m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(-127));//Yaw
+                        m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(-mixerRange));//Yaw
                     else
                         m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(0));//Yaw
 
@@ -668,12 +668,12 @@ void ConfigCcpmWidget::UpdateMixer()
                 {//tailrotor --or-- counter-clockwise motor
                     if (TypeText.compare(QString::fromUtf8("Coax 2 Servo 90º"), Qt::CaseInsensitive)==0)
                     {
-                        m_ccpm->ccpmAdvancedSettingsTable->item(i,1)->setText(QString("%1").arg(127));//ThrottleCurve1
-                        m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(127));//Yaw
+                        m_ccpm->ccpmAdvancedSettingsTable->item(i,1)->setText(QString("%1").arg(mixerRange));//ThrottleCurve1
+                        m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(mixerRange));//Yaw
                     }
                     else{
                         m_ccpm->ccpmAdvancedSettingsTable->item(i,1)->setText(QString("%1").arg(0));//ThrottleCurve1
-                        m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(127));//Yaw
+                        m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(mixerRange));//Yaw
                     }
 
                     m_ccpm->ccpmAdvancedSettingsTable->item(i,2)->setText(QString("%1").arg(0));//ThrottleCurve2
@@ -684,9 +684,9 @@ void ConfigCcpmWidget::UpdateMixer()
                 if (i>1)
                 {//Swashplate
                     m_ccpm->ccpmAdvancedSettingsTable->item(i,1)->setText(QString("%1").arg(0));//ThrottleCurve1
-                    m_ccpm->ccpmAdvancedSettingsTable->item(i,2)->setText(QString("%1").arg((int)(127.0*CollectiveConstant)));//ThrottleCurve2
-                    m_ccpm->ccpmAdvancedSettingsTable->item(i,3)->setText(QString("%1").arg((int)(127.0*(RollConstant)*sin((180+config.heli.CorrectionAngle + ThisAngle[i])*DEG2RAD))));//Roll
-                    m_ccpm->ccpmAdvancedSettingsTable->item(i,4)->setText(QString("%1").arg((int)(127.0*(PitchConstant)*cos((config.heli.CorrectionAngle + ThisAngle[i])*DEG2RAD))));//Pitch
+                    m_ccpm->ccpmAdvancedSettingsTable->item(i,2)->setText(QString("%1").arg((int)(mixerRange * CollectiveConstant))); //ThrottleCurve2
+                    m_ccpm->ccpmAdvancedSettingsTable->item(i,3)->setText(QString("%1").arg((int)(mixerRange * RollConstant * sin((180 + config.heli.CorrectionAngle + ThisAngle[i])*DEG2RAD)))); //Roll
+                    m_ccpm->ccpmAdvancedSettingsTable->item(i,4)->setText(QString("%1").arg((int)(mixerRange * PitchConstant * cos((config.heli.CorrectionAngle + ThisAngle[i])*DEG2RAD)))); //Pitch
                     m_ccpm->ccpmAdvancedSettingsTable->item(i,5)->setText(QString("%1").arg(0));//Yaw
 
                 }
@@ -917,17 +917,18 @@ void ConfigCcpmWidget::setMixer()
     UpdateMixer();
 
     // Set up some helper pointers
-    qint8 * mixers[8] = {mixerSettingsData.Mixer1Vector,
-                         mixerSettingsData.Mixer2Vector,
-                         mixerSettingsData.Mixer3Vector,
-                         mixerSettingsData.Mixer4Vector,
-                         mixerSettingsData.Mixer5Vector,
-                         mixerSettingsData.Mixer6Vector,
-                         mixerSettingsData.Mixer7Vector,
-                         mixerSettingsData.Mixer8Vector
+    decltype(&mixerSettingsData.Mixer1Vector[0]) mixers[8] = {
+        mixerSettingsData.Mixer1Vector,
+        mixerSettingsData.Mixer2Vector,
+        mixerSettingsData.Mixer3Vector,
+        mixerSettingsData.Mixer4Vector,
+        mixerSettingsData.Mixer5Vector,
+        mixerSettingsData.Mixer6Vector,
+        mixerSettingsData.Mixer7Vector,
+        mixerSettingsData.Mixer8Vector
     };
 
-    quint8 * mixerTypes[8] = {
+    decltype(&mixerSettingsData.Mixer1Type) mixerTypes[8] = {
         &mixerSettingsData.Mixer1Type,
         &mixerSettingsData.Mixer2Type,
         &mixerSettingsData.Mixer3Type,

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configfixedwingwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configfixedwingwidget.cpp
@@ -290,39 +290,39 @@ bool ConfigFixedWingWidget::setupFrameFixedWing(SystemSettings::AirframeTypeOpti
     //motor
     int channel = m_aircraft->fwEngineChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings,channel,MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
+    setMixerVectorValue(mixerSettings,channel,MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
 
     //rudder
     channel = m_aircraft->fwRudder1ChannelBox->currentIndex()-1;
     if (channel > -1) {
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
 
         channel = m_aircraft->fwRudder2ChannelBox->currentIndex()-1;
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
     }
 
     //ailerons
     channel = m_aircraft->fwAileron1ChannelBox->currentIndex()-1;
     if (channel > -1) {
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, mixerRange);
 
         channel = m_aircraft->fwAileron2ChannelBox->currentIndex()-1;
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, mixerRange);
     }
 
     //elevators
     channel = m_aircraft->fwElevator1ChannelBox->currentIndex()-1;
     if (channel > -1) {
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, mixerRange);
 
         channel = m_aircraft->fwElevator2ChannelBox->currentIndex()-1;
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, mixerRange);
     }
 
     m_aircraft->fwStatusLabel->setText("Mixer generated");
@@ -370,31 +370,31 @@ bool ConfigFixedWingWidget::setupFrameElevon(SystemSettings::AirframeTypeOptions
     //motor
     int channel = m_aircraft->fwEngineChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings,channel,MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
+    setMixerVectorValue(mixerSettings,channel,MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
 
     //rudders
     channel = m_aircraft->fwRudder1ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
 
     channel = m_aircraft->fwRudder2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -mixerRange);
 
     //ailerons
     channel = m_aircraft->fwAileron1ChannelBox->currentIndex()-1;
     if (channel > -1) {
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        value = (double)(m_aircraft->elevonSlider2->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider2->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, value);
-        value = (double)(m_aircraft->elevonSlider1->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider1->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, value);
 
         channel = m_aircraft->fwAileron2ChannelBox->currentIndex()-1;
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        value = (double)(m_aircraft->elevonSlider2->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider2->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, value);
-        value = (double)(m_aircraft->elevonSlider1->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider1->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, -value);
     }
 
@@ -442,42 +442,42 @@ bool ConfigFixedWingWidget::setupFrameVtail(SystemSettings::AirframeTypeOptions 
     //motor
     int channel = m_aircraft->fwEngineChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings,channel,MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
+    setMixerVectorValue(mixerSettings,channel,MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
 
     //rudders
     channel = m_aircraft->fwRudder1ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
 
     channel = m_aircraft->fwRudder2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -mixerRange);
 
     //ailerons
     channel = m_aircraft->fwAileron1ChannelBox->currentIndex()-1;
     if (channel > -1) {
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, 127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, mixerRange);
 
         channel = m_aircraft->fwAileron2ChannelBox->currentIndex()-1;
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, -127);
+        setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, -mixerRange);
     }
 
     //vtail
     channel = m_aircraft->fwElevator1ChannelBox->currentIndex()-1;
     if (channel > -1) {
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        value = (double)(m_aircraft->elevonSlider2->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider2->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, value);
-        value = (double)(m_aircraft->elevonSlider1->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider1->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, value);
 
         channel = m_aircraft->fwElevator2ChannelBox->currentIndex()-1;
         setMixerType(mixerSettings,channel,MixerSettings::MIXER1TYPE_SERVO);
-        value = (double)(m_aircraft->elevonSlider2->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider2->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, value);
-        value = (double)(m_aircraft->elevonSlider1->value()*1.27);
+        value = (double)(m_aircraft->elevonSlider1->value()*(mixerRange/100.0));
         setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -value);
     }
 

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configgroundvehiclewidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configgroundvehiclewidget.cpp
@@ -296,20 +296,20 @@ bool ConfigGroundVehicleWidget::setupGroundVehicleMotorcycle(SystemSettings::Air
     //motor
     int channel = m_aircraft->gvMotor2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
 
     //steering
     channel = m_aircraft->gvSteering1ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, -127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, -mixerRange);
 
     //balance
     channel = m_aircraft->gvSteering2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, mixerRange);
 
 	m_aircraft->gvStatusLabel->setText("Mixer generated");
 	
@@ -347,14 +347,14 @@ bool ConfigGroundVehicleWidget::setupGroundVehicleDifferential(SystemSettings::A
     //left motor
     int channel = m_aircraft->gvMotor1ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
 
     //right motor
     channel = m_aircraft->gvMotor2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE2, 127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE2, mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -mixerRange);
 
 	//Output success message
 	m_aircraft->gvStatusLabel->setText("Mixer generated");
@@ -395,19 +395,19 @@ bool ConfigGroundVehicleWidget::setupGroundVehicleCar(SystemSettings::AirframeTy
 
     int channel = m_aircraft->gvSteering1ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel, MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
 
     channel = m_aircraft->gvSteering2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel, MixerSettings::MIXER1TYPE_SERVO);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, -mixerRange);
 
     channel = m_aircraft->gvMotor1ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel, MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
 
     channel = m_aircraft->gvMotor2ChannelBox->currentIndex()-1;
     setMixerType(mixerSettings,channel, MixerSettings::MIXER1TYPE_MOTOR);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE2, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE2, mixerRange);
 
 	//Output success message
     m_aircraft->gvStatusLabel->setText("Mixer generated");

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
@@ -526,7 +526,7 @@ SystemSettings::AirframeTypeOptions ConfigMultiRotorWidget::updateConfigObjectsF
         int channel = m_aircraft->triYawChannelBox->currentIndex()-1;
         if (channel > -1){
             setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_SERVO);
-            setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, 127);
+            setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, mixerRange);
         }
 
         m_aircraft->mrStatusLabel->setText(tr("Configuration OK"));
@@ -569,14 +569,14 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-            setYawMixLevel( -qRound(value/1.27) );
+            setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
             channel = m_aircraft->multiMotorChannelBox2->currentIndex() - 1;
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( -qRound(value/1.27));
+            m_aircraft->mrRollMixLevel->setValue( -qRound(value/(mixerRange/100.0)));
 
         }
     }
@@ -595,13 +595,13 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-            setYawMixLevel( -qRound(value/1.27) );
+            setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( qRound(value/1.27));
+            m_aircraft->mrRollMixLevel->setValue( qRound(value/(mixerRange/100.0)));
 
         }
 
@@ -625,15 +625,15 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-            setYawMixLevel( -qRound(value/1.27) );
+            setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
             //change channels
             channel = m_aircraft->multiMotorChannelBox2->currentIndex() - 1;
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( -qRound(value/1.27) );
+            m_aircraft->mrRollMixLevel->setValue( -qRound(value/(mixerRange/100.0)) );
 
         }
 
@@ -658,14 +658,14 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-            setYawMixLevel( -qRound(value/1.27) );
+            setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
             channel = m_aircraft->multiMotorChannelBox2->currentIndex() - 1;
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( -qRound(value/1.27) );
+            m_aircraft->mrRollMixLevel->setValue( -qRound(value/(mixerRange/100.0)) );
         }
     }
     else if (frameType == SystemSettings::AIRFRAMETYPE_HEXACOAX)
@@ -686,14 +686,14 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(2*value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(2*value/(mixerRange/100.0)) );
 
             channel = m_aircraft->multiMotorChannelBox2->currentIndex() - 1;
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-            setYawMixLevel( qRound(value/1.27) );
+            setYawMixLevel( qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrRollMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
         }
     }
     else if (frameType ==  SystemSettings::AIRFRAMETYPE_OCTO ||
@@ -719,39 +719,39 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         {
             if (frameType == SystemSettings::AIRFRAMETYPE_OCTO) {
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-                m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+                m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-                setYawMixLevel( -qRound(value/1.27) );
+                setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
                 //change channels
                 channel = m_aircraft->multiMotorChannelBox2->currentIndex() - 1;
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-                m_aircraft->mrRollMixLevel->setValue( -qRound(value/1.27) );
+                m_aircraft->mrRollMixLevel->setValue( -qRound(value/(mixerRange/100.0)) );
             }
             else if (frameType == SystemSettings::AIRFRAMETYPE_OCTOV) {
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-                m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+                m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-                setYawMixLevel( -qRound(value/1.27) );
+                setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
                 //change channels
                 channel = m_aircraft->multiMotorChannelBox2->currentIndex() - 1;
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-                m_aircraft->mrRollMixLevel->setValue( -qRound(value/1.27) );
+                m_aircraft->mrRollMixLevel->setValue( -qRound(value/(mixerRange/100.0)) );
             }
             else if (frameType == SystemSettings::AIRFRAMETYPE_OCTOCOAXP) {
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-                m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+                m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-                setYawMixLevel( -qRound(value/1.27) );
+                setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
                 //change channels
                 channel = m_aircraft->multiMotorChannelBox3->currentIndex() - 1;
                 value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-                m_aircraft->mrRollMixLevel->setValue( -qRound(value/1.27) );
+                m_aircraft->mrRollMixLevel->setValue( -qRound(value/(mixerRange/100.0)) );
             }
 
         }
@@ -776,13 +776,13 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW);
-            setYawMixLevel( -qRound(value/1.27) );
+            setYawMixLevel( -qRound(value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrRollMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
         }
     }
     else if (frameType == SystemSettings::AIRFRAMETYPE_TRI)
@@ -799,10 +799,10 @@ void ConfigMultiRotorWidget::refreshAirframeWidgetsValues(SystemSettings::Airfra
         if (channel > -1)
         {
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH);
-            m_aircraft->mrPitchMixLevel->setValue( qRound(2*value/1.27) );
+            m_aircraft->mrPitchMixLevel->setValue( qRound(2*value/(mixerRange/100.0)) );
 
             value = getMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL);
-            m_aircraft->mrRollMixLevel->setValue( qRound(value/1.27) );
+            m_aircraft->mrRollMixLevel->setValue( qRound(value/(mixerRange/100.0)) );
 
         }
     }
@@ -822,11 +822,11 @@ void ConfigMultiRotorWidget::setupQuadMotor(int channel, double pitch, double ro
 
     setMixerType(mixerSettings, channel, MixerSettings::MIXER1TYPE_MOTOR);
 
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, 127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE1, mixerRange);
     setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_THROTTLECURVE2, 0);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, roll*127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, pitch*127);
-    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, yaw*127);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_ROLL, roll*mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_PITCH, pitch*mixerRange);
+    setMixerVectorValue(mixerSettings, channel, MixerSettings::MIXER1VECTOR_YAW, yaw*mixerRange);
 }
 
 

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/vehicleconfig.h
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/vehicleconfig.h
@@ -143,6 +143,8 @@ class VehicleConfig: public ConfigTaskWidget
         QStringList mixerVectors;
         QStringList mixerTypeDescriptions;
 
+        static constexpr double mixerRange = 127.0;
+
     private:
 
         static UAVObjectManager* getUAVObjectManager();

--- a/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
+++ b/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
@@ -63,8 +63,8 @@ QWidget *SpinBoxDelegate::createEditor(QWidget *parent,
     const QModelIndex &/* index */) const
 {
     QSpinBox *editor = new QSpinBox(parent);
-    editor->setMinimum(-127);
-    editor->setMaximum(127);
+    editor->setMinimum(-VehicleConfig::mixerRange);
+    editor->setMaximum(VehicleConfig::mixerRange);
 
     return editor;
 }


### PR DESCRIPTION
Currently the maximum mixer value is assumed to be 127. This abstracts out the magic number so other values could be used. It also fixes a brittle dependency on the UAVObject autogenerated structure, which was previously an impediment to changing the maximum value type.

The GCS changes are pretty superficial, but the firmware changes are a little more in-depth and require more reviewer attention. (To be honest, I'm surprised that the firmware never broke before because of the dependency on the autogenerated MixerSettings struct.)

Note that there is currently no way to deduce the maximum mixer value from any UAVObject. Thus, it needs to be manually set in vehicleconfig.h and actuator.c. Also note that in one the maximum was ```127``` and in the other ```128```. I have elected not to change this at this time.