### PR TITLE
Flight - OpenLog integration cleanup.

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -97,9 +97,15 @@ extern uintptr_t streamfs_id;
  */
 int32_t LoggingInitialize(void)
 {
-	// TODO: make selectable
-	logging_com_id = PIOS_COM_LOGGING;
-
+	if (PIOS_COM_OPENLOG) {
+		logging_com_id = PIOS_COM_OPENLOG;
+		destination_spi_flash = false;
+	}
+	else if (PIOS_COM_SPIFLASH) {
+		logging_com_id = PIOS_COM_SPIFLASH;
+		destination_spi_flash = true;
+	}
+		
 #ifdef MODULE_Logging_BUILTIN
 	module_enabled = true;
 #else
@@ -120,15 +126,7 @@ int32_t LoggingInitialize(void)
 
 	LoggingStatsInitialize();
 	LoggingSettingsInitialize();
-	
-	LoggingSettingsLogDestinationOptions log_destination;
-	LoggingSettingsLogDestinationGet(&log_destination);
-	
-	if (log_destination == LOGGINGSETTINGS_LOGDESTINATION_SPIFLASH)
-		destination_spi_flash = true;
-	else
-		destination_spi_flash = false;
-	
+
 	// Initialise UAVTalk
 	uavTalkCon = UAVTalkInitialize(&send_data);
 

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -32,7 +32,6 @@
 #include <pios_rfm22b_rcvr_priv.h>
 #include <pios_hsum_priv.h>
 
-#include <loggingsettings.h>
 #include <manualcontrolsettings.h>
 
 #include <sanitycheck.h>
@@ -366,7 +365,6 @@ static void PIOS_HAL_ConfigureHSUM(const struct pios_usart_cfg *usart_hsum_cfg,
  * @param[in] sbus_rcvr_cfg usart configuration for SBUS modes
  * @param[in] sbus_cfg SBUS configuration for this port
  * @param[in] sbus_toggle Whether there is SBUS inverters to touch on this port
- * @param[in] log_dest Log file destination, SPIFlash or OpenLog
  */
 void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		const struct pios_usart_cfg *usart_port_cfg,
@@ -382,8 +380,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		HwSharedDSMxModeOptions dsm_mode,
 		const struct pios_usart_cfg *sbus_rcvr_cfg,
 		const struct pios_sbus_cfg *sbus_cfg,
-		bool sbus_toggle,
-		LoggingSettingsLogDestinationOptions log_dest)
+		bool sbus_toggle)
 {
 	uintptr_t port_driver_id;
 	uintptr_t *target = NULL, *target2 = NULL;;
@@ -550,11 +547,9 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		break;
 	    case HWSHARED_PORTTYPES_OPENLOG:
 #if defined(PIOS_INCLUDE_OPENLOG)
-			if (log_dest == LOGGINGSETTINGS_LOGDESTINATION_OPENLOG) {
-				PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, com_driver, &port_driver_id);
-				target = &pios_com_logging_id;
-				PIOS_COM_ChangeBaud(port_driver_id, 115200);
-			}
+			PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, com_driver, &port_driver_id);
+			target = &pios_com_openlog_logging_id;
+			PIOS_COM_ChangeBaud(port_driver_id, 115200);
 #endif /* PIOS_INCLUDE_OPENLOG */
 		break;
 

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -12,8 +12,6 @@
 #include <pios_usb_cdc_priv.h>
 #include <pios_usb_hid_priv.h>
 
-#include <loggingsettings.h>
-
 #if defined(PIOS_INCLUDE_RFM22B)
 #include <pios_rfm22b_priv.h>
 #include <pios_openlrs_priv.h>
@@ -43,6 +41,7 @@ void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
 		const struct pios_com_driver *com_driver, uintptr_t *com_id);
 
 void PIOS_HAL_Panic(uint32_t led_id, int32_t code);
+
 void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		const struct pios_usart_cfg *usart_port_cfg,
 		const struct pios_com_driver *com_driver,
@@ -57,8 +56,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		HwSharedDSMxModeOptions dsm_mode,
 		const struct pios_usart_cfg *sbus_rcvr_cfg,
 		const struct pios_sbus_cfg *sbus_cfg,
-		bool sbus_toggle,
-		LoggingSettingsLogDestinationOptions log_dest);
+		bool sbus_toggle);
 
 void PIOS_HAL_ConfigureCDC(HwSharedUSB_VCPPortOptions port_type,
 		uintptr_t usb_id,

--- a/flight/targets/aq32/board-info/pios_board.h
+++ b/flight/targets/aq32/board-info/pios_board.h
@@ -116,7 +116,7 @@ extern uintptr_t pios_com_frsky_sensor_hub_id;
 extern uintptr_t pios_com_lighttelemetry_id;
 extern uintptr_t pios_com_picoc_id;
 extern uintptr_t pios_com_frsky_sport_id;
-extern uintptr_t pios_com_logging_id;
+extern uintptr_t pios_com_openlog_logging_id;
 
 #define PIOS_COM_GPS                    (pios_com_gps_id)
 #define PIOS_COM_TELEM_USB              (pios_com_telem_usb_id)
@@ -129,7 +129,8 @@ extern uintptr_t pios_com_logging_id;
 #define PIOS_COM_LIGHTTELEMETRY         (pios_com_lighttelemetry_id)
 #define PIOS_COM_PICOC                  (pios_com_picoc_id)
 #define PIOS_COM_FRSKY_SPORT            (pios_com_frsky_sport_id)
-#define PIOS_COM_LOGGING                (pios_com_logging_id)
+#define PIOS_COM_OPENLOG                (pios_com_openlog_logging_id)
+#define PIOS_COM_SPIFLASH               (uintptr_t)(NULL)              // No SPI Flash on AQ32 Hardware
 
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
 extern uintptr_t pios_com_debug_id;

--- a/flight/targets/aq32/fw/pios_board.c
+++ b/flight/targets/aq32/fw/pios_board.c
@@ -42,7 +42,6 @@
 #include <openpilot.h>
 #include <uavobjectsinit.h>
 #include "hwaq32.h"
-#include "loggingsettings.h"
 #include "manualcontrolsettings.h"
 #include "modulesettings.h"
 
@@ -162,7 +161,7 @@ static const struct pios_ms5611_cfg pios_ms5611_cfg = {
 
 bool external_mag_fail;
 
-uintptr_t pios_com_logging_id;
+uintptr_t pios_com_openlog_logging_id;
 uintptr_t pios_uavo_settings_fs_id;
 uintptr_t pios_waypoints_settings_fs_id;
 uintptr_t pios_internal_adc_id;
@@ -254,8 +253,6 @@ void PIOS_Board_Init(void) {
 
     HwAQ32Initialize();
     ModuleSettingsInitialize();
-    LoggingSettingsInitialize();
-
 #if defined(PIOS_INCLUDE_RTC)
     /* Initialize the real-time clock and its associated tick */
     PIOS_RTC_Init(&pios_rtc_main_cfg);
@@ -388,9 +385,6 @@ void PIOS_Board_Init(void) {
     HwAQ32DSMxModeOptions hw_DSMxMode;
     HwAQ32DSMxModeGet(&hw_DSMxMode);
 
-    LoggingSettingsLogDestinationOptions log_destination;
-    LoggingSettingsLogDestinationGet(&log_destination);
-    
     /* UART1 Port */
     uint8_t hw_uart1;
     HwAQ32Uart1Get(&hw_uart1);
@@ -408,8 +402,7 @@ void PIOS_Board_Init(void) {
             0,                                   // dsm_mode
             NULL,                                // sbus_rcvr_cfg
             NULL,                                // sbus_cfg    
-            false,                               // sbus_toggle
-            log_destination);                     // log_dest
+            false);                              // sbus_toggle
 
     /* UART2 Port */
     uint8_t hw_uart2;
@@ -428,8 +421,7 @@ void PIOS_Board_Init(void) {
             0,                                   // dsm_mode
             NULL,                                // sbus_rcvr_cfg
             NULL,                                // sbus_cfg    
-            false,                               // sbus_toggle
-            log_destination);                     // log_dest
+            false);                              // sbus_toggle
 
     /* UART3 Port */
     uint8_t hw_uart3;
@@ -448,8 +440,7 @@ void PIOS_Board_Init(void) {
             0,                                   // dsm_mode
             &pios_usart3_sbus_cfg,               // sbus_rcvr_cfg
             &pios_usart3_sbus_aux_cfg,           // sbus_cfg                
-            true,                                // sbus_toggle
-            log_destination);                     // log_dest
+            true);                               // sbus_toggle
             
     if (hw_uart3 == HWAQ32_UART3_FRSKYSENSORHUB)
     {
@@ -474,8 +465,7 @@ void PIOS_Board_Init(void) {
             hw_DSMxMode,                         // dsm_mode
             NULL,                                // sbus_rcvr_cfg
             NULL,                                // sbus_cfg    
-            false,                               // sbus_toggle
-            log_destination);                     // log_dest
+            false);                              // sbus_toggle
 
     /* UART6 Port */
     uint8_t hw_uart6;
@@ -494,8 +484,7 @@ void PIOS_Board_Init(void) {
             hw_DSMxMode,                         // dsm_mode
             NULL,                                // sbus_rcvr_cfg
             NULL,                                // sbus_cfg    
-            false,                               // sbus_toggle
-            log_destination);                     // log_dest
+            false);                              // sbus_toggle
 
     /* Configure the rcvr port */
     PIOS_HAL_ConfigurePort(hw_rcvrport,          // port type protocol
@@ -511,8 +500,7 @@ void PIOS_Board_Init(void) {
             0,                                   // dsm_mode
             NULL,                                // sbus_rcvr_cfg
             NULL,                                // sbus_cfg    
-            false,                               // sbus_toggle
-            log_destination);                     // log_dest
+            false);                              // sbus_toggle
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
     GCSReceiverInitialize();

--- a/flight/targets/colibri/board-info/pios_board.h
+++ b/flight/targets/colibri/board-info/pios_board.h
@@ -119,7 +119,7 @@ extern uintptr_t pios_com_hott_id;
 extern uintptr_t pios_com_frsky_sensor_hub_id;
 extern uintptr_t pios_com_lighttelemetry_id;
 extern uintptr_t pios_com_picoc_id;
-extern uintptr_t pios_com_logging_id;
+extern uintptr_t pios_com_spiflash_logging_id;
 
 #define PIOS_COM_GPS                    (pios_com_gps_id)
 #define PIOS_COM_TELEM_USB              (pios_com_telem_usb_id)
@@ -131,7 +131,8 @@ extern uintptr_t pios_com_logging_id;
 #define PIOS_COM_FRSKY_SENSOR_HUB       (pios_com_frsky_sensor_hub_id)
 #define PIOS_COM_LIGHTTELEMETRY         (pios_com_lighttelemetry_id)
 #define PIOS_COM_PICOC                  (pios_com_picoc_id)
-#define PIOS_COM_LOGGING                (pios_com_logging_id)
+#define PIOS_COM_OPENLOG                (uintptr_t)(NULL)
+#define PIOS_COM_SPIFLASH               (pios_com_spiflash_logging_id)
 
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
 extern uintptr_t pios_com_debug_id;

--- a/flight/targets/colibri/fw/pios_board.c
+++ b/flight/targets/colibri/fw/pios_board.c
@@ -205,7 +205,7 @@ uintptr_t pios_com_hott_id;
 uintptr_t pios_com_frsky_sensor_hub_id;
 uintptr_t pios_com_lighttelemetry_id;
 uintptr_t pios_com_picoc_id;
-uintptr_t pios_com_logging_id;
+uintptr_t pios_com_spiflash_logging_id;
 uintptr_t pios_uavo_settings_fs_id;
 uintptr_t pios_waypoints_settings_fs_id;
 uintptr_t pios_internal_adc_id;
@@ -1627,7 +1627,7 @@ void PIOS_Board_Init(void)
 	const uint32_t LOG_BUF_LEN = 256;
 	uint8_t *log_rx_buffer = PIOS_malloc(LOG_BUF_LEN);
 	uint8_t *log_tx_buffer = PIOS_malloc(LOG_BUF_LEN);
-	if (PIOS_COM_Init(&pios_com_logging_id, &pios_streamfs_com_driver, streamfs_id,
+	if (PIOS_COM_Init(&pios_com_spiflash_logging_id, &pios_streamfs_com_driver, streamfs_id,
 	                  log_rx_buffer, LOG_BUF_LEN, log_tx_buffer, LOG_BUF_LEN) != 0)
 		panic(9);
 #endif /* PIOS_INCLUDE_FLASH */

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -410,7 +410,7 @@ void PIOS_Board_Init(void) {
 					&pios_usart_dsm_hsum_rcvrserial_cfg,
 					&pios_dsm_rcvrserial_cfg,
 					hw_DSMxMode,
-					NULL, NULL, false, 0);
+					NULL, NULL, false);
 		}
 
 		// Fall through to set up PPM.

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -153,7 +153,7 @@ void PIOS_Board_Init(void) {
 	    &pios_usart_serial_cfg, &pios_usart_com_driver,
 	    /* no I2C, DSM, HSUM, SBUS, etc. */
 	    NULL, NULL, NULL, NULL, PIOS_LED_ALARM,
-	    NULL, NULL, 0, NULL, NULL, false, 0);
+	    NULL, NULL, 0, NULL, NULL, false);
 
 	// Update the com baud rate.
 	uint32_t comBaud = 9600;

--- a/flight/targets/quanton/board-info/pios_board.h
+++ b/flight/targets/quanton/board-info/pios_board.h
@@ -27,7 +27,6 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
-
 #ifndef STM3210E_INS_H_
 #define STM3210E_INS_H_
 
@@ -80,7 +79,6 @@ TIM8  |           |           |           |
 #define BOARD_WRITABLE					true
 #define MAX_DEL_RETRYS					3
 
-
 //------------------------
 // PIOS_LED
 //------------------------
@@ -109,8 +107,6 @@ extern uint32_t pios_i2c_usart3_adapter_id;
 #define PIOS_I2C_ADAPTER_1				(pios_i2c_usart1_adapter_id)
 #define PIOS_I2C_ADAPTER_2				(pios_i2c_usart3_adapter_id)
 
-
-
 //-------------------------
 // PIOS_COM
 //
@@ -127,7 +123,8 @@ extern uintptr_t pios_com_frsky_sensor_hub_id;
 extern uintptr_t pios_com_lighttelemetry_id;
 extern uintptr_t pios_com_picoc_id;
 extern uintptr_t pios_com_frsky_sport_id;
-extern uintptr_t pios_com_logging_id;
+extern uintptr_t pios_com_spiflash_logging_id;
+extern uintptr_t pios_com_openlog_logging_id;
 
 #define PIOS_COM_GPS                    (pios_com_gps_id)
 #define PIOS_COM_TELEM_USB              (pios_com_telem_usb_id)
@@ -140,14 +137,13 @@ extern uintptr_t pios_com_logging_id;
 #define PIOS_COM_LIGHTTELEMETRY         (pios_com_lighttelemetry_id)
 #define PIOS_COM_PICOC                  (pios_com_picoc_id)
 #define PIOS_COM_FRSKY_SPORT            (pios_com_frsky_sport_id)
-#define PIOS_COM_LOGGING                (pios_com_logging_id)
+#define PIOS_COM_OPENLOG                (pios_com_openlog_logging_id)
+#define PIOS_COM_SPIFLASH               (pios_com_spiflash_logging_id)
 
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
 extern uintptr_t pios_com_debug_id;
 #define PIOS_COM_DEBUG                  (pios_com_debug_id)
 #endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
-
-
 
 //------------------------
 // TELEMETRY
@@ -178,7 +174,6 @@ extern uintptr_t pios_com_debug_id;
 //
 #define PIOS_PERIPHERAL_APB2_CLOCK		PIOS_SYSCLK
 
-
 //-------------------------
 // Interrupt Priorities
 //-------------------------
@@ -186,7 +181,6 @@ extern uintptr_t pios_com_debug_id;
 #define PIOS_IRQ_PRIO_MID				8               // higher than RTOS
 #define PIOS_IRQ_PRIO_HIGH				5               // for SPI, ADC, I2C etc...
 #define PIOS_IRQ_PRIO_HIGHEST			4               // for USART etc...
-
 
 //------------------------
 // PIOS_RCVR

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -190,6 +190,8 @@ uintptr_t pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE];
 #define PIOS_COM_FRSKYSPORT_TX_BUF_LEN 16
 #define PIOS_COM_FRSKYSPORT_RX_BUF_LEN 16
 
+#define PIOS_COM_OPENLOG_TX_BUF_LEN 256
+
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
 #define PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN 40
 uintptr_t pios_com_debug_id;
@@ -205,7 +207,8 @@ uintptr_t pios_com_hott_id;
 uintptr_t pios_com_frsky_sensor_hub_id;
 uintptr_t pios_com_lighttelemetry_id;
 uintptr_t pios_com_picoc_id;
-uintptr_t pios_com_logging_id;
+uintptr_t pios_com_openlog_logging_id;
+uintptr_t pios_com_spiflash_logging_id;
 uintptr_t pios_uavo_settings_fs_id;
 uintptr_t pios_waypoints_settings_fs_id;
 uintptr_t pios_internal_adc_id;
@@ -721,6 +724,12 @@ void PIOS_Board_Init(void) {
 		PIOS_Board_configure_com(&pios_usart1_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_FRSKYSPORTTELEMETRY */
 		break;
+	case HWQUANTON_UART1_OPENLOG:
+#if defined(PIOS_INCLUDE_OPENLOG)
+		PIOS_Board_configure_com(&pios_usart1_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_openlog_logging_id);
+		PIOS_COM_ChangeBaud(pios_com_openlog_logging_id, 115200);
+#endif /* PIOS_INCLUDE_OPENLOG */
+		break;
 	}
 
 	/* UART2 Port */
@@ -833,6 +842,12 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
 		PIOS_Board_configure_com(&pios_usart2_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_FRSKYSPORTTELEMETRY */
+		break;
+	case HWQUANTON_UART2_OPENLOG:
+#if defined(PIOS_INCLUDE_OPENLOG)
+		PIOS_Board_configure_com(&pios_usart2_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_openlog_logging_id);
+		PIOS_COM_ChangeBaud(pios_com_openlog_logging_id, 115200);
+#endif /* PIOS_INCLUDE_OPENLOG */
 		break;
 	}
 
@@ -959,6 +974,12 @@ void PIOS_Board_Init(void) {
 		PIOS_Board_configure_com(&pios_usart3_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_FRSKYSPORTTELEMETRY */
 		break;
+	case HWQUANTON_UART3_OPENLOG:
+#if defined(PIOS_INCLUDE_OPENLOG)
+		PIOS_Board_configure_com(&pios_usart3_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_openlog_logging_id);
+		PIOS_COM_ChangeBaud(pios_com_openlog_logging_id, 115200);
+#endif /* PIOS_INCLUDE_OPENLOG */
+		break;
 	}
 
 	/* UART4 Port */
@@ -1052,6 +1073,12 @@ void PIOS_Board_Init(void) {
 		PIOS_Board_configure_com(&pios_usart4_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_FRSKYSPORTTELEMETRY */
 		break;
+	case HWQUANTON_UART4_OPENLOG:
+#if defined(PIOS_INCLUDE_OPENLOG)
+		PIOS_Board_configure_com(&pios_usart4_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_openlog_logging_id);
+		PIOS_COM_ChangeBaud(pios_com_openlog_logging_id, 115200);
+#endif /* PIOS_INCLUDE_OPENLOG */
+		break;
 	}
 
 	/* UART5 Port */
@@ -1144,6 +1171,12 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY) && defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
 		PIOS_Board_configure_com(&pios_usart5_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_FRSKYSPORTTELEMETRY */
+		break;
+	case HWQUANTON_UART5_OPENLOG:
+#if defined(PIOS_INCLUDE_OPENLOG)
+		PIOS_Board_configure_com(&pios_usart5_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_openlog_logging_id);
+		PIOS_COM_ChangeBaud(pios_com_openlog_logging_id, 115200);
+#endif /* PIOS_INCLUDE_OPENLOG */
 		break;
 	}
 
@@ -1439,14 +1472,14 @@ void PIOS_Board_Init(void) {
 	}
 #endif
 
-#if defined(PIOS_INCLUDE_FLASH)
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
 	if ( PIOS_STREAMFS_Init(&streamfs_id, &streamfs_settings, FLASH_PARTITION_LABEL_LOG) != 0)
 		panic(8);
 
 	const uint32_t LOG_BUF_LEN = 256;
 	uint8_t *log_rx_buffer = PIOS_malloc(LOG_BUF_LEN);
 	uint8_t *log_tx_buffer = PIOS_malloc(LOG_BUF_LEN);
-	if (PIOS_COM_Init(&pios_com_logging_id, &pios_streamfs_com_driver, streamfs_id,
+	if (PIOS_COM_Init(&pios_com_spiflash_logging_id, &pios_streamfs_com_driver, streamfs_id,
 	                  log_rx_buffer, LOG_BUF_LEN, log_tx_buffer, LOG_BUF_LEN) != 0)
 		panic(9);
 #endif /* PIOS_INCLUDE_FLASH */

--- a/flight/targets/quanton/fw/pios_config.h
+++ b/flight/targets/quanton/fw/pios_config.h
@@ -56,6 +56,7 @@
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_FASTHEAP
 #define PIOS_INCLUDE_HPWM
+#define PIOS_INCLUDE_OPENLOG
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_HMC5883

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -333,7 +333,7 @@ void PIOS_Board_Init(void) {
 			&pios_usart_com_driver, NULL, NULL, NULL, NULL, PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
 			hw_DSMxMode >= HWREVOMINI_DSMXMODE_BIND3PULSES ? HWREVOMINI_DSMXMODE_AUTODETECT : hw_DSMxMode /* No bind on main port */, &pios_usart_sbus_main_cfg,
-			&pios_sbus_cfg, true, 0);
+			&pios_sbus_cfg, true);
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
@@ -343,7 +343,7 @@ void PIOS_Board_Init(void) {
 			&pios_usart_com_driver, &pios_i2c_flexiport_adapter_id,
 			&pios_i2c_flexiport_adapter_cfg, NULL, NULL, PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxMode, NULL, NULL, false, 0);
+			hw_DSMxMode, NULL, NULL, false);
 
 	HwRevoMiniData hwRevoMini;
 	HwRevoMiniGet(&hwRevoMini);

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -383,7 +383,7 @@ void PIOS_Board_Init(void)
 	                       &pios_usart_com_driver, NULL, NULL, NULL, NULL,
 	                       PIOS_LED_ALARM,
 	                       &pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg,
-	                       hw_DSMxMode, NULL, NULL, false, 0);
+	                       hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
@@ -394,7 +394,7 @@ void PIOS_Board_Init(void)
 	                       &pios_i2c_flexi_cfg, NULL, NULL,
 	                       PIOS_LED_ALARM,
 	                       &pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg,
-	                       hw_DSMxMode, NULL, NULL, false, 0);
+	                       hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;
@@ -408,7 +408,7 @@ void PIOS_Board_Init(void)
 	                       &pios_rcvr_dsm_hsum_cfg,
 	                       &pios_rcvr_dsm_aux_cfg,
 	                       hw_DSMxMode, &pios_rcvr_sbus_cfg,
-	                       &pios_rcvr_sbus_aux_cfg, false, 0);
+	                       &pios_rcvr_sbus_aux_cfg, false);
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();

--- a/flight/targets/sparky2/board-info/pios_board.h
+++ b/flight/targets/sparky2/board-info/pios_board.h
@@ -115,8 +115,8 @@ extern uintptr_t pios_com_frsky_sensor_hub_id;
 extern uintptr_t pios_com_lighttelemetry_id;
 extern uintptr_t pios_com_picoc_id;
 extern uintptr_t pios_com_debug_id;
-extern uintptr_t pios_com_logging_id;
 extern uintptr_t pios_com_frsky_sport_id;
+extern uintptr_t pios_com_spiflash_logging_id;
 
 #define PIOS_COM_GPS                    (pios_com_gps_id)
 #define PIOS_COM_TELEM_USB              (pios_com_telem_usb_id)
@@ -129,8 +129,9 @@ extern uintptr_t pios_com_frsky_sport_id;
 #define PIOS_COM_LIGHTTELEMETRY         (pios_com_lighttelemetry_id)
 #define PIOS_COM_PICOC                  (pios_com_picoc_id)
 #define PIOS_COM_DEBUG                  (pios_com_debug_id)
-#define PIOS_COM_LOGGING                (pios_com_logging_id)
 #define PIOS_COM_FRSKY_SPORT            (pios_com_frsky_sport_id)
+#define PIOS_COM_OPENLOG                (uintptr_t)(NULL)
+#define PIOS_COM_SPIFLASH               (pios_com_spiflash_logging_id)
 
 #define DEBUG_LEVEL 0
 #define DEBUG_PRINTF(level, ...) {if(level <= DEBUG_LEVEL && pios_com_debug_id > 0) { PIOS_COM_SendFormattedStringNonBlocking(pios_com_debug_id, __VA_ARGS__); }}

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -130,7 +130,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_external_cfg = {
 #define PIOS_COM_CAN_RX_BUF_LEN 256
 #define PIOS_COM_CAN_TX_BUF_LEN 256
 
-uintptr_t pios_com_logging_id;
+uintptr_t pios_com_spiflash_logging_id;
 uintptr_t pios_com_can_id;
 uintptr_t pios_internal_adc_id = 0;
 uintptr_t pios_uavo_settings_fs_id;
@@ -439,7 +439,7 @@ void PIOS_Board_Init(void) {
 			&pios_usart_com_driver, NULL, NULL, NULL, NULL,
 			PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
-			hw_DSMxMode, NULL, NULL, false, 0);
+			hw_DSMxMode, NULL, NULL, false);
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
@@ -451,7 +451,7 @@ void PIOS_Board_Init(void) {
 			&pios_i2c_flexiport_adapter_cfg, NULL, NULL,
 			PIOS_LED_ALARM,
 			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxMode, NULL, NULL, false, 0);
+			hw_DSMxMode, NULL, NULL, false);
 
 #if defined(PIOS_INCLUDE_RFM22B)
 	HwSparky2Data hwSparky2;
@@ -488,7 +488,7 @@ void PIOS_Board_Init(void) {
 			&pios_usart_dsm_hsum_rcvr_cfg,
 			&pios_dsm_rcvr_cfg,
 			hw_DSMxMode, get_sbus_rcvr_cfg(bdinfo->board_rev),
-			&pios_sbus_cfg, get_sbus_toggle(bdinfo->board_rev), 0);
+			&pios_sbus_cfg, get_sbus_toggle(bdinfo->board_rev));
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();
@@ -681,7 +681,7 @@ void PIOS_Board_Init(void) {
 		const uint32_t LOG_BUF_LEN = 256;
 		uint8_t *log_rx_buffer = PIOS_malloc(LOG_BUF_LEN);
 		uint8_t *log_tx_buffer = PIOS_malloc(LOG_BUF_LEN);
-		if (PIOS_COM_Init(&pios_com_logging_id, &pios_streamfs_com_driver, streamfs_id,
+		if (PIOS_COM_Init(&pios_com_spiflash_logging_id, &pios_streamfs_com_driver, streamfs_id,
 			log_rx_buffer, LOG_BUF_LEN, log_tx_buffer, LOG_BUF_LEN) != 0)
 			panic(9);
 	}

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -22,6 +22,7 @@
 				<option>LighttelemetryTx</option>
 				<option>PicoC</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>OpenLog</option>
 			</options>
 		</field>
 
@@ -43,6 +44,7 @@
 				<option>LighttelemetryTx</option>
 				<option>PicoC</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>OpenLog</option>
 			</options>
 		</field>
 
@@ -64,6 +66,7 @@
 				<option>LighttelemetryTx</option>
 				<option>PicoC</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>OpenLog</option>
 			</options>
 		</field>
 
@@ -84,6 +87,7 @@
 				<option>FrSKY Sensor Hub</option>
 				<option>PicoC</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>OpenLog</option>
 			</options>
 		</field>
 
@@ -104,6 +108,7 @@
 				<option>LighttelemetryTx</option>
 				<option>PicoC</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>OpenLog</option>
 			</options>
 		</field>
 

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -1,7 +1,6 @@
 <xml>
 	<object name="LoggingSettings" singleinstance="true" settings="true">
 		<description>Settings for the logging module</description>
-		<field name="LogDestination" units="" type="enum" options="SPIFlash,OpenLog" elements="1" defaultvalue="OpenLog"/>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
 		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
 		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100" elements="1" defaultvalue="25"/>


### PR DESCRIPTION
Fixes/streamlines some of the issues with the original pull request.

Dropped the need for the destination UAVObject.  On a board without SPI Flash such as the AQ32, the logging module will only become active if logging is enabled and OpenLog is assigned to one of the available ports.  Otherwise the module does not load.

On a board like Quanton, logging destination will be SPI Flash, unless OpenLog is assigned to one of the available ports, in which case the log data will be sent to the OpenLog.

So the complete change could be tested, I added the Quanton implementation to the PR.

Test Results (results assume logging has already been enabled):

AQ32 - with OpenLog not assigned to a ports, the logging module is inactive.  Once OpenLog is assigned to a port and the board is reset, the logging module is loaded and active.  As per the rest of the setup, logging takes place when the board is armed.  Tests run on uart4 and uart6.

Quanton - with OpenLog not assigned to a port, the logging module is active, and log data is sent to SPI Flash when armed.  The logged file can be downloaded via the GCS.  With OpenLog assigned to a port, after a reset the logging module is still active, and log data is sent to the OpenLog upon system arming.  Tests run on uart2 and uart5.

This implementation is quite a bit easier to setup, and should take care of previous issues/concerns.

Colibri and Sparky2 implementation should be straight forward, but I did not include those boards in this PR because I can not test them.