### PR TITLE
AttitudeHold: Change default deadband

### DIFF
--- a/shared/uavobjectdefinition/altitudeholdsettings.xml
+++ b/shared/uavobjectdefinition/altitudeholdsettings.xml
@@ -7,7 +7,8 @@
         <field name="AttitudeComp" units="%" type="uint16" elements="1" defaultvalue="100"/>
         <field name="MaxClimbRate" units="dm/s" type="uint8" elements="1" defaultvalue="40"/>
         <field name="Expo" units="" type="uint8" elements="1" defaultvalue="40"/>
-        <field name="Deadband" units="%" type="uint8" elements="1" defaultvalue="30"/>
+        <field name="Deadband" units="%" type="uint8" elements="1" defaultvalue="15"/>
+
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>
         <telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
The deadband was very wide at 30%. This reduces that by half. It seems a more sensible default.

Flying with this for the better part of a year. Works fine with Taranis. I think the deadband is still wide enough that even with lower-quality transmitters it should be good.