### PR TITLE
Make:Package: Copy xcbglintegrations to qtplugins directory on linux

### DIFF
--- a/package/Makefile.linux
+++ b/package/Makefile.linux
@@ -40,7 +40,7 @@ ALL_DEB_FILES += $(foreach f, $(DEB_MACHINE_FILES), $(DEB_BUILD_DIR)/$(f))
 
 DEB_PACKAGE_NAME	:= taulabs_$(VERSION_FULL)_$(DEB_PLATFORM)
 
-QT_PLUGINS_USED		:=imageformats platforms sqldrivers
+QT_PLUGINS_USED		:= imageformats platforms sqldrivers xcbglintegrations
 
 standalone: gcs
 	@echo $@ starting
@@ -50,6 +50,7 @@ standalone: gcs
 	$(V1)cp -v -R $(QT_PLUGINS_DIR)/platforms $(ROOT_DIR)/build/ground/gcs/lib/taulabs/qtplugins/
 	$(V1) mkdir -p "$(ROOT_DIR)/build/ground/gcs/lib/taulabs/qtplugins/sqldrivers"
 	$(V1)cp -v -R $(QT_PLUGINS_DIR)/sqldrivers/libqsqlite.so $(ROOT_DIR)/build/ground/gcs/lib/taulabs/qtplugins/sqldrivers
+	$(V1)cp -v -R $(QT_PLUGINS_DIR)/xcbglintegrations $(ROOT_DIR)/build/ground/gcs/lib/taulabs/qtplugins/
 	$(V1) mkdir -p "$(ROOT_DIR)/build/ground/gcs/lib/taulabs/qml"
 	$(V1)cp -v -R $(QT_PLUGINS_DIR)/../qml/QtQuick.2 $(ROOT_DIR)/build/ground/gcs/lib/taulabs/qml/
 	$(V1)cp -v -R $(QT_PLUGINS_DIR)/../qml/QtQuick $(ROOT_DIR)/build/ground/gcs/lib/taulabs/qml/


### PR DESCRIPTION
Required for Qt 5.5, as per #1913. Seems Qt changed from [compile time detection](http://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbintegration.cpp?h=v5.4.1#n249) to [runtime detection](http://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbintegration.cpp?h=v5.5.0#n214) of GL in 5.5 and it depends on this plugin being present. Mostly solved by @mlyle.