### PR TITLE
Actuator: Curve fit motor channels

### DIFF
--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -8,6 +8,10 @@
         <field name="ChannelMin" units="us" type="uint16" elements="10" defaultvalue="1000"/>
         <field name="ChannelType" units="" type="enum" elements="10" options="PWM,PWM Alarm,Arming LED,Info LED" defaultvalue="PWM"/>
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
+
+        <!-- Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type a*x^b-->
+        <field name="MotorInputOutputCurveFit" units="-" type="float" elementnames="A,B" defaultvalue="1,1"/>
+
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>
         <telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
This provides a power curve fitting for the motor channels. All motors are assumed to be identical. This is a poor assumption, but it works in most common scenarios.

* The fitting maps the linear [-1,1] range to a nonlinear [-1,1].
* It uses an equation of the type y = a*x^b.

Been flying with this for about 5 months, it makes a pretty significant difference, especially when using ESCs in closed loop mode where the setpoint is the RPM.