### PR TITLE
AltitudeHold: Add support for a separate maximum descent rate

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -1074,11 +1074,14 @@ static void altitude_hold_desired(ManualControlCommandData * cmd, bool flightMod
 	} else {
 		uint8_t altitude_hold_expo;
 		uint8_t altitude_hold_maxclimbrate10;
+		uint8_t altitude_hold_maxdescentrate10;
 		uint8_t altitude_hold_deadband;
 		AltitudeHoldSettingsMaxClimbRateGet(&altitude_hold_maxclimbrate10);
+		AltitudeHoldSettingsMaxDescentRateGet(&altitude_hold_maxdescentrate10);
 
 		// Scale altitude hold rate
 		float altitude_hold_maxclimbrate = altitude_hold_maxclimbrate10 * 0.1f;
+		float altitude_hold_maxdescentrate = altitude_hold_maxdescentrate10 * 0.1f;
 
 		AltitudeHoldSettingsExpoGet(&altitude_hold_expo);
 		AltitudeHoldSettingsDeadbandGet(&altitude_hold_deadband);
@@ -1090,9 +1093,9 @@ static void altitude_hold_desired(ManualControlCommandData * cmd, bool flightMod
 		if (cmd->Throttle > DEADBAND_HIGH) {
 			climb_rate = expo3((cmd->Throttle - DEADBAND_HIGH) / (1.0f - DEADBAND_HIGH), altitude_hold_expo) *
 		                         altitude_hold_maxclimbrate;
-		} else if (cmd->Throttle < DEADBAND_LOW && altitude_hold_maxclimbrate > MIN_CLIMB_RATE) {
+		} else if (cmd->Throttle < DEADBAND_LOW && altitude_hold_maxdescentrate > MIN_CLIMB_RATE) {
 			climb_rate = ((cmd->Throttle < 0) ? DEADBAND_LOW : DEADBAND_LOW - cmd->Throttle) / DEADBAND_LOW;
-			climb_rate = -expo3(climb_rate, altitude_hold_expo) * altitude_hold_maxclimbrate;
+			climb_rate = -expo3(climb_rate, altitude_hold_expo) * altitude_hold_maxdescentrate;
 		}
 
 		// When throttle is negative tell the module that we are in landing mode

--- a/shared/uavobjectdefinition/altitudeholdsettings.xml
+++ b/shared/uavobjectdefinition/altitudeholdsettings.xml
@@ -6,6 +6,7 @@
         <field name="VelocityKi" units="throttle/m/s" type="float" elements="1" defaultvalue="0.3"/>
         <field name="AttitudeComp" units="%" type="uint16" elements="1" defaultvalue="100"/>
         <field name="MaxClimbRate" units="dm/s" type="uint8" elements="1" defaultvalue="40"/>
+        <field name="MaxDescentRate" units="dm/s" type="uint8" elements="1" defaultvalue="15"/>
         <field name="Expo" units="" type="uint8" elements="1" defaultvalue="40"/>
         <field name="Deadband" units="%" type="uint8" elements="1" defaultvalue="30"/>
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
Previously, maximum climb and descent rates were saved in the same setting. This leads to problems where the maximum climb rate can safely be far higher than the maximum descent rate. This PR simply separates the two and sets a reasonably safe rate for maximum descent.

Tested and confirmed to work.