### PR TITLE
Logging UI: Enable status messages

### DIFF
--- a/ground/gcs/src/plugins/logging/flightlogdownload.cpp
+++ b/ground/gcs/src/plugins/logging/flightlogdownload.cpp
@@ -113,6 +113,8 @@ void FlightLogDownload::updateReceived()
         loggingStats->updated();
         ui->sectorLabel->setText(QString::number(logging.FileSectorNum));
         qDebug() << "Requesting sector num: " << logging.FileSectorNum;
+
+        ui->lb_operationStatus->setText("Downloading...");
         break;
     case LoggingStats::OPERATION_COMPLETE:
     {
@@ -127,6 +129,7 @@ void FlightLogDownload::updateReceived()
         logFile->write(log);
         logFile->close();
 
+        ui->lb_operationStatus->setText("Download complete.");
         break;
     }
     case LoggingStats::OPERATION_ERROR:
@@ -136,6 +139,7 @@ void FlightLogDownload::updateReceived()
         UAVObject::SetFlightTelemetryUpdateMode(mdata, UAVObject::UPDATEMODE_MANUAL);
         loggingStats->setMetadata(mdata);
 
+        ui->lb_operationStatus->setText("Download error.");
         break;
     default:
         qDebug() << "Unhandled";

--- a/ground/gcs/src/plugins/logging/flightlogdownload.ui
+++ b/ground/gcs/src/plugins/logging/flightlogdownload.ui
@@ -88,6 +88,24 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Operation status: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lb_operationStatus">
+       <property name="text">
+        <string>Idle</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Previously, there was no UI indication that the logging was completed. This adds simple functionality to display the logging download state in the logging dialog box. It helps differentiate between a stalled vs. a completed download.

