### PR TITLE
Naze: Configure gyro sample-rate and filter cutoff

### DIFF
--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -528,6 +528,34 @@ void PIOS_Board_Init(void) {
 			break;
 	}
 
+	// the filter has to be set before rate else divisor calculation will fail
+	uint8_t hw_mpu_dlpf;
+	HwNazeMPU6000DLPFGet(&hw_mpu_dlpf);
+	enum pios_mpu60x0_filter mpu_dlpf = \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
+			    pios_mpu6050_cfg.default_filter;
+	PIOS_MPU6050_SetLPF(mpu_dlpf);
+
+	uint8_t hw_mpu_samplerate;
+	HwNazeMPU6000RateGet(&hw_mpu_samplerate);
+	uint16_t mpu_samplerate = \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_200) ? 200 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_333) ? 333 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_500) ? 500 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_666) ? 666 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_1000) ? 1000 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_2000) ? 2000 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_4000) ? 4000 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_8000) ? 8000 : \
+			    pios_mpu6050_cfg.default_samplerate;
+	PIOS_MPU6050_SetSampleRate(mpu_samplerate);
+
 #endif /* PIOS_INCLUDE_MPU6050 */
 
 	//I2C is slow, sensor init as well, reset watchdog to prevent reset here

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -530,29 +530,24 @@ void PIOS_Board_Init(void) {
 
 	// the filter has to be set before rate else divisor calculation will fail
 	uint8_t hw_mpu_dlpf;
-	HwNazeMPU6000DLPFGet(&hw_mpu_dlpf);
+	HwNazeMPU6050DLPFGet(&hw_mpu_dlpf);
 	enum pios_mpu60x0_filter mpu_dlpf = \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
-			    (hw_mpu_dlpf == HWNAZE_MPU6000DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
+			    (hw_mpu_dlpf == HWNAZE_MPU6050DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
 			    pios_mpu6050_cfg.default_filter;
 	PIOS_MPU6050_SetLPF(mpu_dlpf);
 
 	uint8_t hw_mpu_samplerate;
-	HwNazeMPU6000RateGet(&hw_mpu_samplerate);
+	HwNazeMPU6050RateGet(&hw_mpu_samplerate);
 	uint16_t mpu_samplerate = \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_200) ? 200 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_333) ? 333 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_500) ? 500 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_666) ? 666 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_1000) ? 1000 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_2000) ? 2000 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_4000) ? 4000 : \
-			    (hw_mpu_samplerate == HWNAZE_MPU6000RATE_8000) ? 8000 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6050RATE_200) ? 200 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6050RATE_333) ? 333 : \
+			    (hw_mpu_samplerate == HWNAZE_MPU6050RATE_500) ? 500 : \
 			    pios_mpu6050_cfg.default_samplerate;
 	PIOS_MPU6050_SetSampleRate(mpu_samplerate);
 

--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -9,8 +9,8 @@
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="500"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
-		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,333,500,666,1000,2000,4000,8000" defaultvalue="500"/>
-		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="256"/>
+		<field name="MPU6050Rate" units="" type="enum" elements="1" options="200,333,500" defaultvalue="500"/>
+		<field name="MPU6050DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="256"/>
 
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Looks like this was missed out when we originally merged the target. It can run okay up to (and including) 666 Hz sample-rate (with 99% CPU usage reported) but after that it fails to operate correctly. Thoughts on removing the (unusable) higher rate options?