### PR TITLE
AltitudeHold: Scale altitude hold by 10, and control in dm/s

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -1072,8 +1072,14 @@ static void altitude_hold_desired(ManualControlCommandData * cmd, bool flightMod
 		altitudeHoldDesired.Altitude = -current_down;
 		altitudeHoldDesired.ClimbRate = 0;
 	} else {
-		uint8_t altitude_hold_expo, altitude_hold_maxrate, altitude_hold_deadband;
-		AltitudeHoldSettingsMaxRateGet(&altitude_hold_maxrate);
+		uint8_t altitude_hold_expo;
+		uint8_t altitude_hold_maxrate10;
+		uint8_t altitude_hold_deadband;
+		AltitudeHoldSettingsMaxRateGet(&altitude_hold_maxrate10);
+
+		// Scale altitude hold rate
+		float altitude_hold_maxrate = altitude_hold_maxrate10 * 0.1f;
+
 		AltitudeHoldSettingsExpoGet(&altitude_hold_expo);
 		AltitudeHoldSettingsDeadbandGet(&altitude_hold_deadband);
 

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -1073,12 +1073,12 @@ static void altitude_hold_desired(ManualControlCommandData * cmd, bool flightMod
 		altitudeHoldDesired.ClimbRate = 0;
 	} else {
 		uint8_t altitude_hold_expo;
-		uint8_t altitude_hold_maxrate10;
+		uint8_t altitude_hold_maxclimbrate10;
 		uint8_t altitude_hold_deadband;
-		AltitudeHoldSettingsMaxRateGet(&altitude_hold_maxrate10);
+		AltitudeHoldSettingsMaxClimbRateGet(&altitude_hold_maxclimbrate10);
 
 		// Scale altitude hold rate
-		float altitude_hold_maxrate = altitude_hold_maxrate10 * 0.1f;
+		float altitude_hold_maxclimbrate = altitude_hold_maxclimbrate10 * 0.1f;
 
 		AltitudeHoldSettingsExpoGet(&altitude_hold_expo);
 		AltitudeHoldSettingsDeadbandGet(&altitude_hold_deadband);
@@ -1089,10 +1089,10 @@ static void altitude_hold_desired(ManualControlCommandData * cmd, bool flightMod
 		float climb_rate = 0.0f;
 		if (cmd->Throttle > DEADBAND_HIGH) {
 			climb_rate = expo3((cmd->Throttle - DEADBAND_HIGH) / (1.0f - DEADBAND_HIGH), altitude_hold_expo) *
-		                         altitude_hold_maxrate;
-		} else if (cmd->Throttle < DEADBAND_LOW && altitude_hold_maxrate > MIN_CLIMB_RATE) {
+		                         altitude_hold_maxclimbrate;
+		} else if (cmd->Throttle < DEADBAND_LOW && altitude_hold_maxclimbrate > MIN_CLIMB_RATE) {
 			climb_rate = ((cmd->Throttle < 0) ? DEADBAND_LOW : DEADBAND_LOW - cmd->Throttle) / DEADBAND_LOW;
-			climb_rate = -expo3(climb_rate, altitude_hold_expo) * altitude_hold_maxrate;
+			climb_rate = -expo3(climb_rate, altitude_hold_expo) * altitude_hold_maxclimbrate;
 		}
 
 		// When throttle is negative tell the module that we are in landing mode

--- a/shared/uavobjectdefinition/altitudeholdsettings.xml
+++ b/shared/uavobjectdefinition/altitudeholdsettings.xml
@@ -5,7 +5,7 @@
         <field name="VelocityKp" units="throttle/m" type="float" elements="1" defaultvalue="0.3"/>
         <field name="VelocityKi" units="throttle/m/s" type="float" elements="1" defaultvalue="0.3"/>
         <field name="AttitudeComp" units="%" type="uint16" elements="1" defaultvalue="100"/>
-        <field name="MaxRate" units="dm/s" type="uint8" elements="1" defaultvalue="40"/>
+        <field name="MaxClimbRate" units="dm/s" type="uint8" elements="1" defaultvalue="40"/>
         <field name="Expo" units="" type="uint8" elements="1" defaultvalue="40"/>
         <field name="Deadband" units="%" type="uint8" elements="1" defaultvalue="30"/>
         <access gcs="readwrite" flight="readwrite"/>

--- a/shared/uavobjectdefinition/altitudeholdsettings.xml
+++ b/shared/uavobjectdefinition/altitudeholdsettings.xml
@@ -5,7 +5,7 @@
         <field name="VelocityKp" units="throttle/m" type="float" elements="1" defaultvalue="0.3"/>
         <field name="VelocityKi" units="throttle/m/s" type="float" elements="1" defaultvalue="0.3"/>
         <field name="AttitudeComp" units="%" type="uint16" elements="1" defaultvalue="100"/>
-        <field name="MaxRate" units="m/s" type="uint8" elements="1" defaultvalue="4"/>
+        <field name="MaxRate" units="dm/s" type="uint8" elements="1" defaultvalue="40"/>
         <field name="Expo" units="" type="uint8" elements="1" defaultvalue="40"/>
         <field name="Deadband" units="%" type="uint8" elements="1" defaultvalue="30"/>
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
This provides more granularity to autonomous altitude change rates. There didn't seem to be much reason to have a rate resolution of [m] when our altitude precision is on the order of [cm].