### PR TITLE
Python API improvements

### DIFF
--- a/python/taulabs/telemetry.py
+++ b/python/taulabs/telemetry.py
@@ -327,6 +327,7 @@ class FDTelemetry(TelemetryBase):
         if r:
             # Shouldn't throw an exception-- they just told us
             # it was ready for read.
+            # TODO: Figure out why read sometimes fails when using sockets
             try:
                 chunk = os.read(self.fd, 1024)
                 if chunk == '':

--- a/python/taulabs/uavo_collection.py
+++ b/python/taulabs/uavo_collection.py
@@ -8,6 +8,7 @@ Licensed under the GNU LGPL version 2.1 or any later version (see COPYING.LESSER
 import uavo
 
 import operator
+import os.path as op
 
 class UAVOCollection(dict):
     def __init__(self):
@@ -33,11 +34,13 @@ class UAVOCollection(dict):
         import subprocess
         import tarfile
         from cStringIO import StringIO
+        # Get the directory where the Tau Labs code is located
+        tl_dir = op.join(op.dirname(__file__), "..", "..")
         #
         # Grab the exact uavo definition files from the git repo using the header's git hash
         #
         p = subprocess.Popen(['git', 'archive', githash, '--', 'shared/uavobjectdefinition/'],
-                             stdout=subprocess.PIPE)
+                             stdout=subprocess.PIPE, cwd=tl_dir)
         # grab the tar file data
         git_archive_data, git_archive_errors = p.communicate()
 
@@ -47,11 +50,19 @@ class UAVOCollection(dict):
         # feed the tar file data to a tarfile object
         t = tarfile.open(fileobj=fobj)
 
-        # Build up the uavo definitions for all of the available UAVO at this git hash
+        # Get the file members
+        f_members = []
         for f_info in t.getmembers():
             if not f_info.isfile():
                 continue
+            # Make sure the shared definitions are parsed first
+            if op.basename(f_info.name).lower().find('shared') > 0:
+                f_members.insert(0, f_info)
+            else:
+                f_members.append(f_info)
 
+        # Build up the UAV objects from the xml definitions
+        for f_info in f_members:
             f = t.extractfile(f_info)
 
             u = uavo.make_class(f)
@@ -63,7 +74,15 @@ class UAVOCollection(dict):
         import os
         import glob
 
+        # Make sure the shared definitions are parsed first
+        file_names = []
         for file_name in glob.glob(os.path.join(path, '*.xml')):
+            if op.basename(file_name).lower().find('shared') > 0:
+                file_names.insert(0, file_name)
+            else:
+                file_names.append(file_name)
+
+        for file_name in file_names:
             with open(file_name, 'rU') as f:
                 u = uavo.make_class(f)
 


### PR DESCRIPTION
Several improvements to the Python API:
- It is now possible to directly instantiate UAVOs in Python with the correct default values from the xml file. E.g.: `sparky = uavo.UAVO_HwSparky2()`
- ENUMs are included in the Python UAVOs (including correct parsing of shared definitions) and are e.g. used to produce more informative representations of the objects . E.g.:

```
    print sparky
    UAVO_HwSparky2(name=UAVO_HwSparky2, time=0, uavo_id=609948424, CoordID=0,
    RcvrPort=Disabled(0), MainPort=Disabled(0), FlexiPort=Disabled(0), USB_HIDPort=USBTelemetry(0), 
    USB_VCPPort=Disabled(4), DSMxMode=Autodetect(0), Radio=Disabled(0), MaxRfSpeed=64000(3), 
    MaxRfPower=125(1), MinChannel=0, MaxChannel=250, GyroRange=2000(3),  AccelRange=8G(2),
    MPU9250Rate=500(3), MPU9250GyroLPF=184(0), MPU9250AccelLPF=184(1), VTX_Ch=1(0),
    Magnetometer=Internal(0), ExtMagOrientation=Top0degCW(0))
```
- Python scripts using the githash to get the UAVO definitions can now be run from any directory (previously, one had to be in the TL root directory)
- Fixed a bug that sometimes caused the TCP telemetry to fail due to a "Resource temporarily unavailable" error (not sure why this error occurred, it shouldn't be possible due to the use of `select`).
