### PR TITLE
misc_math: correct vector clipping function.

### DIFF
--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -189,11 +189,11 @@ float vector3_distances(const float *actual,
 void vector2_clip(float *vels, float limit)
 {
 	float mag = vectorn_magnitude(vels, 2);    // only horiz component
-	float scale = mag / limit;
 
-	if (scale > 1) {
-		vels[0] /= scale;
-		vels[1] /= scale;
+	if (mag > limit && mag != 0) {
+		float scale = limit / mag;
+		vels[0] *= scale;
+		vels[1] *= scale;
 	}
 }
 

--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -192,8 +192,8 @@ void vector2_clip(float *vels, float limit)
 	float scale = mag / limit;
 
 	if (scale > 1) {
-		vels[0] /= mag;
-		vels[1] /= mag;
+		vels[0] /= scale;
+		vels[1] /= scale;
 	}
 }
 

--- a/flight/tests/misc_math/unittest.cpp
+++ b/flight/tests/misc_math/unittest.cpp
@@ -259,7 +259,8 @@ TEST_F(Vector2Clip, TestScale) {
     float test_vec_null[2] = {0, 0};
     float test_vec_within[2] = {limit/2, limit/2};
     float test_vec_edge_numerically_stable[2] = {limit, 0};
-    float test_vec_edge_numerically_unstable[2] = {sqrt(2)/2*limit, sqrt(2)/2*limit};
+    float test_vec_edge_numerically_unstable[2] =
+        {(float) (sqrt(2)/2*limit), (float) (sqrt(2)/2*limit)};
     float test_vec_outside[2] = {limit, limit};
 
     // Test for 0 vector


### PR DESCRIPTION
When we exceed the limit, clip to the limit instead of 1.