### PR TITLE
GCS:Autotune: Warning for very low Tau (i.e. diverged), flight controller name posted to forum

### DIFF
--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -226,6 +226,13 @@ bool ConfigAutotuneWidget::approveSettings(
                                                            "Do you still want to proceed?"), QMessageBox::Yes,QMessageBox::No);
         if (ans == QMessageBox::No)
             return false;
+    } else if (exp(systemIdentData.Tau) < 0.008) {
+
+        int ans = QMessageBox::warning(this,tr("Extreme values"),
+                                     tr("Your estimated response speed (tau) is faster than normal. This will result in large PID values. "
+                                                           "Do you still want to proceed?"), QMessageBox::Yes,QMessageBox::No);
+        if (ans == QMessageBox::No)
+            return false;
     }
 
     return true;

--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -124,8 +124,14 @@ void ConfigAutotuneWidget::onForumInteractionSet(int value)
        return;
     }
 
+    deviceDescriptorStruct firmware;
+    utilMngr->getBoardDescriptionStruct(firmware);
+
     QString message0 = tr(
                 "[b]Flight controller[/b]: %13\n"
+                "[b]Firmware tag[/b]: %14\n"
+                "[b]Firmware commit[/b]: [url=http://github.com/TauLabs/TauLabs/commit/%15]%15[/url]\n"
+                "[b]Firmware date[/b]: %16\n\n\n"
                 "[b]Aircraft description[/b]: %0\n\n\n"
                 "[b]Observations[/b]: %1\n\n\n"
                 "[b]Measured properties[/b]"
@@ -158,7 +164,10 @@ void ConfigAutotuneWidget::onForumInteractionSet(int value)
             .arg(m_autotune->pitchTau->text()).arg(m_autotune->measuredPitchNoise->text())
             .arg(m_autotune->lblDamp->text()).arg(m_autotune->lblNoise->text())
             .arg(m_autotune->wn->text())
-            .arg(utilMngr->getBoardType()->shortName());
+            .arg(utilMngr->getBoardType()->shortName())
+            .arg(firmware.gitTag)
+            .arg(firmware.gitHash.left(7))
+            .arg(firmware.gitDate);
     QString message1 = tr(
                 "[b]\n\nComputed Values[/b]"
                 "[table][tr][td][/td]"

--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -40,6 +40,9 @@ ConfigAutotuneWidget::ConfigAutotuneWidget(QWidget *parent) :
 
     SystemIdent *systemIdent = SystemIdent::GetInstance(getObjectManager());
 
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    utilMngr = pm->getObject<UAVObjectUtilManager>();
+
     addWidget(m_autotune->enableAutoTune);
 
     connect(systemIdent, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(recomputeStabilization()));
@@ -122,6 +125,7 @@ void ConfigAutotuneWidget::onForumInteractionSet(int value)
     }
 
     QString message0 = tr(
+                "[b]Flight controller[/b]: %13\n"
                 "[b]Aircraft description[/b]: %0\n\n\n"
                 "[b]Observations[/b]: %1\n\n\n"
                 "[b]Measured properties[/b]"
@@ -153,7 +157,8 @@ void ConfigAutotuneWidget::onForumInteractionSet(int value)
             .arg(m_autotune->measuredPitchGain->text()).arg(m_autotune->measuredPitchBias->text())
             .arg(m_autotune->pitchTau->text()).arg(m_autotune->measuredPitchNoise->text())
             .arg(m_autotune->lblDamp->text()).arg(m_autotune->lblNoise->text())
-            .arg(m_autotune->wn->text());
+            .arg(m_autotune->wn->text())
+            .arg(utilMngr->getBoardType()->shortName());
     QString message1 = tr(
                 "[b]\n\nComputed Values[/b]"
                 "[table][tr][td][/td]"

--- a/ground/gcs/src/plugins/config/configautotunewidget.h
+++ b/ground/gcs/src/plugins/config/configautotunewidget.h
@@ -47,6 +47,7 @@ public:
 private:
     Ui_AutotuneWidget *m_autotune;
     StabilizationSettings::DataFields stabSettings;
+    UAVObjectUtilManager* utilMngr;
 
     bool approveSettings(SystemIdent::DataFields systemIdentData);
     Utils::ForumInteractionForm *forumInteractionForm;


### PR DESCRIPTION
Two parts to this one:
* A warning is generated if Tau is less than 0.008 s. The lower limit for Tau is 0.007 s according to @peabody124, and this occurs when the identification diverges, resulting in poor tunes as per #2013.
* The flight controller short name is included in forum posts to aid in identifying future issues. The lack of this information was identified whilst discussing #2013 on IRC.