### PR TITLE
Make: UAVO library fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ uavobjects: uavobjgenerator
 uavobjects_test: uavobjgenerator
 	$(V1) $(UAVOBJGENERATOR) -v -none $(UAVOBJ_XML_DIR) $(ROOT_DIR)
 
-uavobjects_clean:
+uavobjects_clean: uavobjects_armsoftfp_clean uavobjects_armhardfp_clean
 	$(V0) @echo " CLEAN      $@"
 	$(V1) [ ! -d "$(UAVOBJ_OUT_DIR)" ] || $(RM) -r "$(UAVOBJ_OUT_DIR)"
 
@@ -816,11 +816,14 @@ ifneq ($(word 2,$(MAKECMDGOALS)),)
 export ENABLE_MSG_EXTRA := yes
 endif
 
+UAVOLIB_SOFT_OUT_DIR = $(BUILD_DIR)/uavobjects_armsoftfp
+UAVOLIB_HARD_OUT_DIR = $(BUILD_DIR)/uavobjects_armhardfp
+
 uavobjects_armsoftfp: TARGET=uavobjects_armsoftfp
-uavobjects_armsoftfp: OUTDIR=$(BUILD_DIR)/$(TARGET)
+uavobjects_armsoftfp: OUTDIR=$(UAVOLIB_SOFT_OUT_DIR)
 
 uavobjects_armhardfp: TARGET=uavobjects_armhardfp
-uavobjects_armhardfp: OUTDIR=$(BUILD_DIR)/$(TARGET)
+uavobjects_armhardfp: OUTDIR=$(UAVOLIB_HARD_OUT_DIR)
 
 uavobjects_%: uavobjects
 	$(V1) mkdir -p $(OUTDIR)/dep
@@ -842,6 +845,15 @@ uavobjects_%: uavobjects
 		OPUAVSYNTHDIR=$(OPUAVSYNTHDIR) \
 		\
 		$@
+
+.PHONY: uavobjects_armsoftfp_clean uavobjects_armhardfp_clean
+uavobjects_armsoftfp_clean:
+	$(V0) @echo " CLEAN      $@"
+	$(V1) [ ! -d "$(UAVOLIB_SOFT_OUT_DIR)" ] || $(RM) -r "$(UAVOLIB_SOFT_OUT_DIR)"
+
+uavobjects_armhardfp_clean:
+	$(V0) @echo " CLEAN      $@"
+	$(V1) [ ! -d "$(UAVOLIB_HARD_OUT_DIR)" ] || $(RM) -r "$(UAVOLIB_HARD_OUT_DIR)"
 
 # $(1) = Canonical board name all in lower case (e.g. coptercontrol)
 define BOARD_PHONY_TEMPLATE
@@ -883,7 +895,7 @@ EF_TARGETS := $(addprefix ef_, $(EF_BOARDS))
 
 .PHONY: all_fw all_fw_clean
 all_fw:        $(addsuffix _tlfw,  $(FW_TARGETS))
-all_fw_clean:  $(addsuffix _clean, $(FW_TARGETS))
+all_fw_clean:  $(addsuffix _clean, $(FW_TARGETS)) uavobjects_armsoftfp_clean uavobjects_armhardfp_clean
 
 .PHONY: all_bl all_bl_clean
 all_bl:        $(addsuffix _bin,   $(BL_TARGETS))

--- a/flight/uavobjectlib/Makefile
+++ b/flight/uavobjectlib/Makefile
@@ -69,5 +69,6 @@ NO_AUTO_UAVO = YES
 include $(MAKE_INC_DIR)/firmware-common.mk
 
 $(OUTDIR)/libuavobject.a: $(ALLOBJ)
-	$(AR) rs $@ $?
+	@echo $(MSG_AR) $(call toprel, $@)
+	$(V1) $(AR) crs $@ $?
 

--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -73,6 +73,7 @@ MSG_JTAG_WIPE        = ${quote} JTAG-WIPE $(MSG_EXTRA) ${quote}
 MSG_PADDING          = ${quote} PADDING   $(MSG_EXTRA) ${quote}
 MSG_FLASH_IMG        = ${quote} FLASH_IMG $(MSG_EXTRA) ${quote}
 MSG_GCOV             = ${quote} GCOV      $(MSG_EXTRA) ${quote}
+MSG_AR               = ${quote} AR        $(MSG_EXTRA) ${quote}
 
 toprel = $(subst $(realpath $(ROOT_DIR))/,,$(abspath $(1)))
 


### PR DESCRIPTION
This addresses some of the issues created by #1985. Specifically:
* ar output is suppressed
* UAVO libs are cleaned by all_fw_clean and uavobjects_clean

I think it makes sense to clean them with all_fw_clean since the fw targets cause them to be generated but also by uavobjects_clean since they are after all UAVOs. Thoughts?