### PR TITLE
sparky: Enable fastheap

### DIFF
--- a/flight/targets/sparky/fw/pios_config.h
+++ b/flight/targets/sparky/fw/pios_config.h
@@ -128,6 +128,8 @@
 
 #define CAMERASTAB_POI_MODE
 
+#define PIOS_INCLUDE_FASTHEAP
+
 #endif /* PIOS_CONFIG_H */
 /**
  * @}


### PR DESCRIPTION
STM32F303CC has 8k of CCM-RAM that was not used.

A base Sparky configuration had 7,408 bytes of normal heap free; with
this patch it has 12,972 bytes free. (A 5.5k benefit).

With the resources we've freed up lately, sparky became capable of light
navigation.  With this change, it's pretty much unlimited in
functionality.
