### PR TITLE
Battery: ADC alarms, disallow negative voltage or current

### DIFF
--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -128,17 +128,32 @@ static void batteryTask(void * parameters)
 				currentADCPin = -1;
 		}
 
+		bool adc_pin_invalid = false;
+		bool adc_offset_invalid = false;
+
 		// handle voltage
 		if (voltageADCPin >= 0) {
-			flightBatteryData.Voltage = (float)PIOS_ADC_GetChannelVolt(voltageADCPin);
+			float adc_voltage = (float)PIOS_ADC_GetChannelVolt(voltageADCPin);
+			float scaled_voltage = 0.0f;
 
-			// A negative result indicates an error (PIOS_ADC_GetChannelVolt returns -1 on error)
-			if(flightBatteryData.Voltage < 0.0f)
-				flightBatteryData.Voltage = 0.0f;
+			// A negative result indicates an error (PIOS_ADC_GetChannelVolt returns negative on error)
+			if(adc_voltage < 0.0f)
+				adc_pin_invalid = true;
+			else {
+				// scale to actual voltage
+				scaled_voltage = (adc_voltage * 1000.0f
+						/ batterySettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_VOLTAGE])
+						+ batterySettings.SensorCalibrationOffset[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONOFFSET_VOLTAGE]; //in Volts
 
-			// scale to actual voltage
-			flightBatteryData.Voltage *= 1000.0f / batterySettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_VOLTAGE];
-			flightBatteryData.Voltage += batterySettings.SensorCalibrationOffset[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONOFFSET_VOLTAGE]; //in Volts
+				// disallow negative values as these are cast to unsigned integral types
+				// in some telemetry layers
+				if(scaled_voltage < 0.0f) {
+					scaled_voltage = 0.0f;
+					adc_offset_invalid = true;
+				}
+			}
+
+			flightBatteryData.Voltage = scaled_voltage;
 
 			// generate alarms and warnings
 			if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM])
@@ -153,15 +168,27 @@ static void batteryTask(void * parameters)
 
 		// handle current
 		if (currentADCPin >= 0) {
-			flightBatteryData.Current = (float)PIOS_ADC_GetChannelVolt(currentADCPin);
+			float adc_voltage = (float)PIOS_ADC_GetChannelVolt(currentADCPin);
+			float scaled_current = 0.0f;
 
 			// A negative result indicates an error (PIOS_ADC_GetChannelVolt returns -1 on error)
-			if(flightBatteryData.Current < 0.0f)
-				flightBatteryData.Current = 0.0f;
+			if(adc_voltage < 0.0f)
+				adc_pin_invalid = true;
+			else {
+				// scale to actual current
+				scaled_current = (adc_voltage * 1000.0f
+						/ batterySettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_CURRENT])
+						+ batterySettings.SensorCalibrationOffset[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONOFFSET_CURRENT]; //in Amps
 
-			// scale to actual current
-			flightBatteryData.Current *= 1000.0f / batterySettings.SensorCalibrationFactor[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONFACTOR_CURRENT];
-			flightBatteryData.Current += batterySettings.SensorCalibrationOffset[FLIGHTBATTERYSETTINGS_SENSORCALIBRATIONOFFSET_CURRENT]; //in Amps
+				// disallow negative values as these are cast to unsigned integral types
+				// in some telemetry layers
+				if(scaled_current < 0.0f) {
+					scaled_current = 0.0f;
+					adc_offset_invalid = true;
+				}
+			}
+
+			flightBatteryData.Current = scaled_current;
 
 			if (flightBatteryData.Current > flightBatteryData.PeakCurrent)
 				flightBatteryData.PeakCurrent = flightBatteryData.Current; //in Amps
@@ -190,6 +217,15 @@ static void batteryTask(void * parameters)
 		} else {
 			flightBatteryData.Current = 0;
 		}
+
+		if(adc_pin_invalid)
+			AlarmsSet(SYSTEMALARMS_ALARM_ADC, SYSTEMALARMS_ALARM_CRITICAL);
+		else if(adc_offset_invalid)
+			AlarmsSet(SYSTEMALARMS_ALARM_ADC, SYSTEMALARMS_ALARM_WARNING);
+		else if(voltageADCPin >= 0 || currentADCPin >= 0)
+			AlarmsSet(SYSTEMALARMS_ALARM_ADC, SYSTEMALARMS_ALARM_OK);
+		else
+			AlarmsSet(SYSTEMALARMS_ALARM_ADC, SYSTEMALARMS_ALARM_UNINITIALISED);
 
 		FlightBatteryStateSet(&flightBatteryData);
 	}

--- a/ground/gcs/share/taulabs/diagrams/default/system-health-linear.svg
+++ b/ground/gcs/share/taulabs/diagrams/default/system-health-linear.svg
@@ -10,8 +10,8 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="365.17761"
-   height="12.441585"
+   width="405.38974"
+   height="12.437008"
    id="svg3604"
    version="1.1"
    inkscape:version="0.48.4 r9939"
@@ -794,16 +794,16 @@
      borderopacity="1"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="3.707287"
-     inkscape:cx="193.36968"
-     inkscape:cy="4.777166"
-     inkscape:current-layer="foreground"
+     inkscape:zoom="29.658296"
+     inkscape:cx="398.27372"
+     inkscape:cy="3.2225689"
+     inkscape:current-layer="background"
      id="namedview3608"
      showgrid="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="850"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-width="2495"
+     inkscape:window-height="1416"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
@@ -829,7 +829,8 @@
      inkscape:snap-grids="false"
      inkscape:snap-to-guides="false"
      showborder="true"
-     inkscape:showpageshadow="false">
+     inkscape:showpageshadow="false"
+     guidetolerance="30">
     <sodipodi:guide
        orientation="0,1"
        position="160.86626,-131.3738"
@@ -892,7 +893,7 @@
        id="guide4864" />
     <sodipodi:guide
        orientation="1,0"
-       position="385.29681,0.53143411"
+       position="403.08661,-8.3923091"
        id="guide4866" />
     <sodipodi:guide
        orientation="0,1"
@@ -922,6 +923,22 @@
        orientation="1,0"
        position="223.50947,10.547352"
        id="guide3292" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="384.34252,-7.9154734"
+       id="guide3455" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="405.38976,-2.3364951"
+       id="guide3457" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="2.2888116,-5.4836111"
+       id="guide3459" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="0,-10.299652"
+       id="guide3461" />
   </sodipodi:namedview>
   <metadata
      id="metadata3610">
@@ -931,7 +948,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -939,11 +956,11 @@
      inkscape:label="Background"
      inkscape:groupmode="layer"
      id="background"
-     transform="translate(-405.17146,-343.74826)"
+     transform="translate(-405.17146,-343.75284)"
      style="display:inline">
     <path
-       style="fill:#453e3e;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.77728355;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 412.24045,344.1369 371.15887,0 c 3.7009,0 6.68031,0.10717 6.68031,0.24029 l 0,11.18372 c 0,0.13312 -2.97941,0.24029 -6.68031,0.24029 l -371.15887,0 c -3.70093,0 -6.68035,-0.10717 -6.68035,-0.24029 l 0,-11.18372 c 0,-0.13312 2.97942,-0.24029 6.68035,-0.24029 z"
+       style="fill:#453e3e;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.79668009;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 412.5994,344.1466 390.56344,0 c 3.89439,0 7.02956,0.10699 7.02956,0.23989 l 0,11.16512 c 0,0.1329 -3.13517,0.23989 -7.02956,0.23989 l -390.56344,0 c -3.89441,0 -7.0296,-0.10699 -7.0296,-0.23989 l 0,-11.16512 c 0,-0.1329 3.13519,-0.23989 7.0296,-0.23989 z"
        id="Background"
        inkscape:connector-curvature="0" />
     <path
@@ -1060,13 +1077,19 @@
        d="m 769.65269,345.90859 18.20274,0 0,8.12092 -18.20274,0 z"
        id="AltitudeHold"
        inkscape:connector-curvature="0" />
+    <path
+       inkscape:label="#ADC"
+       style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53219783;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline"
+       d="m 789.80529,345.9186 18.20274,0 0,8.12092 -18.20274,0 z"
+       id="ADC"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      style="display:none"
      inkscape:label="Alarms-OK"
      id="g11118"
      inkscape:groupmode="layer"
-     transform="translate(92.494173,0.5321132)">
+     transform="translate(92.494173,0.52753585)">
     <rect
        style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
        id="Battery-OK"
@@ -1219,13 +1242,21 @@
        width="18.153212"
        id="AltitudeHold-OK"
        style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    <rect
+       inkscape:label="#ADC-OK"
+       y="1.6378762"
+       x="292.16443"
+       height="8.1216154"
+       width="18.153212"
+       id="ADC-OK"
+       style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
   </g>
   <g
      style="display:none"
      inkscape:label="Alarms-Warning"
      id="g11122"
      inkscape:groupmode="layer"
-     transform="translate(92.494173,0.5321132)">
+     transform="translate(92.494173,0.52753585)">
     <rect
        inkscape:label="#rect3132"
        y="1.5463446"
@@ -1378,13 +1409,21 @@
        height="8.1216154"
        x="272.01181"
        y="1.6278691" />
+    <rect
+       inkscape:label="#ADC-Warning"
+       style="fill:#f1b907;fill-opacity:1;stroke:#ffffff;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="ADC-Warning"
+       width="18.153212"
+       height="8.1216154"
+       x="292.16443"
+       y="1.6378762" />
   </g>
   <g
      style="display:none"
      inkscape:label="Alarms-Error"
      id="g11126"
      inkscape:groupmode="layer"
-     transform="translate(92.494173,0.5321132)">
+     transform="translate(92.494173,0.52753585)">
     <g
        id="SystemConfiguration-Error"
        inkscape:label="#g29709">
@@ -1655,13 +1694,47 @@
          style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
          inkscape:connector-curvature="0" />
     </g>
+    <g
+       transform="translate(40.189222,-6.18e-6)"
+       style="display:inline"
+       id="AltitudeHold-Error"
+       inkscape:label="#AltitudeHold-Error">
+      <path
+         inkscape:label="#path4088-8"
+         id="path26991-1-5-2"
+         d="M 232.00988,9.719467 249.86051,1.657893"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path26989-9-5-3"
+         d="m 231.86592,1.657893 18.06657,7.989596"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(60.341822,0.01000382)"
+       style="display:inline"
+       id="ADC-Error"
+       inkscape:label="#ADC-Error">
+      <path
+         inkscape:label="#path4088-8"
+         id="path26991-1-5-6"
+         d="M 232.00988,9.719467 249.86051,1.657893"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path26989-9-5-5"
+         d="m 231.86592,1.657893 18.06657,7.989596"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         inkscape:connector-curvature="0" />
+    </g>
   </g>
   <g
      style="display:none"
      inkscape:label="Alarms-Critical"
      id="g11130"
      inkscape:groupmode="layer"
-     transform="translate(92.494173,0.5321132)">
+     transform="translate(92.494173,0.52753585)">
     <rect
        inkscape:label="#rect3108"
        style="fill:#cf0e0e;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.53149605;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
@@ -1820,7 +1893,7 @@
      id="g11134"
      inkscape:label="Alarms-Uninitialised"
      style="display:none"
-     transform="translate(92.494173,0.5321132)">
+     transform="translate(92.494173,0.52753585)">
     <rect
        inkscape:label="#rect8365"
        y="1.6278723"
@@ -1985,13 +2058,13 @@
      inkscape:label="FlightTime-Uninitialised"
      id="g11138"
      inkscape:groupmode="layer"
-     transform="translate(92.494173,0.5321132)" />
+     transform="translate(92.494173,0.52753585)" />
   <g
      inkscape:groupmode="layer"
      id="foreground"
      inkscape:label="Foreground"
      style="display:inline"
-     transform="translate(92.494173,0.5321132)">
+     transform="translate(92.494173,0.52753585)">
     <g
        style="display:inline"
        id="g29027">
@@ -2723,8 +2796,8 @@
     <path
        inkscape:connector-curvature="0"
        id="path29775"
-       d="m -85.425182,-0.14347009 371.158852,0 c 3.7009,0 6.68033,0.10716809 6.68033,0.24028612 l 0,11.18372797 c 0,0.133118 -2.97943,0.240286 -6.68033,0.240286 l -371.158852,0 c -3.700932,0 -6.680348,-0.107168 -6.680348,-0.240286 l 0,-11.18372797 c 0,-0.13311803 2.979416,-0.24028612 6.680348,-0.24028612 z"
-       style="fill:none;stroke:#000000;stroke-width:0.77728355;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
+       d="m -85.066228,-0.13377183 390.563418,0 c 3.89438,0 7.02958,0.10698988 7.02958,0.23988655 l 0,11.16513028 c 0,0.132897 -3.1352,0.239887 -7.02958,0.239887 l -390.563418,0 c -3.894421,0 -7.029604,-0.10699 -7.029604,-0.239887 l 0,-11.16513028 c 0,-0.13289667 3.135183,-0.23988655 7.029604,-0.23988655 z"
+       style="fill:none;stroke:#000000;stroke-width:0.79668009;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
     <text
        xml:space="preserve"
        style="font-size:2.87697005px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ffffff;fill-opacity:1;stroke:none;font-family:DejaVu Sans Mono;-inkscape-font-specification:DejaVu Sans Mono"
@@ -2768,13 +2841,14 @@
     <text
        xml:space="preserve"
        style="font-size:2.885602px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:DejaVu Sans Mono;-inkscape-font-specification:DejaVu Sans Mono"
-       x="274.19766"
+       x="275.5152"
        y="4.7037296"
        id="text4868-5-0"><tspan
          sodipodi:role="line"
-         x="274.19766"
+         x="275.5152"
          y="4.7037296"
-         id="tspan4657">Altitude</tspan></text>
+         id="tspan4657"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans">Altitude</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:2.94651628px;font-style:normal;font-weight:normal;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Bitstream Vera Sans"
@@ -2785,10 +2859,22 @@
          id="tspan5683-4"
          x="277.37976"
          y="8.2200718">Hold</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="297.03107"
+       y="7.1547384"
+       id="text3502"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3504"
+         x="297.03107"
+         y="7.1547384"
+         style="font-size:4px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ffffff;fill-opacity:1;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans">ADC</tspan></text>
   </g>
   <g
      style="display:none"
-     transform="translate(-405.17146,-343.74826)"
+     transform="translate(-405.17146,-343.75284)"
      id="g3368"
      inkscape:groupmode="layer"
      inkscape:label="NoLink Warning">

--- a/ground/gcs/share/taulabs/diagrams/default/system-health.svg
+++ b/ground/gcs/share/taulabs/diagrams/default/system-health.svg
@@ -14,7 +14,7 @@
    height="79.57505"
    id="svg3604"
    version="1.1"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.48.4 r9939"
    sodipodi:docname="system-health.svg"
    inkscape:export-filename="C:\NoBackup\OpenPilot\mainboard-health.png"
    inkscape:export-xdpi="269.53"
@@ -689,19 +689,20 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="10.247587"
-     inkscape:cx="46.093027"
-     inkscape:cy="31.153742"
-     inkscape:current-layer="layer52"
+     inkscape:zoom="40.990348"
+     inkscape:cx="42.592795"
+     inkscape:cy="10.848176"
+     inkscape:current-layer="background"
      id="namedview3608"
      showgrid="false"
-     inkscape:window-width="2264"
-     inkscape:window-height="1246"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-width="2495"
+     inkscape:window-height="1416"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      showguides="true"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     units="mm">
     <sodipodi:guide
        orientation="0,1"
        position="68.372091,-63.708224"
@@ -798,7 +799,7 @@
        id="Pwr-Sense"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53585184;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       style="fill:#332d2d;fill-opacity:1;stroke:#ffffff;stroke-width:0.53503937;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
        d="m 526.39636,406.95688 16.17991,0 0,15.0345 -16.17991,0 z"
        id="ADC"
        inkscape:connector-curvature="0" />
@@ -890,6 +891,63 @@
        inkscape:connector-curvature="0" />
   </g>
   <g
+     style="display:none"
+     inkscape:label="ADC-OK"
+     id="g4480"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="ADC-OK"
+       d="m 28.73073,62.67651 16.17991,0 0,15.0345 -16.17991,0 z"
+       style="fill:#04b629;fill-opacity:1;stroke:#ffffff;stroke-width:0.53503937;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g4460"
+     inkscape:label="ADC-Error"
+     style="display:none">
+    <g
+       style="stroke:#cf0e0e;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="ADC-Error"
+       transform="matrix(0.79634214,0,0,1.6454053,-0.69694862,8.7711933)"
+       inkscape:label="#ADC-Error">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 38.076545,33.292974 56.14311,41.28257"
+         id="path4464" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 38.220502,41.354548 17.85063,-8.061574"
+         id="path4466"
+         inkscape:label="#path4088-8" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer49"
+     inkscape:label="ADC-Warning"
+     style="display:none">
+    <path
+       style="fill:#f1b907;fill-opacity:1;stroke:#ffffff;stroke-width:0.53503937;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 28.73073,62.67651 16.17991,0 0,15.0345 -16.17991,0 z"
+       id="ADC-Warning"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="ADC-Critical"
+     id="g4456"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="ADC-Critical"
+       d="m 28.73073,62.67651 16.17991,0 0,15.0345 -16.17991,0 z"
+       style="fill:#cf0e0e;fill-opacity:1;stroke:#ffffff;stroke-width:0.53503937;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       inkscape:label="#ADC-Critical" />
+  </g>
+  <g
      inkscape:groupmode="layer"
      id="layer50"
      inkscape:label="TempBaro-OK"
@@ -912,7 +970,7 @@
        style="fill:#808080;fill-opacity:1;stroke:#ffffff;stroke-width:0.51991701;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
   </g>
   <g
-     style="display:inline"
+     style="display:none"
      inkscape:label="TempBaro-Error"
      id="layer52"
      inkscape:groupmode="layer">
@@ -1061,12 +1119,14 @@
       <path
          id="path3156"
          d="M 38.076545,33.292974 56.14311,41.28257"
-         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
       <path
          inkscape:label="#path4088-8"
          id="path3158"
          d="m 38.220502,41.354548 17.85063,-8.061574"
-         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:none;stroke:#cf0e0e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
   <g
@@ -3701,6 +3761,18 @@
          id="path4446"
          inkscape:connector-curvature="0" />
     </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g4468"
+     inkscape:label="ADC-Uninitialised"
+     style="display:none">
+    <path
+       inkscape:label="#ADC-Uninitialised"
+       style="fill:#808080;fill-opacity:0.89019608;stroke:#ffffff;stroke-width:0.53503937;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 28.73073,62.67651 16.17991,0 0,15.0345 -16.17991,0 z"
+       id="ADC-Uninitialised"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      inkscape:groupmode="layer"

--- a/ground/gcs/src/plugins/systemhealth/html/ADC-Critical.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ADC-Critical.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <title></title>
+    <meta content="">
+    <style></style>
+  </head>
+  <body style="color: black">
+    <h1>ADC: Critical</h1>
+    <p>
+      Invalid ADC configuration (check ADC assignments).
+    </p>
+  </body>
+</html>

--- a/ground/gcs/src/plugins/systemhealth/html/ADC-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/ADC-Warning.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <title></title>
+    <meta content="">
+    <style></style>
+  </head>
+  <body style="color: black">
+    <h1>ADC: Warning</h1>
+    <p>
+      An ADC calibration offset caused a negative voltage or current. 
+    </p>
+  </body>
+</html>

--- a/ground/gcs/src/plugins/systemhealth/systemhealth.qrc
+++ b/ground/gcs/src/plugins/systemhealth/systemhealth.qrc
@@ -29,6 +29,8 @@
         <file>html/Stabilization-Warning.html</file>
         <file>html/Stack-Critical.html</file>
         <file>html/Telemetry-Error.html</file>
+        <file>html/ADC-Critical.html</file>
+        <file>html/ADC-Warning.html</file>
         <file>html/SystemConfiguration-Error-AltitudeHold.html</file>
         <file>html/SystemConfiguration-Error-AutoTune.html</file>
         <file>html/SystemConfiguration-Error-DuplicatePortCfg.html</file>

--- a/shared/uavobjectdefinition/systemalarms.xml
+++ b/shared/uavobjectdefinition/systemalarms.xml
@@ -21,10 +21,11 @@
 				<elementname>FlightTime</elementname>
 				<elementname>I2C</elementname>
 				<elementname>GPS</elementname>
-                		<elementname>AltitudeHold</elementname>
+				<elementname>AltitudeHold</elementname>
 				<elementname>BootFault</elementname>
 				<elementname>TempBaro</elementname>
 				<elementname>GyroBias</elementname>
+				<elementname>ADC</elementname>
 			</elementnames>
 		</field>
 		<field name="ConfigError" units="" type="enum" elements="1" defaultvalue="None">


### PR DESCRIPTION
This adds ADC alarms to the battery module as requested by @kubark42 in #2007. Alarms added are:
* Critical: invalid ADC pin selected for either voltage or current.
* Warning: ADC calibration offset causes negative voltage or current.

These alarms are displayed using the previously unused "ADC In" element in the SystemHealth gadget SVG. The SVG didn't however contain the coloured boxes and error symbol(red cross) so I added these. The linear SVG didn't contain the ADC element so I added it. While editing the linear SVG I also took the liberty of correcting the font on the neighbouring "Altitude Hold" alarm and adding the missing error symbol to it (originally added in 49541da).

In the flight code __negative voltages or currents are clipped to 0__ (after the calibration offset is applied) to ensure we don't encounter undefined behaviour in downstream modules (e.g. telemetry) when they cast the floats to unsigned integers, as mentioned in #2007. The lowest remaining stack space I saw for the Battery task was 60 bytes while trying various combinations of settings, the same as current next without this PR.

The alarms look like this in GCS:
![screenshot from 2015-10-26 16 31 01](https://cloud.githubusercontent.com/assets/9995998/10721403/217bd982-7c08-11e5-8004-813ce596f3d5.png)
Note: the above typo, "Error" instead of "Critical", has been fixed.
![screenshot from 2015-10-26 16 39 27](https://cloud.githubusercontent.com/assets/9995998/10721405/2184770e-7c08-11e5-8438-cb0604e14795.png)
![screenshot from 2015-10-26 16 52 58](https://cloud.githubusercontent.com/assets/9995998/10721406/218908b4-7c08-11e5-99d3-94bca1d684c4.png)
