### PR TITLE
gcs: no longer re-invert motor test output

### DIFF
--- a/ground/gcs/src/plugins/config/outputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/outputchannelform.cpp
@@ -330,9 +330,6 @@ void OutputChannelForm::sendChannelTest(int value)
     if (!ob)
         return;
 
-    if (ui.actuatorMin->value() > ui.actuatorMax->value())
-            value = ui.actuatorMin->value() - value + ui.actuatorMax->value();	// the channel is reversed
-
     if (ui.actuatorLink->checkState() && parent())
     {	// the channel is linked to other channels
         QList<OutputChannelForm*> outputChannelForms = parent()->findChildren<OutputChannelForm*>();


### PR DESCRIPTION
Was resulting in incorrect actuator commands in test with reversed
servos.

Issue #1936.  Bench-tested, but would be nice to have someone confirm I'm sane.