### PR TITLE
Convert Sparky1 to PIOS HAL

### DIFF
--- a/flight/targets/sparky/board-info/board_hw_defs.c
+++ b/flight/targets/sparky/board-info/board_hw_defs.c
@@ -565,6 +565,7 @@ static const struct pios_usart_cfg pios_main_dsm_hsum_cfg = {
 #endif	/* PIOS_INCLUDE_DSM || PIOS_INCLUDE_HSUM */
 
 #if defined(PIOS_INCLUDE_SBUS)
+
 /*
  * S.Bus USART
  */
@@ -683,6 +684,7 @@ static const struct pios_usart_cfg pios_main_sbus_cfg = {
 static const struct pios_sbus_cfg pios_main_sbus_aux_cfg = {
 	/* No inverter configuration, f3 uart subsystem already does this for us */
 };
+
 #endif	/* PIOS_INCLUDE_SBUS */
 
 #ifdef PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY

--- a/flight/targets/sparky/fw/Makefile
+++ b/flight/targets/sparky/fw/Makefile
@@ -149,7 +149,7 @@ SRC += $(PIOSCOMMON)/pios_semaphore.c
 SRC += $(PIOSCOMMON)/pios_mutex.c
 SRC += $(PIOSCOMMON)/pios_thread.c
 SRC += $(PIOSCOMMON)/pios_queue.c
-
+SRC += $(PIOSCOMMON)/pios_hal.c
 
 # List C++ source files here.
 # use file-extension .cpp for C++-files (not .C)

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -38,6 +38,7 @@
 #include "board_hw_defs.c"
 
 #include <pios.h>
+#include <pios_hal.h>
 #include <openpilot.h>
 #include <uavobjectsinit.h>
 #include "hwsparky.h"
@@ -167,37 +168,8 @@ static const struct pios_hmc5883_cfg pios_hmc5883_external_cfg = {
 };
 #endif /* PIOS_INCLUDE_HMC5883 */
 
-/* One slot per selectable receiver group.
- *  eg. PWM, PPM, GCS, SPEKTRUM1, SPEKTRUM2, SBUS
- * NOTE: No slot in this map for NONE.
- */
-uintptr_t pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE];
-
-#define PIOS_COM_TELEM_RF_RX_BUF_LEN 512
-#define PIOS_COM_TELEM_RF_TX_BUF_LEN 512
-
-#define PIOS_COM_GPS_RX_BUF_LEN 32
-#define PIOS_COM_GPS_TX_BUF_LEN 16
-
-#define PIOS_COM_TELEM_USB_RX_BUF_LEN 65
-#define PIOS_COM_TELEM_USB_TX_BUF_LEN 65
-
 #define PIOS_COM_CAN_RX_BUF_LEN 256
 #define PIOS_COM_CAN_TX_BUF_LEN 256
-
-#define PIOS_COM_BRIDGE_RX_BUF_LEN 65
-#define PIOS_COM_BRIDGE_TX_BUF_LEN 12
-
-#define PIOS_COM_MAVLINK_TX_BUF_LEN 32
-#define PIOS_COM_LIGHTTELEMETRY_TX_BUF_LEN 19 
-
-#define PIOS_COM_HOTT_RX_BUF_LEN 16
-#define PIOS_COM_HOTT_TX_BUF_LEN 16
-
-#define PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN 128
-
-#define PIOS_COM_FRSKYSPORT_TX_BUF_LEN 16
-#define PIOS_COM_FRSKYSPORT_RX_BUF_LEN 16
 
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
 #define PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN 40
@@ -205,108 +177,12 @@ uintptr_t pios_com_debug_id;
 #endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
 
 uintptr_t pios_com_aux_id;
-uintptr_t pios_com_gps_id;
-uintptr_t pios_com_telem_usb_id;
 uintptr_t pios_com_telem_rf_id;
-uintptr_t pios_com_vcp_id;
-uintptr_t pios_com_bridge_id;
-uintptr_t pios_com_mavlink_id;
-uintptr_t pios_com_hott_id;
-uintptr_t pios_com_frsky_sensor_hub_id;
-uintptr_t pios_com_lighttelemetry_id; 
 uintptr_t pios_com_can_id;
-uintptr_t pios_com_frsky_sport_id;
-
 uintptr_t pios_uavo_settings_fs_id;
 uintptr_t pios_waypoints_settings_fs_id;
-
 uintptr_t pios_internal_adc_id;
-
 uintptr_t pios_can_id;
-
-/*
- * Setup a com port based on the passed cfg, driver and buffer sizes. tx size of -1 make the port rx only
- */
-#if defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-static void PIOS_Board_configure_com (const struct pios_usart_cfg *usart_port_cfg, size_t rx_buf_len, size_t tx_buf_len,
-		const struct pios_com_driver *com_driver, uintptr_t *pios_com_id)
-{
-	uintptr_t pios_usart_id;
-	if (PIOS_USART_Init(&pios_usart_id, usart_port_cfg)) {
-		PIOS_Assert(0);
-	}
-
-	uint8_t * rx_buffer;
-	if (rx_buf_len > 0) {
-		rx_buffer = (uint8_t *) PIOS_malloc(rx_buf_len);
-		PIOS_Assert(rx_buffer);
-	} else {
-		rx_buffer = NULL;
-	}
-
-	uint8_t * tx_buffer;
-	if (tx_buf_len > 0) {
-		tx_buffer = (uint8_t *) PIOS_malloc(tx_buf_len);
-		PIOS_Assert(tx_buffer);
-	} else {
-		tx_buffer = NULL;
-	}
-
-	if (PIOS_COM_Init(pios_com_id, com_driver, pios_usart_id,
-				rx_buffer, rx_buf_len,
-				tx_buffer, tx_buf_len)) {
-		PIOS_Assert(0);
-	}
-}
-#endif	/* PIOS_INCLUDE_USART && PIOS_INCLUDE_COM */
-
-#ifdef PIOS_INCLUDE_DSM
-static void PIOS_Board_configure_dsm(const struct pios_usart_cfg *pios_usart_dsm_cfg, const struct pios_dsm_cfg *pios_dsm_cfg,
-		const struct pios_com_driver *pios_usart_com_driver,
-		ManualControlSettingsChannelGroupsOptions channelgroup,HwSparkyDSMxModeOptions *mode)
-{
-	uintptr_t pios_usart_dsm_id;
-	if (PIOS_USART_Init(&pios_usart_dsm_id, pios_usart_dsm_cfg)) {
-		PIOS_Assert(0);
-	}
-
-	uintptr_t pios_dsm_id;
-	if (PIOS_DSM_Init(&pios_dsm_id, pios_dsm_cfg, pios_usart_com_driver,
-			pios_usart_dsm_id, *mode)) {
-		PIOS_Assert(0);
-	}
-
-	uintptr_t pios_dsm_rcvr_id;
-	if (PIOS_RCVR_Init(&pios_dsm_rcvr_id, &pios_dsm_rcvr_driver, pios_dsm_id)) {
-		PIOS_Assert(0);
-	}
-	pios_rcvr_group_map[channelgroup] = pios_dsm_rcvr_id;
-}
-#endif
-
-#ifdef PIOS_INCLUDE_HSUM
-static void PIOS_Board_configure_hsum(const struct pios_usart_cfg *pios_usart_hsum_cfg,
-		const struct pios_com_driver *pios_usart_com_driver,enum pios_hsum_proto *proto,
-		ManualControlSettingsChannelGroupsOptions channelgroup)
-{
-	uintptr_t pios_usart_hsum_id;
-	if (PIOS_USART_Init(&pios_usart_hsum_id, pios_usart_hsum_cfg)) {
-		PIOS_Assert(0);
-	}
-	
-	uintptr_t pios_hsum_id;
-	if (PIOS_HSUM_Init(&pios_hsum_id, pios_usart_com_driver,
-			  pios_usart_hsum_id, *proto)) {
-		PIOS_Assert(0);
-	}
-	
-	uintptr_t pios_hsum_rcvr_id;
-	if (PIOS_RCVR_Init(&pios_hsum_rcvr_id, &pios_hsum_rcvr_driver, pios_hsum_id)) {
-		PIOS_Assert(0);
-	}
-	pios_rcvr_group_map[channelgroup] = pios_hsum_rcvr_id;
-}
-#endif
 
 /**
  * Indicate a target-specific error code when a component fails to initialize
@@ -319,22 +195,7 @@ static void PIOS_Board_configure_hsum(const struct pios_usart_cfg *pios_usart_hs
  * 11 pulses - external HMC5883 failed
  */
 void panic(int32_t code) {
-	while(1){
-		for (int32_t i = 0; i < code; i++) {
-			PIOS_WDG_Clear();
-			PIOS_LED_Toggle(PIOS_LED_ALARM);
-			PIOS_DELAY_WaitmS(200);
-			PIOS_WDG_Clear();
-			PIOS_LED_Toggle(PIOS_LED_ALARM);
-			PIOS_DELAY_WaitmS(200);
-		}
-		PIOS_WDG_Clear();
-		PIOS_DELAY_WaitmS(200);
-		PIOS_WDG_Clear();
-		PIOS_DELAY_WaitmS(200);
-		PIOS_WDG_Clear();
-		PIOS_DELAY_WaitmS(100);
-	}
+		PIOS_HAL_Panic(PIOS_LED_ALARM, code);
 }
 
 /**
@@ -489,68 +350,7 @@ void PIOS_Board_Init(void) {
 		hw_usb_vcpport = HWSPARKY_USB_VCPPORT_DISABLED;
 	}
 
-	switch (hw_usb_vcpport) {
-	case HWSPARKY_USB_VCPPORT_DISABLED:
-		break;
-	case HWSPARKY_USB_VCPPORT_USBTELEMETRY:
-#if defined(PIOS_INCLUDE_COM)
-		{
-			uintptr_t pios_usb_cdc_id;
-			if (PIOS_USB_CDC_Init(&pios_usb_cdc_id, &pios_usb_cdc_cfg, pios_usb_id)) {
-				PIOS_Assert(0);
-			}
-			uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_TELEM_USB_RX_BUF_LEN);
-			uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_TELEM_USB_TX_BUF_LEN);
-			PIOS_Assert(rx_buffer);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_telem_usb_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						rx_buffer, PIOS_COM_TELEM_USB_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_TELEM_USB_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-		}
-#endif	/* PIOS_INCLUDE_COM */
-		break;
-	case HWSPARKY_USB_VCPPORT_COMBRIDGE:
-#if defined(PIOS_INCLUDE_COM)
-		{
-			uintptr_t pios_usb_cdc_id;
-			if (PIOS_USB_CDC_Init(&pios_usb_cdc_id, &pios_usb_cdc_cfg, pios_usb_id)) {
-				PIOS_Assert(0);
-			}
-			uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_BRIDGE_RX_BUF_LEN);
-			uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_BRIDGE_TX_BUF_LEN);
-			PIOS_Assert(rx_buffer);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_vcp_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						rx_buffer, PIOS_COM_BRIDGE_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_BRIDGE_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-		}
-#endif	/* PIOS_INCLUDE_COM */
-		break;
-	case HWSPARKY_USB_VCPPORT_DEBUGCONSOLE:
-#if defined(PIOS_INCLUDE_COM)
-#if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
-		{
-			uintptr_t pios_usb_cdc_id;
-			if (PIOS_USB_CDC_Init(&pios_usb_cdc_id, &pios_usb_cdc_cfg, pios_usb_id)) {
-				PIOS_Assert(0);
-			}
-			uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_debug_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						NULL, 0,
-						tx_buffer, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-		}
-#endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
-#endif	/* PIOS_INCLUDE_COM */
-
-		break;
-	}
+	PIOS_HAL_ConfigureCDC(hw_usb_vcpport, pios_usb_id, &pios_usb_cdc_cfg);
 #endif	/* PIOS_INCLUDE_USB_CDC */
 
 #if defined(PIOS_INCLUDE_USB_HID)
@@ -563,29 +363,7 @@ void PIOS_Board_Init(void) {
 		hw_usb_hidport = HWSPARKY_USB_HIDPORT_DISABLED;
 	}
 
-	switch (hw_usb_hidport) {
-	case HWSPARKY_USB_HIDPORT_DISABLED:
-		break;
-	case HWSPARKY_USB_HIDPORT_USBTELEMETRY:
-#if defined(PIOS_INCLUDE_COM)
-		{
-			uintptr_t pios_usb_hid_id;
-			if (PIOS_USB_HID_Init(&pios_usb_hid_id, &pios_usb_hid_cfg, pios_usb_id)) {
-				PIOS_Assert(0);
-			}
-			uint8_t * rx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_USB_RX_BUF_LEN);
-			uint8_t * tx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_USB_TX_BUF_LEN);
-			PIOS_Assert(rx_buffer);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_telem_usb_id, &pios_usb_hid_com_driver, pios_usb_hid_id,
-						rx_buffer, PIOS_COM_TELEM_USB_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_TELEM_USB_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-		}
-#endif	/* PIOS_INCLUDE_COM */
-		break;
-	}
+	PIOS_HAL_ConfigureHID(hw_usb_hidport, pios_usb_id, &pios_usb_hid_cfg);
 
 #endif	/* PIOS_INCLUDE_USB_HID */
 #endif	/* PIOS_INCLUDE_USB */
@@ -594,263 +372,39 @@ void PIOS_Board_Init(void) {
 	HwSparkyDSMxModeOptions hw_DSMxMode;
 	HwSparkyDSMxModeGet(&hw_DSMxMode);
 
-	/* UART1 Port */
-	uint8_t hw_flexi;
-	HwSparkyFlexiPortGet(&hw_flexi);
-	switch (hw_flexi) {
-	case HWSPARKY_FLEXIPORT_DISABLED:
-		break;
-	case HWSPARKY_FLEXIPORT_TELEMETRY:
-#if defined(PIOS_INCLUDE_TELEMETRY_RF) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_telem_rf_id);
-#endif /* PIOS_INCLUDE_TELEMETRY_RF */
-		break;
-	case HWSPARKY_FLEXIPORT_GPS:
-#if defined(PIOS_INCLUDE_GPS) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_GPS_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_gps_id);
-#endif
-		break;
-       case HWSPARKY_FLEXIPORT_I2C:
-#if defined(PIOS_INCLUDE_I2C)
-			if (PIOS_I2C_Init(&pios_i2c_flexi_id, &pios_i2c_flexi_cfg)) {
-				PIOS_Assert(0);
-			}
+	/* Configure main USART port */
+	uint8_t hw_mainport;
+	HwSparkyMainPortGet(&hw_mainport);
+	PIOS_HAL_ConfigurePort(hw_mainport, &pios_main_usart_cfg,
+												 &pios_usart_com_driver, NULL, NULL, NULL,
+												 PIOS_LED_ALARM,
+												 &pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg,
+												 hw_DSMxMode, NULL, NULL, false);
 
-			if (PIOS_I2C_CheckClear(pios_i2c_flexi_id) != 0)
-				panic(11);
-#endif /* PIOS_INCLUDE_I2C */
-               break;
-	case HWSPARKY_FLEXIPORT_SBUS:
-#if defined(PIOS_INCLUDE_SBUS) && defined(PIOS_INCLUDE_USART)
-		{
-			uintptr_t pios_usart_sbus_id;
-			if (PIOS_USART_Init(&pios_usart_sbus_id, &pios_flexi_sbus_cfg)) {
-				PIOS_Assert(0);
-			}
-			uintptr_t pios_sbus_id;
-			if (PIOS_SBus_Init(&pios_sbus_id, &pios_flexi_sbus_aux_cfg, &pios_usart_com_driver, pios_usart_sbus_id)) {
-				PIOS_Assert(0);
-			}
-			uintptr_t pios_sbus_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_sbus_rcvr_id, &pios_sbus_rcvr_driver, pios_sbus_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_SBUS] = pios_sbus_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_SBUS */
-		break;
-	case HWSPARKY_FLEXIPORT_DSM:
-#if defined(PIOS_INCLUDE_DSM)
-		{
-			PIOS_Board_configure_dsm(&pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
-		}
-#endif	/* PIOS_INCLUDE_DSM */
-		break;
-	case HWSPARKY_FLEXIPORT_DEBUGCONSOLE:
-#if defined(PIOS_INCLUDE_DEBUG_CONSOLE) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, 0, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_aux_id);
-#endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
-		break;
-	case HWSPARKY_FLEXIPORT_COMBRIDGE:
-#if defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, PIOS_COM_BRIDGE_RX_BUF_LEN, PIOS_COM_BRIDGE_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_bridge_id);
-#endif
-		break;
-	case HWSPARKY_FLEXIPORT_MAVLINKTX:
-#if defined(PIOS_INCLUDE_MAVLINK)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, 0, PIOS_COM_MAVLINK_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_mavlink_id);
-#endif  /* PIOS_INCLUDE_MAVLINK */
-		break;
-	case HWSPARKY_FLEXIPORT_MAVLINKTX_GPS_RX:
-#if defined(PIOS_INCLUDE_GPS)
-#if defined(PIOS_INCLUDE_MAVLINK)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_MAVLINK_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_gps_id);
-		pios_com_mavlink_id = pios_com_gps_id;
-#endif  /* PIOS_INCLUDE_MAVLINK */
-#endif  /* PIOS_INCLUDE_GPS */
-		break;
-	case HWSPARKY_FLEXIPORT_HOTTTELEMETRY:
-#if defined(PIOS_INCLUDE_HOTT) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_cfg, PIOS_COM_HOTT_RX_BUF_LEN, PIOS_COM_HOTT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_hott_id);
-#endif /* PIOS_INCLUDE_HOTT */
-		break;
-	case HWSPARKY_FLEXIPORT_FRSKYSENSORHUB:
-#if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_flexi_usart_sport_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sensor_hub_id);
-#endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
-		break;
-	case HWSPARKY_FLEXIPORT_LIGHTTELEMETRYTX:
-#if defined(PIOS_INCLUDE_LIGHTTELEMETRY)
-	PIOS_Board_configure_com(&pios_flexi_usart_cfg, 0, PIOS_COM_LIGHTTELEMETRY_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_lighttelemetry_id);
-#endif
-		break;
-	case HWSPARKY_FLEXIPORT_FRSKYSPORTTELEMETRY:
-#if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY)
-		PIOS_Board_configure_com(&pios_flexi_usart_sport_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
-#endif /* PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY */
-		break;
-	}
-
-	/* UART3 Port */
-	uint8_t hw_main;
-	HwSparkyMainPortGet(&hw_main);
-	switch (hw_main) {
-	case HWSPARKY_MAINPORT_DISABLED:
-		break;
-	case HWSPARKY_MAINPORT_TELEMETRY:
-#if defined(PIOS_INCLUDE_TELEMETRY_RF) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_telem_rf_id);
-#endif /* PIOS_INCLUDE_TELEMETRY_RF */
-		break;
-	case HWSPARKY_MAINPORT_GPS:
-#if defined(PIOS_INCLUDE_GPS) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_GPS_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_gps_id);
-#endif
-		break;
-	case HWSPARKY_MAINPORT_SBUS:
-#if defined(PIOS_INCLUDE_SBUS) && defined(PIOS_INCLUDE_USART)
-		{
-			uintptr_t pios_usart_sbus_id;
-			if (PIOS_USART_Init(&pios_usart_sbus_id, &pios_main_sbus_cfg)) {
-				PIOS_Assert(0);
-			}
-			uintptr_t pios_sbus_id;
-			if (PIOS_SBus_Init(&pios_sbus_id, &pios_main_sbus_aux_cfg, &pios_usart_com_driver, pios_usart_sbus_id)) {
-				PIOS_Assert(0);
-			}
-			uintptr_t pios_sbus_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_sbus_rcvr_id, &pios_sbus_rcvr_driver, pios_sbus_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_SBUS] = pios_sbus_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_SBUS */
-		break;
-	case HWSPARKY_MAINPORT_DSM:
-#if defined(PIOS_INCLUDE_DSM)
-		{
-			PIOS_Board_configure_dsm(&pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
-		}
-#endif	/* PIOS_INCLUDE_DSM */
-		break;
-	case HWSPARKY_MAINPORT_DEBUGCONSOLE:
-#if defined(PIOS_INCLUDE_DEBUG_CONSOLE) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, 0, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_aux_id);
-#endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
-		break;
-	case HWSPARKY_MAINPORT_COMBRIDGE:
-#if defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, PIOS_COM_BRIDGE_RX_BUF_LEN, PIOS_COM_BRIDGE_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_bridge_id);
-#endif
-		break;
-	case HWSPARKY_MAINPORT_MAVLINKTX:
-#if defined(PIOS_INCLUDE_MAVLINK)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, 0, PIOS_COM_MAVLINK_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_mavlink_id);
-#endif  /* PIOS_INCLUDE_MAVLINK */
-		break;
-	case HWSPARKY_MAINPORT_MAVLINKTX_GPS_RX:
-#if defined(PIOS_INCLUDE_GPS)
-#if defined(PIOS_INCLUDE_MAVLINK)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_MAVLINK_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_gps_id);
-		pios_com_mavlink_id = pios_com_gps_id;
-#endif  /* PIOS_INCLUDE_MAVLINK */
-#endif  /* PIOS_INCLUDE_GPS */
-		break;
-	case HWSPARKY_MAINPORT_HOTTTELEMETRY:
-#if defined(PIOS_INCLUDE_HOTT) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_cfg, PIOS_COM_HOTT_RX_BUF_LEN, PIOS_COM_HOTT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_hott_id);
-#endif /* PIOS_INCLUDE_HOTT */
-		break;
-	case HWSPARKY_MAINPORT_FRSKYSENSORHUB:
-#if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
-		PIOS_Board_configure_com(&pios_main_usart_sport_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sensor_hub_id);
-#endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
-		break;
-	case HWSPARKY_MAINPORT_LIGHTTELEMETRYTX:
-#if defined(PIOS_INCLUDE_LIGHTTELEMETRY)
-	PIOS_Board_configure_com(&pios_main_usart_cfg, 0, PIOS_COM_LIGHTTELEMETRY_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_lighttelemetry_id);
-#endif /* PIOS_INCLUDE_LIGHTTELEMETRY */
-		break;
-	case HWSPARKY_MAINPORT_FRSKYSPORTTELEMETRY:
-#if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY)
-		PIOS_Board_configure_com(&pios_main_usart_sport_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
-#endif /* PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY */
-		break;
-	}
+	/* Configure FlexiPort */
+	uint8_t hw_flexiport;
+	HwSparkyFlexiPortGet(&hw_flexiport);
+	PIOS_HAL_ConfigurePort(hw_flexiport, &pios_flexi_usart_cfg,
+												 &pios_usart_com_driver,
+												 &pios_i2c_flexi_id,
+												 &pios_i2c_flexi_cfg, NULL,
+												 PIOS_LED_ALARM,
+												 &pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg,
+												 hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;
 	HwSparkyRcvrPortGet(&hw_rcvrport);
-
-	switch (hw_rcvrport) {
-	case HWSPARKY_RCVRPORT_DISABLED:
-		break;
-	case HWSPARKY_RCVRPORT_PPM:
-#if defined(PIOS_INCLUDE_PPM)
-		{
-			uintptr_t pios_ppm_id;
-			PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
-
-			uintptr_t pios_ppm_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PPM] = pios_ppm_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_PPM */
-		break;
-	case HWSPARKY_RCVRPORT_DSM:
-#if defined(PIOS_INCLUDE_DSM)
-		{
-			PIOS_Board_configure_dsm(&pios_rcvr_dsm_hsum_cfg, &pios_rcvr_dsm_aux_cfg, &pios_usart_com_driver,
-				MANUALCONTROLSETTINGS_CHANNELGROUPS_DSM, &hw_DSMxMode);
-		}
-#endif	/* PIOS_INCLUDE_DSM */
-		break;
-	case HWSPARKY_RCVRPORT_HOTTSUMD:
-	case HWSPARKY_RCVRPORT_HOTTSUMH:
-#if defined(PIOS_INCLUDE_HSUM)
-		{
-			enum pios_hsum_proto proto;
-			switch (hw_rcvrport) {
-			case HWSPARKY_RCVRPORT_HOTTSUMD:
-				proto = PIOS_HSUM_PROTO_SUMD;
-				break;
-			case HWSPARKY_RCVRPORT_HOTTSUMH:
-				proto = PIOS_HSUM_PROTO_SUMH;
-				break;
-			default:
-				PIOS_Assert(0);
-				break;
-			}
-			PIOS_Board_configure_hsum(&pios_rcvr_dsm_hsum_cfg, &pios_usart_com_driver,
-				&proto, MANUALCONTROLSETTINGS_CHANNELGROUPS_HOTTSUM);
-		}
-#endif	/* PIOS_INCLUDE_HSUM */
-		break;
-	case HWSPARKY_RCVRPORT_SBUS:
-#if defined(PIOS_INCLUDE_SBUS) && defined(PIOS_INCLUDE_USART)
-		{
-			uintptr_t pios_usart_sbus_id;
-			if (PIOS_USART_Init(&pios_usart_sbus_id, &pios_rcvr_sbus_cfg)) {
-				PIOS_Assert(0);
-			}
-			uintptr_t pios_sbus_id;
-			if (PIOS_SBus_Init(&pios_sbus_id, &pios_rcvr_sbus_aux_cfg, &pios_usart_com_driver, pios_usart_sbus_id)) {
-				PIOS_Assert(0);
-			}
-			uintptr_t pios_sbus_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_sbus_rcvr_id, &pios_sbus_rcvr_driver, pios_sbus_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_SBUS] = pios_sbus_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_SBUS */
-		break;		break;
-	}
-
+	PIOS_HAL_ConfigurePort(hw_rcvrport,
+												 NULL, /* XXX TODO: fix as part of DSM refactor */
+												 &pios_usart_com_driver,
+												 NULL, NULL,
+												 &pios_ppm_cfg, 
+												 PIOS_LED_ALARM,
+												 &pios_rcvr_dsm_hsum_cfg,
+												 &pios_rcvr_dsm_aux_cfg,
+												 hw_DSMxMode, &pios_rcvr_sbus_cfg,
+												 &pios_rcvr_sbus_aux_cfg, false);
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -9,28 +9,28 @@
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
  * @brief      The board specific initialization routines
  * @see        The GNU Public License (GPL) Version 3
- * 
+ *
  *****************************************************************************/
-/* 
- * This program is free software; you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
- * 
- * You should have received a copy of the GNU General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
 /* Pull in the board-specific static HW definitions.
  * Including .c files is a bit ugly but this allows all of
  * the HW definitions to be const and static to limit their
- * scope.  
+ * scope.
  *
  * NOTE: THIS IS THE ONLY PLACE THAT SHOULD EVER INCLUDE THIS FILE
  */
@@ -159,12 +159,12 @@ static struct pios_mpu60x0_cfg pios_mpu9150_cfg = {
 #if defined(PIOS_INCLUDE_HMC5883)
 #include "pios_hmc5883_priv.h"
 static const struct pios_hmc5883_cfg pios_hmc5883_external_cfg = {
-       .exti_cfg            = NULL,
-       .M_ODR               = PIOS_HMC5883_ODR_75,
-       .Meas_Conf           = PIOS_HMC5883_MEASCONF_NORMAL,
-       .Gain                = PIOS_HMC5883_GAIN_1_9,
-       .Mode                = PIOS_HMC5883_MODE_SINGLE,
-       .Default_Orientation = PIOS_HMC5883_TOP_0DEG,
+	.exti_cfg            = NULL,
+	.M_ODR               = PIOS_HMC5883_ODR_75,
+	.Meas_Conf           = PIOS_HMC5883_MEASCONF_NORMAL,
+	.Gain                = PIOS_HMC5883_GAIN_1_9,
+	.Mode                = PIOS_HMC5883_MODE_SINGLE,
+	.Default_Orientation = PIOS_HMC5883_TOP_0DEG,
 };
 #endif /* PIOS_INCLUDE_HMC5883 */
 
@@ -194,8 +194,9 @@ uintptr_t pios_can_id;
  * 6 pulses - CAN
  * 11 pulses - external HMC5883 failed
  */
-void panic(int32_t code) {
-		PIOS_HAL_Panic(PIOS_LED_ALARM, code);
+void panic(int32_t code)
+{
+	PIOS_HAL_Panic(PIOS_LED_ALARM, code);
 }
 
 /**
@@ -206,15 +207,16 @@ void panic(int32_t code) {
 
 #include <pios_board_info.h>
 
-void PIOS_Board_Init(void) {
+void PIOS_Board_Init(void)
+{
 
 	/* Delay system */
 	PIOS_DELAY_Init();
 
-	const struct pios_board_info * bdinfo = &pios_board_info_blob;
+	const struct pios_board_info *bdinfo = &pios_board_info_blob;
 
 #if defined(PIOS_INCLUDE_LED)
-	const struct pios_led_cfg * led_cfg = PIOS_BOARD_HW_DEFS_GetLedCfg(bdinfo->board_rev);
+	const struct pios_led_cfg *led_cfg = PIOS_BOARD_HW_DEFS_GetLedCfg(bdinfo->board_rev);
 	PIOS_Assert(led_cfg);
 	PIOS_LED_Init(led_cfg);
 #endif	/* PIOS_INCLUDE_LED */
@@ -231,8 +233,8 @@ void PIOS_Board_Init(void) {
 	if (PIOS_CAN_Init(&pios_can_id, &pios_can_cfg) != 0)
 		panic(6);
 
-	uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_CAN_RX_BUF_LEN);
-	uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_CAN_TX_BUF_LEN);
+	uint8_t *rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_CAN_RX_BUF_LEN);
+	uint8_t *tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_CAN_TX_BUF_LEN);
 	PIOS_Assert(rx_buffer);
 	PIOS_Assert(tx_buffer);
 	if (PIOS_COM_Init(&pios_com_can_id, &pios_can_com_driver, pios_can_id,
@@ -249,7 +251,7 @@ void PIOS_Board_Init(void) {
 		panic(5);
 
 	/* Register the partition table */
-	const struct pios_flash_partition * flash_partition_table;
+	const struct pios_flash_partition *flash_partition_table;
 	uint32_t num_partitions;
 	flash_partition_table = PIOS_BOARD_HW_DEFS_GetPartitionTable(bdinfo->board_rev, &num_partitions);
 	PIOS_FLASH_register_partition_table(flash_partition_table, num_partitions);
@@ -311,7 +313,7 @@ void PIOS_Board_Init(void) {
 	} else {
 		/* Too many failed boot attempts, force hw config to defaults */
 		HwSparkySetDefaults(HwSparkyHandle(), 0);
-		ModuleSettingsSetDefaults(ModuleSettingsHandle(),0);
+		ModuleSettingsSetDefaults(ModuleSettingsHandle(), 0);
 		AlarmsSet(SYSTEMALARMS_ALARM_BOOTFAULT, SYSTEMALARMS_ALARM_CRITICAL);
 	}
 
@@ -376,35 +378,35 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_mainport;
 	HwSparkyMainPortGet(&hw_mainport);
 	PIOS_HAL_ConfigurePort(hw_mainport, &pios_main_usart_cfg,
-												 &pios_usart_com_driver, NULL, NULL, NULL,
-												 PIOS_LED_ALARM,
-												 &pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg,
-												 hw_DSMxMode, NULL, NULL, false);
+	                       &pios_usart_com_driver, NULL, NULL, NULL,
+	                       PIOS_LED_ALARM,
+	                       &pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg,
+	                       hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
 	HwSparkyFlexiPortGet(&hw_flexiport);
 	PIOS_HAL_ConfigurePort(hw_flexiport, &pios_flexi_usart_cfg,
-												 &pios_usart_com_driver,
-												 &pios_i2c_flexi_id,
-												 &pios_i2c_flexi_cfg, NULL,
-												 PIOS_LED_ALARM,
-												 &pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg,
-												 hw_DSMxMode, NULL, NULL, false);
+	                       &pios_usart_com_driver,
+	                       &pios_i2c_flexi_id,
+	                       &pios_i2c_flexi_cfg, NULL,
+	                       PIOS_LED_ALARM,
+	                       &pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg,
+	                       hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;
 	HwSparkyRcvrPortGet(&hw_rcvrport);
 	PIOS_HAL_ConfigurePort(hw_rcvrport,
-												 NULL, /* XXX TODO: fix as part of DSM refactor */
-												 &pios_usart_com_driver,
-												 NULL, NULL,
-												 &pios_ppm_cfg, 
-												 PIOS_LED_ALARM,
-												 &pios_rcvr_dsm_hsum_cfg,
-												 &pios_rcvr_dsm_aux_cfg,
-												 hw_DSMxMode, &pios_rcvr_sbus_cfg,
-												 &pios_rcvr_sbus_aux_cfg, false);
+	                       NULL, /* XXX TODO: fix as part of DSM refactor */
+	                       &pios_usart_com_driver,
+	                       NULL, NULL,
+	                       &pios_ppm_cfg,
+	                       PIOS_LED_ALARM,
+	                       &pios_rcvr_dsm_hsum_cfg,
+	                       &pios_rcvr_dsm_aux_cfg,
+	                       hw_DSMxMode, &pios_rcvr_sbus_cfg,
+	                       &pios_rcvr_sbus_aux_cfg, false);
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();
@@ -462,10 +464,10 @@ void PIOS_Board_Init(void) {
 #endif
 
 #if defined(PIOS_INCLUDE_ADC)
-	if(number_of_adc_ports > 0) {
+	if (number_of_adc_ports > 0) {
 		internal_adc_cfg.number_of_used_pins = number_of_adc_ports;
 		uint32_t internal_adc_id;
-		if(PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg) < 0)
+		if (PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg) < 0)
 			PIOS_Assert(0);
 		PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
 	}
@@ -517,64 +519,64 @@ void PIOS_Board_Init(void) {
 		// To be safe map from UAVO enum to driver enum
 		uint8_t hw_gyro_range;
 		HwSparkyGyroRangeGet(&hw_gyro_range);
-		switch(hw_gyro_range) {
-			case HWSPARKY_GYRORANGE_250:
-				PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_250_DEG);
-				break;
-			case HWSPARKY_GYRORANGE_500:
-				PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_500_DEG);
-				break;
-			case HWSPARKY_GYRORANGE_1000:
-				PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_1000_DEG);
-				break;
-			case HWSPARKY_GYRORANGE_2000:
-				PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_2000_DEG);
-				break;
+		switch (hw_gyro_range) {
+		case HWSPARKY_GYRORANGE_250:
+			PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_250_DEG);
+			break;
+		case HWSPARKY_GYRORANGE_500:
+			PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_500_DEG);
+			break;
+		case HWSPARKY_GYRORANGE_1000:
+			PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_1000_DEG);
+			break;
+		case HWSPARKY_GYRORANGE_2000:
+			PIOS_MPU9150_SetGyroRange(PIOS_MPU60X0_SCALE_2000_DEG);
+			break;
 		}
 
 		uint8_t hw_accel_range;
 		HwSparkyAccelRangeGet(&hw_accel_range);
-		switch(hw_accel_range) {
-			case HWSPARKY_ACCELRANGE_2G:
-				PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_2G);
-				break;
-			case HWSPARKY_ACCELRANGE_4G:
-				PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_4G);
-				break;
-			case HWSPARKY_ACCELRANGE_8G:
-				PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_8G);
-				break;
-			case HWSPARKY_ACCELRANGE_16G:
-				PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_16G);
-				break;
+		switch (hw_accel_range) {
+		case HWSPARKY_ACCELRANGE_2G:
+			PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_2G);
+			break;
+		case HWSPARKY_ACCELRANGE_4G:
+			PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_4G);
+			break;
+		case HWSPARKY_ACCELRANGE_8G:
+			PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_8G);
+			break;
+		case HWSPARKY_ACCELRANGE_16G:
+			PIOS_MPU9150_SetAccelRange(PIOS_MPU60X0_ACCEL_16G);
+			break;
 		}
 
 		uint8_t hw_mpu9150_dlpf;
 		HwSparkyMPU9150DLPFGet(&hw_mpu9150_dlpf);
 		enum pios_mpu60x0_filter mpu9150_dlpf = \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
-		    (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
-		    pios_mpu9150_cfg.default_filter;
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
+		                                        (hw_mpu9150_dlpf == HWSPARKY_MPU9150DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
+		                                        pios_mpu9150_cfg.default_filter;
 		PIOS_MPU9150_SetLPF(mpu9150_dlpf);
 
 		uint8_t hw_mpu9150_samplerate;
 		HwSparkyMPU9150RateGet(&hw_mpu9150_samplerate);
 		uint16_t mpu9150_samplerate = \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_200) ? 200 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_333) ? 333 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_500) ? 500 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_666) ? 666 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_1000) ? 1000 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_2000) ? 2000 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_4000) ? 4000 : \
-		    (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_8000) ? 8000 : \
-		    pios_mpu9150_cfg.default_samplerate;
-		PIOS_MPU9150_SetSampleRate(mpu9150_samplerate);	
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_200) ? 200 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_333) ? 333 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_500) ? 500 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_666) ? 666 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_1000) ? 1000 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_2000) ? 2000 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_4000) ? 4000 : \
+		                              (hw_mpu9150_samplerate == HWSPARKY_MPU9150RATE_8000) ? 8000 : \
+		                              pios_mpu9150_cfg.default_samplerate;
+		PIOS_MPU9150_SetSampleRate(mpu9150_samplerate);
 	}
 
 #endif /* PIOS_INCLUDE_MPU9150 */
@@ -594,36 +596,36 @@ void PIOS_Board_Init(void) {
 		// To be safe map from UAVO enum to driver enum
 		uint8_t hw_gyro_range;
 		HwSparkyGyroRangeGet(&hw_gyro_range);
-		switch(hw_gyro_range) {
-			case HWSPARKY_GYRORANGE_250:
-				PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_250_DEG);
-				break;
-			case HWSPARKY_GYRORANGE_500:
-				PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_500_DEG);
-				break;
-			case HWSPARKY_GYRORANGE_1000:
-				PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_1000_DEG);
-				break;
-			case HWSPARKY_GYRORANGE_2000:
-				PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_2000_DEG);
-				break;
+		switch (hw_gyro_range) {
+		case HWSPARKY_GYRORANGE_250:
+			PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_250_DEG);
+			break;
+		case HWSPARKY_GYRORANGE_500:
+			PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_500_DEG);
+			break;
+		case HWSPARKY_GYRORANGE_1000:
+			PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_1000_DEG);
+			break;
+		case HWSPARKY_GYRORANGE_2000:
+			PIOS_MPU6050_SetGyroRange(PIOS_MPU60X0_SCALE_2000_DEG);
+			break;
 		}
 
 		uint8_t hw_accel_range;
 		HwSparkyAccelRangeGet(&hw_accel_range);
-		switch(hw_accel_range) {
-			case HWSPARKY_ACCELRANGE_2G:
-				PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_2G);
-				break;
-			case HWSPARKY_ACCELRANGE_4G:
-				PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_4G);
-				break;
-			case HWSPARKY_ACCELRANGE_8G:
-				PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_8G);
-				break;
-			case HWSPARKY_ACCELRANGE_16G:
-				PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_16G);
-				break;
+		switch (hw_accel_range) {
+		case HWSPARKY_ACCELRANGE_2G:
+			PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_2G);
+			break;
+		case HWSPARKY_ACCELRANGE_4G:
+			PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_4G);
+			break;
+		case HWSPARKY_ACCELRANGE_8G:
+			PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_8G);
+			break;
+		case HWSPARKY_ACCELRANGE_16G:
+			PIOS_MPU6050_SetAccelRange(PIOS_MPU60X0_ACCEL_16G);
+			break;
 		}
 	}
 
@@ -637,8 +639,7 @@ void PIOS_Board_Init(void) {
 		uint8_t Magnetometer;
 		HwSparkyMagnetometerGet(&Magnetometer);
 
-		if (Magnetometer == HWSPARKY_MAGNETOMETER_EXTERNALI2CFLEXIPORT)
-		{
+		if (Magnetometer == HWSPARKY_MAGNETOMETER_EXTERNALI2CFLEXIPORT) {
 			// setup sensor orientation
 			uint8_t ExtMagOrientation;
 			HwSparkyExtMagOrientationGet(&ExtMagOrientation);
@@ -657,15 +658,15 @@ void PIOS_Board_Init(void) {
 			}
 
 			enum pios_hmc5883_orientation hmc5883_orientation = \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5883_TOP_0DEG      : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5883_TOP_90DEG     : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5883_TOP_180DEG    : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5883_TOP_270DEG    : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5883_BOTTOM_0DEG   : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_90DEG  : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5883_BOTTOM_180DEG : \
-				(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_270DEG : \
-				pios_hmc5883_external_cfg.Default_Orientation;
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5883_TOP_0DEG      : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5883_TOP_90DEG     : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5883_TOP_180DEG    : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5883_TOP_270DEG    : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5883_BOTTOM_0DEG   : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_90DEG  : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5883_BOTTOM_180DEG : \
+			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_270DEG : \
+			        pios_hmc5883_external_cfg.Default_Orientation;
 			PIOS_HMC5883_SetOrientation(hmc5883_orientation);
 		}
 	}


### PR DESCRIPTION
* I originally opened this against the limbo fork d-Ronin (https://github.com/d-ronin/dronin/pull/19) as a precursor to my practice evaluation with the MOTOLAB
  closed hardware target (tornado f3 / motofc) but figured I might as
  well try my luck here :ocean:
* Converts the sparky1 target board-info / pios_board  to pios_hal per sparky2
  and others..