### PR TITLE
Alarms: Determine which stack overflowed

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -80,6 +80,7 @@ static uint32_t idleCounterClear;
 static struct pios_thread *systemTaskHandle;
 static struct pios_queue *objectPersistenceQueue;
 static bool stackOverflow;
+static uint8_t stackOverflowedName[SYSTEMALARMS_STACKOVERFLOWCODE_NUMELEM];
 
 // Private functions
 static void objectUpdatedCb(UAVObjEvent * ev);
@@ -537,6 +538,7 @@ static void updateSystemAlarms()
 	// Check for stack overflow
 	if (stackOverflow) {
 		AlarmsSet(SYSTEMALARMS_ALARM_STACKOVERFLOW, SYSTEMALARMS_ALARM_CRITICAL);
+		SystemAlarmsStackOverflowCodeSet(stackOverflowedName);
 	} else {
 		AlarmsClear(SYSTEMALARMS_ALARM_STACKOVERFLOW);
 	}
@@ -609,6 +611,9 @@ void vApplicationIdleHook(void)
 void vApplicationStackOverflowHook(uintptr_t pxTask, signed char * pcTaskName)
 {
 	stackOverflow = true;
+	for (int i=0; i< SYSTEMALARMS_STACKOVERFLOWCODE_NUMELEM; i++) {
+		stackOverflowedName[i] = pcTaskName[i];
+	}
 #if DEBUG_STACK_OVERFLOW
 	static volatile bool wait_here = true;
 	while(wait_here);

--- a/shared/uavobjectdefinition/systemalarms.xml
+++ b/shared/uavobjectdefinition/systemalarms.xml
@@ -68,6 +68,9 @@
 			</options>
 		</field>
 
+		<field name="StackOverflowCode" units="" type="uint8" elements="8"/>
+
+
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
The board will raise an error when a module's stack overflows. This writes the module's name to UAVO so the faulty modules can be easily diagnosed.

It has been amazingly useful to me, even though I know there are other ways to determine which stack overflowed. It's just so much easier to read the module name than to have to guess which module at 0 bytes in the TaskInfo UAVO is the problem child.

However, due to the increased UAVO packet size, I think there's a reasonable argument not to merge this.

Comments?