### PR TITLE
PIOS HAL: make RFM22B optional

### DIFF
--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -10,8 +10,11 @@
 #include <pios_i2c_priv.h>
 #include <pios_usb_cdc_priv.h>
 #include <pios_usb_hid_priv.h>
+
+#if defined(PIOS_INCLUDE_RFM22B)
 #include <pios_rfm22b_priv.h>
 #include <pios_openlrs_priv.h>
+#endif /* PIOS_INCLUDE_RFM22B */
 
 /* One slot per selectable receiver group.
  *  eg. PWM, PPM, GCS, SPEKTRUM1, SPEKTRUM2, SBUS
@@ -61,6 +64,7 @@ void PIOS_HAL_ConfigureHID(HwSharedUSB_HIDPortOptions port_type,
 		uintptr_t usb_id,
 		const struct pios_usb_hid_cfg *hid_cfg);
 
+#if defined(PIOS_INCLUDE_RFM22B)
 void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
                 uint8_t board_type, uint8_t board_rev,
                 HwSharedMaxRfPowerOptions max_power,
@@ -69,5 +73,6 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
                 const struct pios_rfm22b_cfg *rfm22b_cfg,
                 uint8_t min_chan, uint8_t max_chan, uint32_t coord_id,
 		int status_inst);
+#endif /* PIOS_INCLUDE_RFM22B */
 
 #endif


### PR DESCRIPTION
Fix by @mluessi.

We couldn't compile a new target using the HAL because it was looking for modules we weren't compiling. This resolves that problem. 