### PR TITLE
Changed top level makefile to allow compile with MSVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ WHEREAMI := $(dir $(lastword $(MAKEFILE_LIST)))
 ROOT_DIR := $(realpath $(WHEREAMI)/ )
 
 # import macros common to all supported build systems
-include $(CURDIR)/make/system-id.mk
+include $(ROOT_DIR)/make/system-id.mk
 
 # configure some directories that are relative to wherever ROOT_DIR is located
 TOOLS_DIR := $(ROOT_DIR)/tools
@@ -257,6 +257,8 @@ $(BUILD_DIR):
 #
 ##############################
 
+GMAKE?=$(MAKE) --no-print-directory -w 
+
 .PHONY: all_ground
 all_ground: gcs
 
@@ -274,7 +276,7 @@ gcs:  uavobjects
 	$(V1) mkdir -p $(BUILD_DIR)/ground/$@
 	$(V1) ( cd $(BUILD_DIR)/ground/$@ && \
 	  PYTHON=$(PYTHON) $(QMAKE) $(ROOT_DIR)/ground/gcs/gcs.pro -spec $(QT_SPEC) -r CONFIG+="$(GCS_BUILD_CONF) $(GCS_SILENT)" $(GCS_QMAKE_OPTS) && \
-	  $(MAKE) -w ; \
+	  $(GMAKE) ; \
 	)
 
 # Workaround for qmake bug that prevents copying the application icon
@@ -303,7 +305,7 @@ uavobjgenerator:
 	$(V1) mkdir -p $(BUILD_DIR)/ground/$@
 	$(V1) ( cd $(BUILD_DIR)/ground/$@ && \
 	  PYTHON=$(PYTHON) $(QMAKE) $(ROOT_DIR)/ground/uavobjgenerator/uavobjgenerator.pro -spec $(QT_SPEC) -r CONFIG+="debug $(UAVOGEN_SILENT)" && \
-	  $(MAKE) --no-print-directory -w ; \
+	  $(GMAKE); \
 	)
 
 UAVOBJ_XML_DIR := $(ROOT_DIR)/shared/uavobjectdefinition

--- a/make/winx86/.bash_profileMSVC
+++ b/make/winx86/.bash_profileMSVC
@@ -1,0 +1,77 @@
+# bashrc for TauLabs development on Windows using MSVC
+
+QT_VERSION_FULL=5.5.0
+QT_VERSION=`echo "$QT_VERSION_FULL" | cut -d '.' -f1-2`
+QT_BASEDIR="/C/Qt"
+
+if [ -d "$QT_BASEDIR/Qt$QT_VERSION_FULL" ] ; then
+  QT_BASEDIR="$QT_BASEDIR/Qt$QT_VERSION_FULL"
+fi
+
+CROSS_COMPILE=false
+if [ $(uname -m)="x86_64" ]; then
+  VS_PLATFORM="amd64"
+  WK_PLATFORM="x64"
+  VC_PLATFORM="/amd64"
+  if [ $CROSS_COMPILE = true ]; then
+    VS_PLATFORM="amd64_x86"
+    WK_PLATFORM="x86"
+    VC_PLATFORM=""
+  fi
+else
+  VS_PLATFORM="x86"
+  WK_PLATFORM="x86"
+  VC_PLATFORM=""
+  if [ $CROSS_COMPILE = true ]; then
+    VS_PLATFORM="x86_amd64"
+    WK_PLATFORM="x64"
+    VC_PLATFORM="/amd64"
+  fi
+fi
+
+QT_MSVCVER="msvc2013_64"
+QT_MINGWVER="mingw492_32"
+
+VS_PATH="/C/Program Files (x86)/Microsoft Visual Studio 12.0"
+VS_INCLUDE_PATH="C:/Program Files (x86)/Microsoft Visual Studio 12.0"
+WK_PATH="/C/Program Files (x86)/Windows Kits/8.1"
+WK_INCLUDE_PATH="C:/Program Files (x86)/Windows Kits/8.1"
+
+test_and_add_to_path ()
+{
+  if which $2 >/dev/null 2>&1 ; then
+    return
+  fi
+
+  if [ -f "$1/$2" ] ; then
+    PATH=$1\:$PATH
+    return
+  fi
+}
+test_and_add_to_path "$QT_BASEDIR/Tools/$QT_MINGWVER/bin" "mingw32-make.exe"
+PATH="$QT_BASEDIR/$QT_VERSION/$QT_MSVCVER/bin"\:$PATH
+PATH="$VS_PATH/VC/BIN/$VS_PLATFORM"\:$PATH
+test_and_add_to_path "$VS_PATH/VC/VCPackages" "VCProject.dll"
+PATH="$VS_PATH/VC/include"\:$PATH
+test_and_add_to_path "$QT_BASEDIR/Tools/QtCreator/bin" "jom.exe"
+test_and_add_to_path "$WK_PATH/bin/$WK_PLATFORM" "rc.exe"
+
+test_and_add_to_path "/C/Python27" "python.exe"
+test_and_add_to_path "/C/OpenOCD/0.4.0/bin/" "openocd.exe"
+test_and_add_to_path "/C/Program Files/NSIS/Unicode" "makensis.exe"
+test_and_add_to_path "/C/Program Files (x86)/NSIS/Unicode" "makensis.exe"
+
+
+if ! which make >/dev/null 2>&1 ; then
+  alias make=mingw32-make
+fi
+
+export INCLUDE="$VS_INCLUDE_PATH/VC/INCLUDE;$VS_INCLUDE_PATH/VC/ATLMFC/INCLUDE;$WK_INCLUDE_PATH/include/shared;$WK_INCLUDE_PATH/include/um;$WK_INCLUDE_PATH/include/winrt;"
+export LIB="$VS_INCLUDE_PATH/VC/LIB$VC_PLATFORM;$VS_INCLUDE_PATH/VC/ATLMFC/LIB$VC_PLATFORM;$WK_INCLUDE_PATH/lib/winv6.3/um/$WK_PLATFORM;"
+export LIBPATH="$VS_INCLUDE_PATH/VC/LIB$VC_PLATFORM;$VS_INCLUDE_PATH/VC/ATLMFC/LIB$VC_PLATFORM;$WK_INCLUDE_PATH/References/CommonConfiguration/Neutral;/C/Program Files (x86)/Microsoft SDKs/Windows/v8.1/ExtensionSDKs/Microsoft.VCLibs/12.0/References/CommonConfiguration/neutral;"
+export MACHINE_TYPE=$(uname -m)
+export VCINSTALLDIR=$VS_INCLUDE_PATH
+export GMAKE="MAKEFLAGS= jom -j3"
+#-call :which UNSIS         "%ProgramFiles%\NSIS\Unicode"  makensis.exe
+
+#echo $PATH


### PR DESCRIPTION
Gnu make can't be used with MSVC so this change makes the top level makefile use "jom" for the gcs targets.
This also adds a .bash_profileMSVC file which needs to be renamed and used instead of the "normal" .bash_profile.

This needs to be used with Qt with msvc2013 options, and  VS2013 community (free https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx).

P.S.-This was only tested on a 64bit machine
P.S.2.-VS2015 is now available, changes need to be made to the .bash_profile paths to make that work.
P.S.3-MSVC builds are currently broken, I'm working on a set of fixes.

EDIT: Builds need to use QT_SPEC=win32-msvc2013 (e.g. make gcs QT_SPEC=win32-msvc2013 V=1)
-jX switch is not passed to jom. jom is supposed to use the appropriate number of processes, if one want's to force X just edit the GMAKE exported var on the bash_profile file. 