### PR TITLE
actuator: cut down stack 200 bytes on F1

### DIFF
--- a/flight/targets/coptercontrol/fw/pios_config.h
+++ b/flight/targets/coptercontrol/fw/pios_config.h
@@ -103,7 +103,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_ACTUATOR_STACK_SIZE        800
+#define PIOS_ACTUATOR_STACK_SIZE        600
 #define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624

--- a/flight/targets/naze32/fw/pios_config.h
+++ b/flight/targets/naze32/fw/pios_config.h
@@ -96,7 +96,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_ACTUATOR_STACK_SIZE        800
+#define PIOS_ACTUATOR_STACK_SIZE        600
 #define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624


### PR DESCRIPTION
The actuator refactor freed up a bunch of stack use but used some more
heap.  -fstack-usage confirms 200 less stack used with that refactor.

Necessary for autotune to work again.  Results in additional heap free.  Needs additional testing before merge.