### PR TITLE
Logging Module Improvements V2 (WIP)

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -30,36 +30,27 @@
 #include "openpilot.h"
 #include "modulesettings.h"
 #include "pios_thread.h"
+#include "pios_queue.h"
+#include "pios_mutex.h"
+#include "uavobjectmanager.h"
+#include "misc_math.h"
 #include "timeutils.h"
 #include "uavobjectmanager.h"
 
 #include "pios_streamfs.h"
 #include <pios_board_info.h>
 
-#include "airspeedactual.h"
-#include "attitudeactual.h"
-#include "accels.h"
-#include "actuatorcommand.h"
 #include "flightstatus.h"
-#include "gyros.h"
-#include "baroaltitude.h"
-#include "flightstatus.h"
-#include "gpsposition.h"
-#include "gpstime.h"
-#include "gpssatellites.h"
-#include "magnetometer.h"
-#include "manualcontrolcommand.h"
-#include "positionactual.h"
 #include "loggingsettings.h"
 #include "loggingstats.h"
-#include "velocityactual.h"
-#include "waypoint.h"
-#include "waypointactive.h"
 
 // Private constants
 #define STACK_SIZE_BYTES 1200
 #define TASK_PRIORITY PIOS_THREAD_PRIO_LOW
 const char DIGITS[16] = "0123456789abcdef";
+
+#define LOGGING_PERIOD_MS 10
+#define LOGGING_QUEUE_SIZE 64
 
 // Private types
 
@@ -68,16 +59,16 @@ static UAVTalkConnection uavTalkCon;
 static struct pios_thread *loggingTaskHandle;
 static bool module_enabled;
 static LoggingSettingsData settings;
-static bool flightstatus_updated = false;
-static bool waypoint_updated = false;
+static LoggingStatsData loggingData;
+struct pios_queue *logging_queue;
+static struct pios_recursive_mutex *mutex;
 
 // Private functions
 static void    loggingTask(void *parameters);
 static int32_t send_data(uint8_t *data, int32_t length);
+static void register_object(UAVObjHandle obj);
 static void logSettings(UAVObjHandle obj);
 static void SettingsUpdatedCb(UAVObjEvent * ev);
-static void FlightStatusUpdatedCb(UAVObjEvent * ev);
-static void WaypointActiveUpdatedCb(UAVObjEvent * ev);
 static void writeHeader();
 
 // Local variables
@@ -147,6 +138,21 @@ int32_t LoggingStart(void)
 		return -1;
 	}
 
+	// create logging queue
+	logging_queue = PIOS_Queue_Create(LOGGING_QUEUE_SIZE, sizeof(UAVObjEvent));
+	if (!logging_queue){
+		return -1;
+	}
+
+	// Create mutex
+	mutex = PIOS_Recursive_Mutex_Create();
+	if (mutex == NULL){
+		return -2;
+	}
+
+	// Process all registered objects and connect queue for updates
+	UAVObjIterate(&register_object);
+
 	// Start logging task
 	loggingTaskHandle = PIOS_Thread_Create(loggingTask, "Logging", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 
@@ -159,11 +165,13 @@ MODULE_INITCALL(LoggingInitialize, LoggingStart);
 
 static void loggingTask(void *parameters)
 {
+	UAVObjEvent ev;
+
 	bool armed = false;
-	bool write_open = false;
-	bool first_run = true;
+	uint32_t now = PIOS_Thread_Systime();
 	
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+	bool write_open = false;
 	bool read_open = false;
 	int32_t read_sector = 0;
 	uint8_t read_data[LOGGINGSTATS_FILESECTOR_NUMELEM];
@@ -173,12 +181,6 @@ static void loggingTask(void *parameters)
 	LoggingSettingsGet(&settings);
 	LoggingSettingsConnectCallback(SettingsUpdatedCb);
 
-	// Connect callbacks for UAVOs being logged on change
-	FlightStatusConnectCallback(FlightStatusUpdatedCb);
-	if (WaypointActiveHandle())
-		WaypointActiveConnectCallback(WaypointActiveUpdatedCb);
-
-	LoggingStatsData loggingData;
 	LoggingStatsGet(&loggingData);
 	loggingData.BytesLogged = 0;
 	
@@ -191,55 +193,16 @@ static void loggingTask(void *parameters)
 #endif
 
 	if (settings.LogBehavior == LOGGINGSETTINGS_LOGBEHAVIOR_LOGONSTART) {
-		loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
-		write_open = true;
-		first_run = true;
-
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-		if (destination_spi_flash)
-		{
-			if (PIOS_STREAMFS_OpenWrite(streamfs_id) != 0) 
-			{
-				loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
-				write_open = false;
-				first_run = false;
-			} 
-		}
-#endif
-
+		loggingData.Operation = LOGGINGSTATS_OPERATION_INITIALIZING;
 	} else {
 		loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
 	}
 
 	LoggingStatsSet(&loggingData);
 
-	int i = 0;
-
 	// Loop forever
 	while (1) 
 	{
-
-		// Sleep for some time depending on logging rate
-		switch(settings.MaxLogRate){
-			case LOGGINGSETTINGS_MAXLOGRATE_5:
-				PIOS_Thread_Sleep(200);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_10:
-				PIOS_Thread_Sleep(100);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_25:
-				PIOS_Thread_Sleep(40);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_50:
-				PIOS_Thread_Sleep(20);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_100:
-				PIOS_Thread_Sleep(10);
-				break;
-			default:
-				PIOS_Thread_Sleep(1000);
-		}
-
 		LoggingStatsGet(&loggingData);
 
 		// Check for change in armed state if logging on armed
@@ -250,7 +213,7 @@ static void loggingTask(void *parameters)
 
 			if (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED && !armed) {
 				// Start logging because just armed
-				loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
+				loggingData.Operation = LOGGINGSTATS_OPERATION_INITIALIZING;
 				armed = true;
 				LoggingStatsSet(&loggingData);
 			} else if (flightStatus.Armed == FLIGHTSTATUS_ARMED_DISARMED && armed) {
@@ -260,128 +223,82 @@ static void loggingTask(void *parameters)
 			}
 		}
 
-		///////////////////////////////////////////////////////////////////////
-		
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-		if (destination_spi_flash) {
-			if (loggingData.Operation == LOGGINGSTATS_OPERATION_LOGGING && read_open) { // If currently downloading a log, close the file
-				PIOS_STREAMFS_Close(streamfs_id);
-				read_open = false;
-			}
-		}
-#endif
-
-		if (loggingData.Operation == LOGGINGSTATS_OPERATION_LOGGING && !write_open) {
-			write_open = true;
-			
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-			if (destination_spi_flash) {
-				if (PIOS_STREAMFS_OpenWrite(streamfs_id) != 0) {
-					loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
-					write_open = false;
-				} 
-			
-				loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
-				loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
-				LoggingStatsSet(&loggingData);
-			}
-#endif
-		} else if (loggingData.Operation != LOGGINGSTATS_OPERATION_LOGGING && write_open) {
-			write_open = false;
-			
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-			if (destination_spi_flash) {
-				PIOS_STREAMFS_Close(streamfs_id);
-				loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
-				loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
-				LoggingStatsSet(&loggingData);
-			}
-#endif
-		}
-
 		switch (loggingData.Operation) {
-		case LOGGINGSTATS_OPERATION_LOGGING:
-			if (!write_open)
-				continue;
-
-			if (first_run){
-				// Write information at start of the log file
-				writeHeader();
-
-				// Log settings
-				if (settings.LogSettingsOnStart == LOGGINGSETTINGS_LOGSETTINGSONSTART_TRUE){
-					UAVObjIterate(&logSettings);
+		case LOGGINGSTATS_OPERATION_FORMAT:
+			// Format the file system
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+			if (destination_spi_flash){
+				if (read_open || write_open) {
+					PIOS_STREAMFS_Close(streamfs_id);
+					read_open = false;
+					write_open = false;
 				}
 
-				// Log some data objects that are unlikely to change during flight
-				// Waypoints
-				if (WaypointHandle()){
-					for (int i = 0; i < UAVObjGetNumInstances(WaypointHandle()); i++) {
-						UAVTalkSendObjectTimestamped(uavTalkCon, WaypointHandle(), i, false, 0);
+				PIOS_STREAMFS_Format(streamfs_id);
+			}
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
+			loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
+			LoggingStatsSet(&loggingData);
+			break;
+		case LOGGINGSTATS_OPERATION_INITIALIZING:
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+			if (destination_spi_flash){
+				// Close the file if it is open for reading
+				if (read_open) {
+					PIOS_STREAMFS_Close(streamfs_id);
+					read_open = false;
+				}
+				// Open the file if it is not open for writing
+				if (!write_open) {
+					if (PIOS_STREAMFS_OpenWrite(streamfs_id) != 0) {
+						loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
+						continue;
+					} else {
+						write_open = true;
 					}
+					loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
+					loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
+					LoggingStatsSet(&loggingData);
 				}
+			}
+			else {
+				read_open = false;
+				write_open = true;
+			}
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
 
-				// Trigger logging for objects that are logged on change
-				flightstatus_updated = true;
-				waypoint_updated = true;
+			// Write information at start of the log file
+			writeHeader();
 
-				first_run = false;
+			// Log settings
+			if (settings.LogSettingsOnStart == LOGGINGSETTINGS_LOGSETTINGSONSTART_TRUE){
+				UAVObjIterate(&logSettings);
 			}
 
-			// Log objects on change
-			if (flightstatus_updated){
-				UAVTalkSendObjectTimestamped(uavTalkCon, FlightStatusHandle(), 0, false, 0);
-				flightstatus_updated = false;
-			}
-
-			if (waypoint_updated && WaypointActiveHandle()){
-				UAVTalkSendObjectTimestamped(uavTalkCon, WaypointActiveHandle(), 0, false, 0);
-				waypoint_updated = false;
-			}
-
-			// Log very fast
-			UAVTalkSendObjectTimestamped(uavTalkCon, AccelsHandle(), 0, false, 0);
-			UAVTalkSendObjectTimestamped(uavTalkCon, GyrosHandle(), 0, false, 0);
-
-			// Log a bit slower
-			if ((i % 2) == 0) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, AttitudeActualHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, MagnetometerHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, ManualControlCommandHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, ActuatorCommandHandle(), 0, false, 0);
-			}
-
-			// Log slower
-			if ((i % 10) == 1) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, BaroAltitudeHandle(), 0, false, 0);
-				if (AirspeedActualHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, AirspeedActualHandle(), 0, false, 0);
-				if (GPSPositionHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, GPSPositionHandle(), 0, false, 0);
-				if (PositionActualHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, PositionActualHandle(), 0, false, 0);
-				if (VelocityActualHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, VelocityActualHandle(), 0, false, 0);
-			}
-
-			// Log slow
-			if ((i % 50) == 2 && GPSTimeHandle()) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, GPSTimeHandle(), 0, false, 0);
-			}
-
-			// Log very slow
-			if ((i % 500) == 3 && GPSSatellitesHandle()) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, GPSSatellitesHandle(), 0, false, 0);
-			}
+			// Empty the queue
+			while(PIOS_Queue_Receive(logging_queue, &ev, 0))
 
 			LoggingStatsBytesLoggedSet(&written_bytes);
-
+			loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
+			LoggingStatsSet(&loggingData);
 			break;
+		case LOGGINGSTATS_OPERATION_LOGGING:
+			{
+				// Sleep between writing
+				PIOS_Thread_Sleep_Until(&now, LOGGING_PERIOD_MS);
 
+				// Log the objects registred to the shared queue
+				while (PIOS_Queue_Receive(logging_queue, &ev, 0) == true) {
+					UAVTalkSendObjectTimestamped(uavTalkCon, ev.obj, ev.instId, false, 0);
+				}
+				LoggingStatsBytesLoggedSet(&written_bytes);
+
+				now = PIOS_Thread_Systime();
+			}
+			break;
 		case LOGGINGSTATS_OPERATION_DOWNLOAD:
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-			if (destination_spi_flash)
-			{
+			if (destination_spi_flash) {
 				if (!read_open) {
 					// Start reading
 					if (PIOS_STREAMFS_OpenRead(streamfs_id, loggingData.FileRequest) != 0) {
@@ -391,25 +308,21 @@ static void loggingTask(void *parameters)
 						read_sector = -1;
 					}
 				}
-
 				if (read_open && read_sector == loggingData.FileSectorNum) {
 					// Request received for same sector. Reupdate.
 					memcpy(loggingData.FileSector, read_data, LOGGINGSTATS_FILESECTOR_NUMELEM);
 					loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
 				} else if (read_open && (read_sector + 1) == loggingData.FileSectorNum) {
 					int32_t bytes_read = PIOS_COM_ReceiveBuffer(logging_com_id, read_data, LOGGINGSTATS_FILESECTOR_NUMELEM, 1);
-
 					if (bytes_read < 0 || bytes_read > LOGGINGSTATS_FILESECTOR_NUMELEM) {
 						// close on error
 						loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
 						PIOS_STREAMFS_Close(streamfs_id);
 						read_open = false;
 					} else if (bytes_read < LOGGINGSTATS_FILESECTOR_NUMELEM) {
-
 						// Check it has really run out of bytes by reading again
 						int32_t bytes_read2 = PIOS_COM_ReceiveBuffer(logging_com_id, &read_data[bytes_read], LOGGINGSTATS_FILESECTOR_NUMELEM - bytes_read, 1);
 						memcpy(loggingData.FileSector, read_data, LOGGINGSTATS_FILESECTOR_NUMELEM);
-
 						if ((bytes_read + bytes_read2) < LOGGINGSTATS_FILESECTOR_NUMELEM) {
 							// indicate end of file
 							loggingData.Operation = LOGGINGSTATS_OPERATION_COMPLETE;
@@ -426,27 +339,93 @@ static void loggingTask(void *parameters)
 					}
 					read_sector = loggingData.FileSectorNum;
 				}
-				LoggingStatsSet(&loggingData);		
+				LoggingStatsSet(&loggingData);
 			}
-#endif
-			break;
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
+
+			// fall-through to default case
+		default:
+			//  Makes sure that we are not hogging the processor
+			PIOS_Thread_Sleep(10);
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+			if (destination_spi_flash) {
+				// Close the file if necessary
+				if (write_open) {
+					PIOS_STREAMFS_Close(streamfs_id);
+					loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
+					loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
+					LoggingStatsSet(&loggingData);
+					write_open = false;
+				}
+			}
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
 		}
-        
-		i++;
 	}
 }
-
 
 /**
  * Log all settings objects
  * \param[in] obj Object to log
- */
+*/
 static void logSettings(UAVObjHandle obj)
 {
 	if (UAVObjIsSettings(obj)) {
 		UAVTalkSendObjectTimestamped(uavTalkCon, obj, 0, false, 0);
 	}
 }
+
+/**
+ * Forward data from UAVTalk out the serial port
+ * \param[in] data Data buffer to send
+ * \param[in] length Length of buffer
+ * \return -1 on failure
+ * \return number of bytes transmitted on success
+ */
+static int32_t send_data(uint8_t *data, int32_t length)
+{
+	if( PIOS_COM_SendBuffer(logging_com_id, data, length) < 0)
+		return -1;
+
+	written_bytes += length;
+
+	return length;
+}
+
+/**
+ * @brief Callback for adding an object to the logging queue
+ * @param ev the event
+ */
+static void obj_updated_callback(UAVObjEvent * ev)
+{
+	if (loggingData.Operation != LOGGINGSTATS_OPERATION_LOGGING){
+		// We are not logging, so all events are discarded
+		return;
+	}
+	PIOS_Recursive_Mutex_Lock(mutex, PIOS_MUTEX_TIMEOUT_MAX);
+	PIOS_Queue_Send(logging_queue, ev, 0);
+	PIOS_Recursive_Mutex_Unlock(mutex);
+}
+
+/**
+ * Register a new object, adds object to local list and connects the update callback
+ * \param[in] obj Object to connect
+ */
+static void register_object(UAVObjHandle obj)
+{
+	// check whether we want to log this object
+	UAVObjMetadata meta_data;
+	if (UAVObjGetMetadata(obj, &meta_data) < 0){
+		return;
+	}
+
+	if (meta_data.loggingUpdatePeriod == 0){
+		return;
+	}
+
+	uint16_t interval = MAX(meta_data.loggingUpdatePeriod, LOGGING_PERIOD_MS);
+	UAVObjConnectCallbackThrottled(obj, obj_updated_callback, EV_UPDATED | EV_UNPACKED, interval);
+}
+
 
 /**
  * Write log file header
@@ -503,40 +482,6 @@ static void writeHeader()
 static void SettingsUpdatedCb(UAVObjEvent * ev)
 {
 	LoggingSettingsGet(&settings);
-}
-
-
-/**
- * Callback triggered when FlightStatus is updated
- */
-static void FlightStatusUpdatedCb(UAVObjEvent * ev)
-{
-	flightstatus_updated = true;
-}
-
-/**
- * Callback triggered when WaypointActive is updated
- */
-static void WaypointActiveUpdatedCb(UAVObjEvent * ev)
-{
-	waypoint_updated = true;
-}
-
-/**
- * Forward data from UAVTalk out the serial port
- * \param[in] data Data buffer to send
- * \param[in] length Length of buffer
- * \return -1 on failure
- * \return number of bytes transmitted on success
- */
-static int32_t send_data(uint8_t *data, int32_t length)
-{
-	if( PIOS_COM_SendBuffer(logging_com_id, data, length) < 0)
-		return -1;
-
-	written_bytes += length;
-
-	return length;
 }
 
 /**

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -135,7 +135,7 @@ struct streamfs_footer {
  * @return 0 if success, < 0 on failure
  * @note Must be called while holding the flash transaction lock
  */
-static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint16_t arena_id)
+static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint32_t arena_id)
 {
 	uintptr_t arena_addr = streamfs_get_addr(streamfs, arena_id, 0);
 
@@ -155,9 +155,9 @@ static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint1
  */
 static int32_t streamfs_erase_all_arenas(const struct streamfs_state *streamfs)
 {
-	uint16_t num_arenas = streamfs->partition_size / streamfs->cfg->arena_size;
+	uint32_t num_arenas = streamfs->partition_size / streamfs->cfg->arena_size;
 
-	for (uint16_t arena = 0; arena < num_arenas; arena++) {
+	for (uint32_t arena = 0; arena < num_arenas; arena++) {
 		if (streamfs_erase_arena(streamfs, arena) != 0)
 			return -1;
 	}
@@ -213,8 +213,20 @@ static int32_t streamfs_new_sector(struct streamfs_state *streamfs)
 	streamfs->active_file_arena_offset = 0;
 	streamfs->active_file_segment++;
 
-	if (streamfs_erase_arena(streamfs, streamfs->active_file_arena) != 0) {
+	// Test whether the sector has already been erased by checking the footer
+	start_address = streamfs_get_addr(streamfs, streamfs->active_file_arena,
+			                          streamfs->cfg->arena_size - sizeof(footer));
+	if (PIOS_FLASH_read_data(streamfs->partition_id, start_address, (uint8_t *) &footer, sizeof(footer)) != 0) {
 		return -2;
+	}
+
+	for (int i=0; i < sizeof(footer); i++) {
+		if (((uint8_t*)&footer)[i] != 0xFF) {
+			if (streamfs_erase_arena(streamfs, streamfs->active_file_arena) != 0) {
+				return -3;
+			}
+			break;
+		}
 	}
 
 	return 0;

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -110,7 +110,7 @@ struct streamfs_state {
  * @brief Return the offset in flash of a particular slot within an arena
  * @return address of the requested slot
  */
-static uintptr_t streamfs_get_addr(const struct streamfs_state *streamfs, uint16_t arena_id, uint16_t arena_offset)
+static uintptr_t streamfs_get_addr(const struct streamfs_state *streamfs, uint32_t arena_id, uint16_t arena_offset)
 {
 	PIOS_Assert(arena_id < (streamfs->partition_size / streamfs->cfg->arena_size));
 	PIOS_Assert(arena_offset < streamfs->cfg->arena_size);

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -4,7 +4,6 @@
 		<field name="LogDestination" units="" type="enum" options="SPIFlash,OpenLog" elements="1" defaultvalue="OpenLog"/>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
 		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
-		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100" elements="1" defaultvalue="25"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/loggingstats.xml
+++ b/shared/uavobjectdefinition/loggingstats.xml
@@ -5,7 +5,7 @@
 	<field name="MinFileId" units="" type="uint16" elements="1"/>
 	<field name="MaxFileId" units="" type="uint16" elements="1"/>
 
-	<field name="Operation" units="" type="enum" elements="1" options="LOGGING, IDLE, DOWNLOAD, COMPLETE, ERROR"/>
+	<field name="Operation" units="" type="enum" elements="1" options="INITIALIZING, LOGGING, IDLE, DOWNLOAD, COMPLETE, FORMAT, ERROR"/>
 
 	<field name="FileRequest" units="" type="uint16" elements="1"/>
 	<field name="FileSectorNum" units="" type="uint16" elements="1"/>


### PR DESCRIPTION
Based on the discussion of the previous PR #1928, this now uses a single queue and throttled callbacks introduced in #2030. 

However, as noted in #1928, the queue doesn't actually store the UAVO values and can't be used as a buffer. To make this work properly, I propose to add a RAM ring buffer and the callback directly calls `UAVTalkSendObjectTimestamped` with an UAVTalk connection that simply writes the data into the ring buffer (if there is sufficient space). The logging task would then retrieve the data from the ring buffer and write it to the flash file system (or serial port). This would have the advantage that the callback would never block and the timestamp would be created at the time the callback occurs. 
