### PR TITLE
Naze: Add ADC and Battery monitoring support

### DIFF
--- a/flight/PiOS/STM32F10x/inc/pios_internal_adc_light_priv.h
+++ b/flight/PiOS/STM32F10x/inc/pios_internal_adc_light_priv.h
@@ -1,0 +1,49 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS_INTERNAL_ADC Internal ADC Functions
+ * @{
+ *
+ * @file       pios_internal_adc_light_priv.h
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @brief      ADC private definitions.
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef PIOS_INTERNAL_ADC_LIGHT_PRIV_H
+#define PIOS_INTERNAL_ADC_LIGHT_PRIV_H
+
+#include <pios.h>
+#include <pios_stm32.h>
+#include <pios_internal_adc.h>
+#include <pios_internal_adc_priv.h>
+#include <fifo_buffer.h>
+
+extern int32_t PIOS_INTERNAL_ADC_LIGHT_Init(uint32_t *internal_adc_id,
+		const struct pios_internal_adc_cfg *cfg,
+		uint16_t number_of_used_pins);
+
+#endif /* PIOS_INTERNAL_ADC_LIGHT_PRIV_H */
+
+/**
+ * @}
+ * @}
+ */
+

--- a/flight/PiOS/STM32F10x/pios_internal_adc_light.c
+++ b/flight/PiOS/STM32F10x/pios_internal_adc_light.c
@@ -1,0 +1,287 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS_ADC STM32F103 ADC1 Functions
+ * @{
+ *
+ * @file       pios_internal_adc.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
+ * @brief      STM32F10x internal ADC PIOS interface
+ * @see        The GNU Public License (GPL) Version 3
+ *****************************************************************************/
+/* 
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the GNU General Public License as published by 
+ * the Free Software Foundation; either version 3 of the License, or 
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but 
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ * for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along 
+ * with this program; if not, write to the Free Software Foundation, Inc., 
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include <pios_internal_adc_priv.h>
+
+#if defined(PIOS_INCLUDE_ADC)
+
+static void PIOS_INTERNAL_ADC_PinConfig(uint32_t internal_adc_id);
+static void PIOS_INTERNAL_DMAConfig(uint32_t internal_adc_id);
+int32_t PIOS_INTERNAL_ADC_Init(uint32_t *internal_adc_id, const struct pios_internal_adc_cfg *cfg);
+static void PIOS_INTERNAL_ADC_Converter_Config(uint32_t internal_adc_id);
+static bool PIOS_INTERNAL_ADC_Available(uint32_t internal_adc_id, uint32_t pin);
+static int32_t PIOS_INTERNAL_ADC_PinGet(uint32_t internal_adc_id, uint32_t pin);
+static uint8_t PIOS_INTERNAL_ADC_NumberOfChannels(uint32_t internal_adc_id);
+static float PIOS_INTERNAL_ADC_LSB_Voltage(uint32_t internal_adc_id);
+
+const struct pios_adc_driver pios_internal_adc_driver = {
+		.available = PIOS_INTERNAL_ADC_Available,
+		.get_pin = PIOS_INTERNAL_ADC_PinGet,
+		.set_queue = NULL,
+		.number_of_channels = PIOS_INTERNAL_ADC_NumberOfChannels,
+		.lsb_voltage = PIOS_INTERNAL_ADC_LSB_Voltage,
+};
+
+// Private types
+enum pios_internal_adc_dev_magic {
+	PIOS_INTERNAL_ADC_DEV_MAGIC = 0xBD37C124,
+};
+
+struct pios_internal_adc_dev {
+	const struct pios_internal_adc_cfg * cfg;
+	uint16_t dma_transfer_size;
+	volatile uint16_t *raw_data_buffer;
+	enum pios_internal_adc_dev_magic magic;
+};
+
+/**
+ * @brief Validates an internal ADC device
+ * \return true if device is valid
+ */
+static bool PIOS_INTERNAL_ADC_validate(struct pios_internal_adc_dev * dev)
+{
+	if (dev == NULL )
+		return false;
+
+	return (dev->magic == PIOS_INTERNAL_ADC_DEV_MAGIC);
+}
+
+/**
+ * @brief Allocates an internal ADC device
+ */
+static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate()
+{
+	struct pios_internal_adc_dev *adc_dev = (struct pios_internal_adc_dev *)PIOS_malloc(sizeof(*adc_dev));
+	if (!adc_dev)
+		return (NULL );
+	adc_dev->magic = PIOS_INTERNAL_ADC_DEV_MAGIC;
+	return (adc_dev);
+}
+
+/**
+ * @brief Configures the pins used on the ADC device
+ * \param[in] handle to the ADC device
+ */
+static void PIOS_INTERNAL_ADC_PinConfig(uint32_t internal_adc_id)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+	if (!PIOS_INTERNAL_ADC_validate(adc_dev)) {
+		return;
+	}
+	/* Setup analog pins */
+	GPIO_InitTypeDef GPIO_InitStructure;
+	GPIO_StructInit(&GPIO_InitStructure);
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AIN;
+
+	for (int32_t i = 0; i < adc_dev->cfg->number_of_used_pins; i++) {
+		if (adc_dev->cfg->adc_pins[i].port == NULL )
+			continue;
+		GPIO_InitStructure.GPIO_Pin = adc_dev->cfg->adc_pins[i].pin;
+		GPIO_Init(adc_dev->cfg->adc_pins[i].port, (GPIO_InitTypeDef*) &GPIO_InitStructure);
+	}
+}
+/**
+ * @brief Configures the DMA used on the ADC device
+ * \param[in] handle to the ADC device
+ */
+static void PIOS_INTERNAL_DMAConfig(uint32_t internal_adc_id)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+	if (!PIOS_INTERNAL_ADC_validate(adc_dev)) {
+		return;
+	}
+
+	/* Disable interrupts */
+	DMA_ITConfig(adc_dev->cfg->dma.rx.channel, adc_dev->cfg->dma.irq.flags, DISABLE);
+
+	/* Configure DMA channel */
+	DMA_DeInit(adc_dev->cfg->dma.rx.channel);
+
+	RCC_AHBPeriphClockCmd(adc_dev->cfg->dma.ahb_clk, ENABLE);
+
+	DMA_InitTypeDef DMAInit = adc_dev->cfg->dma.rx.init;
+
+	DMAInit.DMA_PeripheralBaseAddr = (uint32_t) &ADC1->DR;
+	DMAInit.DMA_MemoryBaseAddr = (uint32_t) adc_dev->raw_data_buffer;
+	DMAInit.DMA_BufferSize = adc_dev->dma_transfer_size;
+	DMAInit.DMA_DIR = DMA_DIR_PeripheralSRC;
+	DMAInit.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
+	DMAInit.DMA_MemoryInc = DMA_MemoryInc_Enable;
+	DMAInit.DMA_PeripheralDataSize = DMA_PeripheralDataSize_HalfWord;
+	DMAInit.DMA_MemoryDataSize = DMA_MemoryDataSize_HalfWord;
+	DMAInit.DMA_Mode = DMA_Mode_Circular;
+	DMAInit.DMA_M2M = DMA_M2M_Disable;
+
+	DMA_Init(adc_dev->cfg->dma.rx.channel, &DMAInit); /* channel is actually stream ... */
+
+	/* enable DMA */
+	DMA_Cmd(adc_dev->cfg->dma.rx.channel, ENABLE);
+}
+/**
+ * @brief Configures the ADC device
+ * \param[in] handle to the ADC device
+ */
+static void PIOS_INTERNAL_ADC_Converter_Config(uint32_t internal_adc_id)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+
+	ADC_DeInit(ADC1);
+
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
+
+	RCC_ADCCLKConfig(RCC_PCLK2_Div8);
+
+	for (int32_t i = 0; i < adc_dev->cfg->number_of_used_pins; i++) {
+		ADC_RegularChannelConfig(ADC1, adc_dev->cfg->adc_pins[i].adc_channel,
+					 i + 1, ADC_SampleTime_239Cycles5);
+	}
+
+	ADC_InitTypeDef ADC_InitStructure;
+	ADC_StructInit(&ADC_InitStructure);
+
+	ADC_InitStructure.ADC_Mode = ADC_Mode_Independent;
+	ADC_InitStructure.ADC_ScanConvMode = ENABLE;
+	ADC_InitStructure.ADC_ContinuousConvMode = ENABLE;
+	ADC_InitStructure.ADC_ExternalTrigConv = ADC_ExternalTrigConv_None;
+	ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
+	ADC_InitStructure.ADC_NbrOfChannel = adc_dev->cfg->number_of_used_pins;
+
+	ADC_Init(ADC1, &ADC_InitStructure);
+
+	ADC_Cmd(ADC1, ENABLE);
+
+	PIOS_DELAY_WaituS(10);
+	ADC_ResetCalibration(ADC1);
+	while(ADC_GetResetCalibrationStatus(ADC1));
+	ADC_StartCalibration(ADC1);
+	while (ADC_GetCalibrationStatus(ADC1));
+
+	/* Enable ADC->DMA request */
+	ADC_DMACmd(ADC1, ENABLE);
+
+	PIOS_DELAY_WaituS(10);
+	ADC_SoftwareStartConvCmd(ADC1, ENABLE);
+}
+
+/**
+ * @brief Init the ADC.
+ */
+int32_t PIOS_INTERNAL_ADC_Init(uint32_t * internal_adc_id, const struct pios_internal_adc_cfg * cfg)
+{
+	PIOS_DEBUG_Assert(internal_adc_id); PIOS_DEBUG_Assert(cfg);
+
+	struct pios_internal_adc_dev * adc_dev;
+	adc_dev = PIOS_INTERNAL_ADC_Allocate();
+	if (adc_dev == NULL )
+		return -1;
+	adc_dev->cfg = cfg;
+
+	*internal_adc_id = (uint32_t) adc_dev;
+
+	// DMA transfer size in units defined by DMA_PeripheralDataSize, 32bits for dual mode and 16bits for single mode
+	adc_dev->dma_transfer_size = adc_dev->cfg->number_of_used_pins;
+	adc_dev->raw_data_buffer = PIOS_malloc(adc_dev->dma_transfer_size * sizeof(uint16_t));
+	if (adc_dev->raw_data_buffer == NULL )
+		return -1;
+
+	PIOS_INTERNAL_ADC_PinConfig((uint32_t) adc_dev);
+
+	PIOS_INTERNAL_DMAConfig((uint32_t) adc_dev);
+
+	PIOS_INTERNAL_ADC_Converter_Config((uint32_t) adc_dev);
+	return 0;
+}
+
+/**
+ * Checks if a pin is available on a certain ADC device
+ * @param[in] pin number
+ * @param[in] internal_adc_id handler to the device to check
+ * @return True if the pin is available.
+ */
+static bool PIOS_INTERNAL_ADC_Available(uint32_t internal_adc_id, uint32_t pin)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+	/* Check if pin exists */
+	if (pin >= adc_dev->cfg->number_of_used_pins) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Checks the number of channels on a certain ADC device
+ * @param[in] internal_adc_id handler to the device to check
+ * @return number of channels on the device.
+ */
+static uint8_t PIOS_INTERNAL_ADC_NumberOfChannels(uint32_t internal_adc_id)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+	if (!PIOS_INTERNAL_ADC_validate(adc_dev))
+		return 0;
+	return adc_dev->cfg->number_of_used_pins;
+
+}
+
+/**
+ * @brief Gets the value of an ADC pinn
+ * @param[in] pin number, acording to the order passed on the configuration
+ * @return ADC pin value averaged over the set of samples since the last reading.
+ * @return -1 if pin doesn't exist
+ */
+static int32_t PIOS_INTERNAL_ADC_PinGet(uint32_t internal_adc_id, uint32_t pin)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+
+	/* Check if pin exists */
+	if (pin >= adc_dev->cfg->number_of_used_pins) {
+		return -1;
+	}
+
+	/* This results in a half-word load (2 cycles) of the volatile buffer location
+	   written by DMA. The buffer is dynamically allocated and thus will always be aligned. 
+	   A barrier is not required for this on Cortex-M. See ARM App. Note 321 */
+	return adc_dev->raw_data_buffer[pin];
+}
+
+/**
+ * @brief Gets the least significant bit voltage of the ADC
+ */
+static float PIOS_INTERNAL_ADC_LSB_Voltage(uint32_t internal_adc_id)
+{
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *) internal_adc_id;
+	if (!PIOS_INTERNAL_ADC_validate(adc_dev)) {
+		return 0;
+	}
+        return VREF_PLUS / (((uint32_t)1 << 12) - 1);
+}
+#endif /* PIOS_INCLUDE_ADC */
+/** 
+ * @}
+ * @}
+ */

--- a/flight/targets/naze32/board-info/board_hw_defs.c
+++ b/flight/targets/naze32/board-info/board_hw_defs.c
@@ -237,6 +237,37 @@ const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32
 
 #endif	/* PIOS_INCLUDE_FLASH */
 
+#if defined(PIOS_INCLUDE_ADC)
+#include "pios_adc_priv.h"
+#include "pios_internal_adc_priv.h"
+
+/**
+ * ADC0 : PA4 ADC_IN4
+ * ADC1 : PA5 ADC_IN5
+ * ADC2 : PA1 ADC_IN1
+ * ADC3 : PB1 ADC_IN9
+ */
+static /*const*/ struct pios_internal_adc_cfg internal_adc_cfg = {
+	.dma = {
+		.ahb_clk  = RCC_AHBPeriph_DMA1,
+		.rx = {
+			.channel = DMA1_Channel1,
+			.init    = {
+				.DMA_Priority           = DMA_Priority_High,
+			},
+		}
+	},
+	.number_of_used_pins = 4,
+	.adc_pins = (struct adc_pin[]){
+		{GPIOA, GPIO_Pin_4, ADC_Channel_4, true},  // VBat
+		{GPIOA, GPIO_Pin_5, ADC_Channel_5, true},  // ADC Pad
+		{GPIOA, GPIO_Pin_1, ADC_Channel_1, true},  // RC IN 2
+		{GPIOB, GPIO_Pin_1, ADC_Channel_9, true},  // RC IN 8
+	}
+};
+
+#endif /* PIOS_INCLUDE_ADC */
+
 #include "pios_tim_priv.h"
 
 static const TIM_TimeBaseInitTypeDef tim_1_2_3_4_time_base = {

--- a/flight/targets/naze32/board-info/board_hw_defs.c
+++ b/flight/targets/naze32/board-info/board_hw_defs.c
@@ -239,7 +239,7 @@ const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32
 
 #if defined(PIOS_INCLUDE_ADC)
 #include "pios_adc_priv.h"
-#include "pios_internal_adc_priv.h"
+#include "pios_internal_adc_light_priv.h"
 
 /**
  * ADC0 : PA4 ADC_IN4
@@ -247,7 +247,7 @@ const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32
  * ADC2 : PA1 ADC_IN1
  * ADC3 : PB1 ADC_IN9
  */
-static /*const*/ struct pios_internal_adc_cfg internal_adc_cfg = {
+static const struct pios_internal_adc_cfg internal_adc_cfg = {
 	.dma = {
 		.ahb_clk  = RCC_AHBPeriph_DMA1,
 		.rx = {
@@ -257,7 +257,8 @@ static /*const*/ struct pios_internal_adc_cfg internal_adc_cfg = {
 			},
 		}
 	},
-	.number_of_used_pins = 4,
+	.number_of_used_pins = 4, // this is the max number, can be reduced at runtime (due to port config)
+	.adc_dev_master = ADC1,
 	.adc_pins = (struct adc_pin[]){
 		{GPIOA, GPIO_Pin_4, ADC_Channel_4, true},  // VBat
 		{GPIOA, GPIO_Pin_5, ADC_Channel_5, true},  // ADC Pad

--- a/flight/targets/naze32/board-info/pios_board.h
+++ b/flight/targets/naze32/board-info/pios_board.h
@@ -171,7 +171,19 @@ extern uintptr_t pios_com_mavlink_id;
 
 //-------------------------
 // ADC
+// ADC0 : PA4 ADC_IN4
+// ADC1 : PA5 ADC_IN5
+// ADC2 : PA1 ADC_IN1
+// ADC3 : PB1 ADC_IN9
 //-------------------------
+
+#if defined(PIOS_INCLUDE_ADC)
+extern uintptr_t pios_internal_adc_id;
+#define pios_internal_adc_id					(pios_internal_adc_id)
+#endif
+#define PIOS_ADC_SUB_DRIVER_MAX_INSTANCES		1
+
+#define VREF_PLUS								3.3
 
 //-------------------------
 // GPIO

--- a/flight/targets/naze32/fw/Makefile
+++ b/flight/targets/naze32/fw/Makefile
@@ -64,7 +64,7 @@ USE_UAVOMAVLINKBRIDGE ?= YES
 USE_UAVOMSPBRIDGE ?= YES
 USE_UAVOLIGHTTELEMETRYBRIDGE ?= NO
 USE_UAVOFRSKYSENSORHUBBRIDGE ?= YES
-USE_BATTERY ?= NO
+USE_BATTERY ?= YES
 # @endgroup  Optional modules
 
 # List of optional modules to include
@@ -167,7 +167,7 @@ SRC += $(PIOSSTM32F10X)/pios_sys.c
 SRC += $(PIOSSTM32F10X)/pios_led.c
 SRC += $(PIOSSTM32F10X)/pios_usart.c
 SRC += $(PIOSSTM32F10X)/pios_irq.c
-#SRC += $(PIOSSTM32F10X)/pios_internal_adc.c
+SRC += $(PIOSSTM32F10X)/pios_internal_adc_light.c
 SRC += $(PIOSSTM32F10X)/pios_servo.c
 #SRC += $(PIOSSTM32F10X)/pios_i2c.c
 SRC += $(PIOSSTM32F10X)/pios_i2c_alt.c
@@ -199,7 +199,7 @@ SRC += $(PIOSCOMMON)/pios_hsum.c
 SRC += $(PIOSCOMMON)/pios_sensors.c
 SRC += $(PIOSCOMMON)/pios_gcsrcvr.c
 SRC += $(PIOSCOMMON)/printf-stdarg.c
-#SRC += $(PIOSCOMMON)/pios_adc.c
+SRC += $(PIOSCOMMON)/pios_adc.c
 SRC += $(PIOSCOMMON)/pios_flash.c
 SRC += $(PIOSCOMMON)/pios_heap.c
 SRC += $(PIOSCOMMON)/pios_semaphore.c

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -494,7 +494,21 @@ void PIOS_Board_Init(void) {
 #endif
 
 #if defined(PIOS_INCLUDE_ADC)
-#error "Not yet implemented"
+	{
+		uint16_t number_of_adc_pins = 2; // first two pins are always available
+		switch(hw_rcvrport) {
+		case HWNAZE_RCVRPORT_PPM:
+		case HWNAZE_RCVRPORT_PPMSERIAL:
+			number_of_adc_pins += 2; // rcvr port pins also available
+			break;
+		default:
+			break;
+		}
+		uint32_t internal_adc_id;
+		internal_adc_cfg.number_of_used_pins = number_of_adc_pins;
+		PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg);
+		PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
+	}
 #endif /* PIOS_INCLUDE_ADC */
 	PIOS_WDG_Clear();
 	PIOS_DELAY_WaitmS(200);

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -505,8 +505,7 @@ void PIOS_Board_Init(void) {
 			break;
 		}
 		uint32_t internal_adc_id;
-		internal_adc_cfg.number_of_used_pins = number_of_adc_pins;
-		PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg);
+		PIOS_INTERNAL_ADC_LIGHT_Init(&internal_adc_id, &internal_adc_cfg, number_of_adc_pins);
 		PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
 	}
 #endif /* PIOS_INCLUDE_ADC */

--- a/flight/targets/naze32/fw/pios_config.h
+++ b/flight/targets/naze32/fw/pios_config.h
@@ -32,7 +32,7 @@
 #define PIOS_CONFIG_H
 
 /* Enable/Disable PiOS Modules */
-//#define PIOS_INCLUDE_ADC
+#define PIOS_INCLUDE_ADC
 #define PIOS_INCLUDE_DELAY
 #define PIOS_INCLUDE_I2C
 //#define PIOS_INCLUDE_I2C_ESC


### PR DESCRIPTION
This adds a lightweight ADC driver, intended solely for battery monitoring, on the F1 (without any filtering/buffering, since there isn't enough RAM). The ADC driver and battery module are added to the Naze. 

The ADC driver Init function uses a slightly different interface to other PIOS_INTERNAL_ADC drivers, with a number_of_used_pins parameter added. This avoids the need to have the entire ADC config structure in RAM, saving around 200 bytes that are badly needed on the F1.

On the Naze, the Battery module and ADC driver can run in parallel with the UAVOMSPBridge module, and there is still enough RAM for autotune with all modules disabled (just under 200 bytes heap free). Shown here is a Naze32 running Tau Labs connected to baseflight configurator (with some modifications to the UAVOMSPBridge module on a local branch) and providing battery data.
![screenshot from 2015-11-01 12 07 21](https://cloud.githubusercontent.com/assets/9995998/10866588/65b2f626-809a-11e5-8386-c6e1d7f79557.png)
