### PR TITLE
python: open telemetry in binary format

### DIFF
--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -506,7 +506,7 @@ def get_telemetry_by_args(desc="Process telemetry", service_in_iter=True,
     import os.path
 
     if os.path.isfile(args.source):
-        file_obj = file(args.source, 'r')
+        file_obj = file(args.source, 'rb')
 
         t = telemetry.FileTelemetry(file_obj, parse_header=parse_header,
             gcs_timestamps=args.timestamped, name=args.source)


### PR DESCRIPTION
Fixes issues on windows where telemetry is truncated or empty.