### PR TITLE
Fix AxisLock rate limitation

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -423,7 +423,7 @@ static void stabilizationTask(void* parameters)
 					if (reinit)
 						pids[PID_RATE_ROLL + i].iAccumulator = 0;
 
-					if(fabs(stabDesiredAxis[i]) > max_axislock_rate) {
+					if (fabsf(stabDesiredAxis[i]) > max_axislock_rate) {
 						// While getting strong commands act like rate mode
 						rateDesiredAxis[i] = bound_sym(stabDesiredAxis[i], settings.ManualRate[i]);
 


### PR DESCRIPTION
AxisLock was saturating to the wrong value. The takeaway is that we can now push yaw rates well past 720deg/s (although it's mind numbing to fly a drone spinning at that speed).

The bug was an errant bounding by ```MaximumRate``` where there should have been bounding by ```ManualRate```.