### PR TITLE
Throttled UAVO Events

### DIFF
--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -292,6 +292,23 @@ float linear_interpolate(float const input, float const * curve, uint8_t num_poi
 }
 
 
+/**
+ * Return a psedorandom integer from 0 to interval
+ * Based on the Park-Miller-Carta Pseudo-Random Number Generator
+ * http://www.firstpr.com.au/dsp/rand31/
+ */
+uint16_t randomize_int(uint16_t interval)
+{
+	static uint32_t seed = 1;
+	uint32_t hi, lo;
+	lo = 16807 * (seed & 0xFFFF);
+	hi = 16807 * (seed >> 16);
+	lo += (hi & 0x7FFF) << 16;
+	lo += hi >> 15;
+	if (lo > 0x7FFFFFFF) lo -= 0x7FFFFFFF;
+	seed = lo;
+	return (uint16_t)( ((float)interval * (float)lo) / (float)0x7FFFFFFF );
+}
 
 /**
  * @}

--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -65,6 +65,7 @@ void vector2_rotate(const float *original, float *out, float angle);
 float cubic_deadband(float in, float w, float b, float m, float r);
 void cubic_deadband_setup(float w, float b, float *m, float *r);
 float linear_interpolate(float const input, float const * curve, uint8_t num_points, const float input_min, const float input_max);
+uint16_t randomize_int(uint16_t interval);
 
 /* Note--- current compiler chain has been verified to produce proper call
  * to fpclassify even when compiling with -ffast-math / -ffinite-math.

--- a/flight/UAVObjects/eventdispatcher.c
+++ b/flight/UAVObjects/eventdispatcher.c
@@ -33,6 +33,7 @@
 #include "pios_mutex.h"
 #include "pios_thread.h"
 #include "pios_queue.h"
+#include "misc_math.h"
 
 // Private constants
 #if defined(PIOS_EVENTDISAPTCHER_QUEUE)
@@ -85,7 +86,6 @@ static int32_t processPeriodicUpdates();
 static void eventTask();
 static int32_t eventPeriodicCreate(UAVObjEvent* ev, UAVObjEventCallback cb, struct pios_queue *queue, uint16_t periodMs);
 static int32_t eventPeriodicUpdate(UAVObjEvent* ev, UAVObjEventCallback cb, struct pios_queue *queue, uint16_t periodMs);
-static uint16_t randomizePeriod(uint16_t periodMs);
 
 
 /**
@@ -239,7 +239,7 @@ static int32_t eventPeriodicCreate(UAVObjEvent* ev, UAVObjEventCallback cb, stru
 	objEntry->evInfo.cb = cb;
 	objEntry->evInfo.queue = queue;
     objEntry->updatePeriodMs = periodMs;
-    objEntry->timeToNextUpdateMs = randomizePeriod(periodMs); // avoid bunching of updates
+    objEntry->timeToNextUpdateMs = randomize_int(periodMs); // avoid bunching of updates
     // Add to list
     LL_APPEND(objList, objEntry);
 	// Release lock
@@ -271,7 +271,7 @@ static int32_t eventPeriodicUpdate(UAVObjEvent* ev, UAVObjEventCallback cb, stru
 		{
 			// Object found, update period
 			objEntry->updatePeriodMs = periodMs;
-			objEntry->timeToNextUpdateMs = randomizePeriod(periodMs); // avoid bunching of updates
+			objEntry->timeToNextUpdateMs = randomize_int(periodMs); // avoid bunching of updates
 			// Release lock
 			PIOS_Recursive_Mutex_Unlock(mutex);
 			return 0;
@@ -381,24 +381,6 @@ static int32_t processPeriodicUpdates()
     // Done
     PIOS_Recursive_Mutex_Unlock(mutex);
     return timeToNextUpdate;
-}
-
-/**
- * Return a psedorandom integer from 0 to periodMs
- * Based on the Park-Miller-Carta Pseudo-Random Number Generator
- * http://www.firstpr.com.au/dsp/rand31/
- */
-static uint16_t randomizePeriod(uint16_t periodMs)
-{
-	static uint32_t seed = 1;
-	uint32_t hi, lo;
-	lo = 16807 * (seed & 0xFFFF);
-	hi = 16807 * (seed >> 16);
-	lo += (hi & 0x7FFF) << 16;
-	lo += hi >> 15;
-	if (lo > 0x7FFFFFFF) lo -= 0x7FFFFFFF;
-	seed = lo;
-	return (uint16_t)( ((float)periodMs * (float)lo) / (float)0x7FFFFFFF );
 }
 
 /**

--- a/flight/UAVObjects/inc/uavobjectmanager.h
+++ b/flight/UAVObjects/inc/uavobjectmanager.h
@@ -92,7 +92,7 @@ typedef enum {
 	EV_UPDATED_MANUAL = 0x04, /** Object update event manually generated */
 	EV_UPDATED_PERIODIC = 0x08, /** Object update from periodic event */
 	EV_UPDATE_REQ = 0x10, /** Request to update object data */
-	EV_UPDATED_THROTTLED_DIRTY = 0x80 /** Indicates a throttled object has been updated but not sent **/
+	EV_UPDATED_THROTTLED_DIRTY = 0x20 /** Indicates a throttled object has been updated but not sent **/
 } UAVObjEventType;
 
 /**
@@ -199,7 +199,9 @@ void UAVObjSetTelemetryGcsUpdateMode(UAVObjMetadata* dataOut, UAVObjUpdateMode v
 int8_t UAVObjReadOnly(UAVObjHandle obj);
 int32_t UAVObjConnectQueue(UAVObjHandle obj_handle, struct pios_queue *queue, uint8_t eventMask);
 int32_t UAVObjDisconnectQueue(UAVObjHandle obj_handle, struct pios_queue *queue);
+int32_t UAVObjConnectQueueThrottled(UAVObjHandle obj_handle, struct pios_queue *queue, uint8_t eventMask, uint16_t interval);
 int32_t UAVObjConnectCallback(UAVObjHandle obj_handle, UAVObjEventCallback cb, uint8_t eventMask);
+int32_t UAVObjConnectCallbackThrottled(UAVObjHandle obj_handle, UAVObjEventCallback cb, uint8_t eventMask, uint16_t interval);
 int32_t UAVObjDisconnectCallback(UAVObjHandle obj_handle, UAVObjEventCallback cb);
 void UAVObjRequestUpdate(UAVObjHandle obj);
 void UAVObjRequestInstanceUpdate(UAVObjHandle obj_handle, uint16_t instId);

--- a/flight/UAVObjects/inc/uavobjectmanager.h
+++ b/flight/UAVObjects/inc/uavobjectmanager.h
@@ -92,7 +92,7 @@ typedef enum {
 	EV_UPDATED_MANUAL = 0x04, /** Object update event manually generated */
 	EV_UPDATED_PERIODIC = 0x08, /** Object update from periodic event */
 	EV_UPDATE_REQ = 0x10, /** Request to update object data */
-	EV_UPDATED_THROTTLED_DIRTY = 0x20 /** Indicates a throttled object has been updated but not sent **/
+	EV_UPDATED_THROTTLED_DIRTY = 0x40 /** Indicates a throttled object has been updated but not sent **/
 } UAVObjEventType;
 
 /**

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -61,7 +61,7 @@ struct ObjectEventEntry {
 };
 
 struct ObjectEventEntryThrottled {
-	struct ObjectEventEntry   entry;
+	struct ObjectEventEntry   entry; // MUST be frist! So throttled entry can be interpreted as ObjectEventEntry
 
 	uint32_t                  due;
 	uint16_t                  interval;
@@ -1677,6 +1677,7 @@ static int32_t sendEvent(struct UAVOBase * obj, uint16_t instId,
 		if (event->eventMask == 0
 			|| (event->eventMask & triggered_event) != 0) {
 			if (event->hasThrottle) {
+				// This is a throttled event (triggered with a spacing of at least "interval" ms)
 				struct ObjectEventEntryThrottled *throtInfo =
 					(struct ObjectEventEntryThrottled *) event;
 

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -61,7 +61,7 @@ struct ObjectEventEntry {
 };
 
 struct ObjectEventEntryThrottled {
-	struct ObjectEventEntry   entry; // MUST be frist! So throttled entry can be interpreted as ObjectEventEntry
+	struct ObjectEventEntry   entry; // MUST be first! So throttled entry can be interpreted as ObjectEventEntry
 
 	uint32_t                  due;
 	uint16_t                  interval;

--- a/flight/targets/discoveryf4/fw/Makefile
+++ b/flight/targets/discoveryf4/fw/Makefile
@@ -81,6 +81,8 @@ SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
 #endif
 
+SRC += $(MATHLIB)/misc_math.c
+
 SRC += $(FLIGHTLIB)/fifo_buffer.c
 SRC += $(FLIGHTLIB)/taskmonitor.c
 


### PR DESCRIPTION
As discussed in #1928, this add the option to add a minimum interval to callbacks and queue connections. This should be useful for things like logging or telemetry where we are only interested in updates at a slow rate. Handling this in the UAVO manager should be more efficient than discarding the unwanted events in the callback.

Credit goes to @mlyle for [figuring out a way](https://github.com/TauLabs/TauLabs/pull/1928#discussion_r41660621) to implement this without needing more memory for callbacks without throttling. 
