### PR TITLE
Uavobrowser search

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/browseritemdelegate.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/browseritemdelegate.cpp
@@ -25,19 +25,22 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include "uavobjectbrowserwidget.h"
 #include "browseritemdelegate.h"
 #include "fieldtreeitem.h"
 
-BrowserItemDelegate::BrowserItemDelegate(QObject *parent) :
+BrowserItemDelegate::BrowserItemDelegate(TreeSortFilterProxyModel *proxyModel, QObject *parent) :
         QStyledItemDelegate(parent)
 {
+    this->proxyModel=proxyModel;
 }
 
 QWidget *BrowserItemDelegate::createEditor(QWidget *parent,
                                            const QStyleOptionViewItem & option ,
-                                           const QModelIndex & index ) const
+                                           const QModelIndex & proxyIndex ) const
 {
     Q_UNUSED(option)
+    QModelIndex index = proxyModel->mapToSource(proxyIndex);
     FieldTreeItem *item = static_cast<FieldTreeItem*>(index.internalPointer());
     QWidget *editor = item->createEditor(parent);
     Q_ASSERT(editor);
@@ -68,19 +71,22 @@ bool BrowserItemDelegate::eventFilter(QObject *object, QEvent *event)
 }
 
 void BrowserItemDelegate::setEditorData(QWidget *editor,
-                                        const QModelIndex &index) const
+                                        const QModelIndex &proxyIndex) const
 {
+    QModelIndex index = proxyModel->mapToSource(proxyIndex);
     FieldTreeItem *item = static_cast<FieldTreeItem*>(index.internalPointer());
-    QVariant value = index.model()->data(index, Qt::EditRole);
+    QVariant value = proxyIndex.model()->data(proxyIndex, Qt::EditRole);
     item->setEditorValue(editor, value);
 }
 
 void BrowserItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
-                                       const QModelIndex &index) const
+                                       const QModelIndex &proxyIndex) const
 {
+    QModelIndex index = proxyModel->mapToSource(proxyIndex);
     FieldTreeItem *item = static_cast<FieldTreeItem*>(index.internalPointer());
     QVariant value = item->getEditorValue(editor);
-    model->setData(index, value, Qt::EditRole);
+    bool ret = model->setData(proxyIndex, value, Qt::EditRole);
+    Q_ASSERT(ret);
 }
 
 void BrowserItemDelegate::updateEditorGeometry(QWidget *editor,

--- a/ground/gcs/src/plugins/uavobjectbrowser/browseritemdelegate.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/browseritemdelegate.h
@@ -31,11 +31,13 @@
 #include <QStyledItemDelegate>
 #include <QEvent>
 
+class TreeSortFilterProxyModel;
+
 class BrowserItemDelegate : public QStyledItemDelegate
 {
 Q_OBJECT
 public:
-    explicit BrowserItemDelegate(QObject *parent = 0);
+    explicit BrowserItemDelegate(TreeSortFilterProxyModel *proxyModel, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
                           const QModelIndex &index) const;
@@ -57,6 +59,8 @@ signals:
 
 public slots:
 
+private:
+    TreeSortFilterProxyModel *proxyModel;
 };
 
 #endif // BROWSERITEMDELEGATE_H

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowser.ui
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowser.ui
@@ -217,6 +217,29 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Filter:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="le_searchField"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
     </layout>
    </item>
   </layout>

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowser.ui
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowser.ui
@@ -228,6 +228,13 @@
       <widget class="QLineEdit" name="le_searchField"/>
      </item>
      <item>
+      <widget class="QPushButton" name="bn_clearSearchField">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -589,6 +589,29 @@ void UAVObjectBrowserWidget::searchTextCleared()
     m_browser->le_searchField->clear();
 }
 
+void UAVObjectBrowserWidget::keyPressEvent(QKeyEvent *e)
+{
+    switch(e->key())
+    {
+    case Qt::Key_Escape:
+        searchTextCleared();
+    default:
+        QWidget::keyPressEvent(e);
+    }
+}
+
+void UAVObjectBrowserWidget::keyReleaseEvent(QKeyEvent *e)
+{
+    switch(e->key())
+    {
+    case Qt::Key_Escape:
+        searchTextCleared();
+    default:
+        QWidget::keyReleaseEvent(e);
+    }
+}
+
+
 //============================
 
 /**

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -78,6 +78,7 @@ UAVObjectBrowserWidget::UAVObjectBrowserWidget(QWidget *parent) : QWidget(parent
     connect((QTreeView*) treeView, SIGNAL(expanded(QModelIndex)), this, SLOT(onTreeItemExpanded(QModelIndex) ));
 
     connect(m_browser->le_searchField, SIGNAL(textChanged(QString)), this, SLOT(searchTextChanged(QString)));
+    connect(m_browser->bn_clearSearchField, SIGNAL(clicked()), this, SLOT(searchTextCleared()));
 
     // Set browser buttons to disabled
     enableUAVOBrowserButtons(false);
@@ -571,6 +572,11 @@ void UAVObjectBrowserWidget::enableUAVOBrowserButtons(bool enableState)
 void UAVObjectBrowserWidget::searchTextChanged(QString searchText)
 {
     proxyModel->setFilterRegExp(QRegExp(searchText, Qt::CaseInsensitive, QRegExp::FixedString));
+}
+
+void UAVObjectBrowserWidget::searchTextCleared()
+{
+    m_browser->le_searchField->clear();
 }
 
 //============================

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -316,7 +316,7 @@ void UAVObjectBrowserWidget::refreshHiddenObjects()
  */
 void UAVObjectBrowserWidget::showMetaData(bool show)
 {
-    refreshViewOtpions();
+    refreshViewOptions();
     QList<QModelIndex> metaIndexes = m_model->getMetaDataIndexes();
     foreach(QModelIndex modelIndex, metaIndexes)
     {
@@ -329,7 +329,7 @@ void UAVObjectBrowserWidget::showMetaData(bool show)
 /**
  * @brief fires the viewOptionsChanged SIGNAL with the current values.
  */
-void UAVObjectBrowserWidget::refreshViewOtpions()
+void UAVObjectBrowserWidget::refreshViewOptions()
 {
     emit viewOptionsChanged(m_viewoptions->cbCategorized->isChecked(),m_viewoptions->cbScientific->isChecked(),m_viewoptions->cbMetaData->isChecked(),m_viewoptions->cbHideNotPresent->isChecked());
 }
@@ -341,7 +341,7 @@ void UAVObjectBrowserWidget::refreshViewOtpions()
 void UAVObjectBrowserWidget::showNotPresent(bool show)
 {
     Q_UNUSED(show);
-    refreshViewOtpions();
+    refreshViewOptions();
     refreshHiddenObjects();
 }
 

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -62,7 +62,7 @@ UAVObjectBrowserWidget::UAVObjectBrowserWidget(QWidget *parent) : QWidget(parent
     proxyModel->setSourceModel(m_model);
 
     // Create tree view and add to layout
-    treeView = new UAVOBrowserTreeView(m_model, MAXIMUM_UPDATE_PERIOD);
+    treeView = new UAVOBrowserTreeView(MAXIMUM_UPDATE_PERIOD);
     treeView->setObjectName(QString::fromUtf8("treeView"));
     m_browser->verticalLayout->addWidget(treeView);
 
@@ -88,6 +88,7 @@ void UAVObjectBrowserWidget::onTreeItemExpanded(QModelIndex currentProxyIndex)
 {
     QModelIndex currentIndex = proxyModel->mapToSource(currentProxyIndex);
     TreeItem *item = static_cast<TreeItem*>(currentIndex.internalPointer());
+    Q_ASSERT(item);
     TopTreeItem *top = dynamic_cast<TopTreeItem*>(item->parent());
 
     //Check if current tree index is the child of the top tree item
@@ -148,6 +149,7 @@ void UAVObjectBrowserWidget::onTreeItemCollapsed(QModelIndex currentProxyIndex)
 {
     QModelIndex currentIndex = proxyModel->mapToSource(currentProxyIndex);
     TreeItem *item = static_cast<TreeItem*>(currentIndex.internalPointer());
+    Q_ASSERT(item);
     TopTreeItem *top = dynamic_cast<TopTreeItem*>(item->parent());
 
     //Check if current tree index is the child of the top tree item
@@ -276,7 +278,7 @@ void UAVObjectBrowserWidget::initialize()
     treeView->setSelectionBehavior(QAbstractItemView::SelectItems);
     treeView->setUniformRowHeights(true);
 
-    BrowserItemDelegate *m_delegate = new BrowserItemDelegate();
+    BrowserItemDelegate *m_delegate = new BrowserItemDelegate(proxyModel);
     treeView->setItemDelegate(m_delegate);
 
     // Connect signals
@@ -502,6 +504,7 @@ void UAVObjectBrowserWidget::toggleUAVOButtons(const QModelIndex &currentProxyIn
 
     QModelIndex currentIndex = proxyModel->mapToSource(currentProxyIndex);
     TreeItem *item = static_cast<TreeItem*>(currentIndex.internalPointer());
+    Q_ASSERT(item);
     TopTreeItem *top = dynamic_cast<TopTreeItem*>(item);
     ObjectTreeItem *data = dynamic_cast<ObjectTreeItem*>(item);
     CategoryTreeItem *category = dynamic_cast<CategoryTreeItem*>(item);
@@ -584,8 +587,7 @@ void UAVObjectBrowserWidget::searchTextCleared()
 /**
  * @brief UAVOBrowserTreeView::UAVOBrowserTreeView Constructor for reimplementation of QTreeView
  */
-UAVOBrowserTreeView::UAVOBrowserTreeView(UAVObjectTreeModel *m_model_new, unsigned int updateTimerPeriod) : QTreeView(),
-    m_model(m_model_new),
+UAVOBrowserTreeView::UAVOBrowserTreeView(unsigned int updateTimerPeriod) : QTreeView(),
     m_updateTreeViewFlag(false)
 {
     // Start timer at 100ms
@@ -620,8 +622,8 @@ void UAVOBrowserTreeView::updateTimerPeriod(unsigned int val)
 void UAVOBrowserTreeView::onTimeout_updateView()
 {
     if (m_updateTreeViewFlag == true) {
-        QModelIndex topLeftData = m_model->getIndex(0, 0, m_model->getNonSettingsTree());
-        QModelIndex bottomRightData = m_model->getIndex(1, 1, m_model->getNonSettingsTree());
+        QModelIndex topLeftData = dynamic_cast<UAVObjectTreeModel *>(model())->getIndex(0, 0, dynamic_cast<UAVObjectTreeModel *>(model())->getNonSettingsTree());
+        QModelIndex bottomRightData = dynamic_cast<UAVObjectTreeModel *>(model())->getIndex(1, 1, dynamic_cast<UAVObjectTreeModel *>(model())->getNonSettingsTree());
 
         QTreeView::dataChanged(topLeftData, bottomRightData);
     }

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -32,6 +32,7 @@
 #include <QModelIndex>
 #include <QWidget>
 #include <QTreeView>
+#include <QSortFilterProxyModel>
 #include "objectpersistence.h"
 #include "uavobjecttreemodel.h"
 
@@ -39,6 +40,17 @@ class QPushButton;
 class ObjectTreeItem;
 class Ui_UAVObjectBrowser;
 class Ui_viewoptions;
+
+class TreeSortFilterProxyModel : public QSortFilterProxyModel
+{
+public:
+    TreeSortFilterProxyModel(QObject *parent);
+
+protected:
+    bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
+    bool filterAcceptsRowItself(int source_row, const QModelIndex &source_parent) const;
+    bool hasAcceptedChildren(int source_row, const QModelIndex &source_parent) const;
+};
 
 class UAVOBrowserTreeView : public QTreeView
 {
@@ -103,6 +115,8 @@ private slots:
     void onTreeItemCollapsed(QModelIndex);
     void onTreeItemExpanded(QModelIndex);
 
+    void searchTextChanged(QString searchText);
+
 signals:
     void viewOptionsChanged(bool categorized,bool scientific,bool metadata,bool hideNotPresent);
 private:
@@ -112,6 +126,7 @@ private:
     Ui_viewoptions *m_viewoptions;
     QDialog *m_viewoptionsDialog;
     UAVObjectTreeModel *m_model;
+    TreeSortFilterProxyModel *proxyModel;
 
     int m_recentlyUpdatedTimeout;
     QColor m_recentlyUpdatedColor;

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -57,8 +57,10 @@ class UAVOBrowserTreeView : public QTreeView
     Q_OBJECT
 public:
     UAVOBrowserTreeView(unsigned int updateTimerPeriod);
-    void updateView(QModelIndex topLeft, QModelIndex bottomRight);
+    void updateView(const QModelIndex &topLeft, const QModelIndex &bottomRight);
     void updateTimerPeriod(unsigned int val);
+
+    virtual void setModel(QAbstractItemModel *model){QTreeView::setModel(model); proxyModel = static_cast<TreeSortFilterProxyModel *>(model);}
 
     /**
      * @brief dataChanged Reimplements QTreeView::dataChanged signal
@@ -74,6 +76,7 @@ private slots:
 
 private:
     bool m_updateTreeViewFlag;
+    TreeSortFilterProxyModel *proxyModel;
 
     QTimer m_updateViewTimer;
 

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -141,7 +141,7 @@ private:
     QMap<QString, unsigned int> expandedUavoItems;
 
     unsigned int updatePeriod;
-    void refreshViewOtpions();
+    void refreshViewOptions();
 };
 
 #endif /* UAVOBJECTBROWSERWIDGET_H_ */

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -116,6 +116,7 @@ private slots:
     void onTreeItemExpanded(QModelIndex);
 
     void searchTextChanged(QString searchText);
+    void searchTextCleared();
 
 signals:
     void viewOptionsChanged(bool categorized,bool scientific,bool metadata,bool hideNotPresent);

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -56,7 +56,7 @@ class UAVOBrowserTreeView : public QTreeView
 {
     Q_OBJECT
 public:
-    UAVOBrowserTreeView(UAVObjectTreeModel *m_model, unsigned int updateTimerPeriod);
+    UAVOBrowserTreeView(unsigned int updateTimerPeriod);
     void updateView(QModelIndex topLeft, QModelIndex bottomRight);
     void updateTimerPeriod(unsigned int val);
 
@@ -69,14 +69,10 @@ public:
     virtual void dataChanged(const QModelIndex & topLeft, const QModelIndex & bottomRight,
                              const QVector<int> & roles = QVector<int> ());
 
-    void setModel(QAbstractItemModel *model) {m_model = dynamic_cast<UAVObjectTreeModel*>(model); QTreeView::setModel(model);}
-
 private slots:
     void onTimeout_updateView();
 
 private:
-    UAVObjectTreeModel *m_model;
-
     bool m_updateTreeViewFlag;
 
     QTimer m_updateViewTimer;

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.h
@@ -31,6 +31,7 @@
 
 #include <QModelIndex>
 #include <QWidget>
+#include <QKeyEvent>
 #include <QTreeView>
 #include <QSortFilterProxyModel>
 #include "objectpersistence.h"
@@ -138,6 +139,8 @@ private:
     void enableUAVOBrowserButtons(bool enableState);
     ObjectTreeItem *findCurrentObjectTreeItem();
     void updateThrottlePeriod(UAVObject *);
+    void keyPressEvent(QKeyEvent *e);
+    void keyReleaseEvent(QKeyEvent *e);
 
     UAVOBrowserTreeView *treeView;
 


### PR DESCRIPTION
This is a cool feature I was asked to develop. It provides a search field for the UAVO browser.

Works very intuitively, all text matching the string is found. This includes partial strings, even ones which are embedded in the middle of a larger string. So it doesn't just search UAVO names, but looks at the children fields as well.

<ESC> button works as expected, i.e. clearing the text. 

Ideally, it would be nicer if the CLEAR button were replaced by a small 'X', like in search fields in cell phones, but that's a nice improvement for another day.

<img width="672" alt="screen shot 2015-09-22 at 10 42 58 am" src="https://cloud.githubusercontent.com/assets/1118185/10026459/c5571ab0-6116-11e5-8ca6-cdbd1b4fe735.png">
<img width="673" alt="screen shot 2015-09-22 at 10 43 15 am" src="https://cloud.githubusercontent.com/assets/1118185/10026460/c56dbce8-6116-11e5-8391-092bd40547cc.png">

In use for more than a year, no bugs found or anomalies to report.