### PR TITLE
PIOS: Remove unused registration struct from sensors

### DIFF
--- a/flight/PiOS/inc/pios_sensors.h
+++ b/flight/PiOS/inc/pios_sensors.h
@@ -92,12 +92,6 @@ enum pios_sensor_type
 	PIOS_SENSOR_LAST
 };
 
-//! Structure to register the data
-struct pios_sensor_registration {
-	enum pios_sensor_type type;
-	struct pios_queue *queue;
-};
-
 //! Initialize the PIOS_SENSORS interface
 int32_t PIOS_SENSORS_Init();
 


### PR DESCRIPTION
This was added when the sensors module was originally used but has remained unused ever since.
```
mike@mike-desktop:~/Dev/TauLabs/TauLabs$ grep -r pios_sensor_registration
flight/PiOS/inc/pios_sensors.h:struct pios_sensor_registration {
```