### PR TITLE
Naze: Support Setup Wizard in GCS

### DIFF
--- a/ground/gcs/src/plugins/boards_naze/naze.cpp
+++ b/ground/gcs/src/plugins/boards_naze/naze.cpp
@@ -43,7 +43,7 @@ Naze::Naze(void)
     boardType = 0xA0;
 
     // Define the bank of channels that are connected to a given timer
-    channelBanks.resize(6);
+    channelBanks.resize(4);
     channelBanks[0] = QVector<int> () << 1 << 2; // T1
     channelBanks[1] = QVector<int> () << 3 << 4 << 5 << 6; // T4
     channelBanks[2] = QVector<int> () << 7 << 8 << 9 << 10; // T2
@@ -57,7 +57,7 @@ Naze::~Naze()
 
 QString Naze::shortName()
 {
-    return QString("naze");
+    return QString("Naze");
 }
 
 QString Naze::boardDescription()

--- a/ground/gcs/src/plugins/boards_naze/naze.cpp
+++ b/ground/gcs/src/plugins/boards_naze/naze.cpp
@@ -129,3 +129,89 @@ int Naze::queryMaxGyroRate()
         return 500;
     }
 }
+
+//! Determine if this board supports configuring the receiver
+bool Naze::isInputConfigurationSupported()
+{
+    // doesn't work for now since the board can't reconnect  automatically after reboot
+    return false;
+}
+
+/**
+ * Configure the board to use a receiver input type on a port number
+ * @param type the type of receiver to use
+ * @param port_num which input port to configure (board specific numbering)
+ * @return true if successfully configured or false otherwise
+ */
+bool Naze::setInputOnPort(enum InputType type, int port_num)
+{
+    if (port_num != 0)
+        return false;
+
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
+    Q_ASSERT(hwNaze);
+    if (!hwNaze)
+        return false;
+
+    HwNaze::DataFields settings = hwNaze->getData();
+
+    switch(type) {
+    case INPUT_TYPE_PPM:
+        settings.RcvrPort = HwNaze::RCVRPORT_PPM;
+        break;
+    case INPUT_TYPE_DSM:
+        settings.RcvrPort = HwNaze::RCVRPORT_PPMSERIAL;
+        settings.RcvrSerial = HwNaze::RCVRSERIAL_DSM;
+        break;
+    case INPUT_TYPE_HOTTSUMD:
+        settings.RcvrPort = HwNaze::RCVRPORT_PPMSERIAL;
+        settings.RcvrSerial = HwNaze::RCVRSERIAL_HOTTSUMD;
+        break;
+    default:
+        return false;
+    }
+
+    // Apply these changes
+    hwNaze->setData(settings);
+
+    return true;
+}
+
+/**
+ * @brief Naze::getInputOnPort fetch the currently selected input type
+ * @param port_num the port number to query (must be zero)
+ * @return the selected input type
+ */
+enum Core::IBoardType::InputType Naze::getInputOnPort(int port_num)
+{
+    if (port_num != 0)
+        return INPUT_TYPE_UNKNOWN;
+
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
+    Q_ASSERT(hwNaze);
+    if (!hwNaze)
+        return INPUT_TYPE_UNKNOWN;
+
+    HwNaze::DataFields settings = hwNaze->getData();
+
+    switch(settings.RcvrPort) {
+    case HwNaze::RCVRPORT_PPM:
+        return INPUT_TYPE_PPM;
+    case HwNaze::RCVRPORT_PPMSERIAL:
+        switch(settings.RcvrSerial) {
+        case HwNaze::RCVRSERIAL_DSM:
+            return INPUT_TYPE_DSM;
+        case HwNaze::RCVRSERIAL_HOTTSUMD:
+            return INPUT_TYPE_HOTTSUMD;
+        default:
+            // can still use PPM
+            return INPUT_TYPE_PPM;
+        }
+    default:
+        return INPUT_TYPE_UNKNOWN;
+    }
+}

--- a/ground/gcs/src/plugins/boards_naze/naze.h
+++ b/ground/gcs/src/plugins/boards_naze/naze.h
@@ -45,6 +45,7 @@ public:
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();
     virtual int queryMaxGyroRate();
+    virtual bool isUSBSupported() { return false; }
 };
 
 

--- a/ground/gcs/src/plugins/boards_naze/naze.h
+++ b/ground/gcs/src/plugins/boards_naze/naze.h
@@ -45,6 +45,9 @@ public:
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();
     virtual int queryMaxGyroRate();
+    virtual bool isInputConfigurationSupported();
+    virtual bool setInputOnPort(enum InputType type, int port_num);
+    virtual enum Core::IBoardType::InputType getInputOnPort(int port_num);
     virtual bool isUSBSupported() { return false; }
 };
 

--- a/ground/gcs/src/plugins/coreplugin/iboardtype.h
+++ b/ground/gcs/src/plugins/coreplugin/iboardtype.h
@@ -220,6 +220,12 @@ public:
                            Core::IBoardType::LinkMode /*linkMode*/, quint8 /*min*/,
                            quint8 /*max*/) { return false; }
 
+    /**
+     * Check whether the board has USB
+     * @return true if usb, false if not
+     */
+    virtual bool isUSBSupported() { return true; }
+
     static QString getBoardNameFromID(int id);
 
 signals:

--- a/ground/gcs/src/plugins/setupwizard/pages/controllerpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/controllerpage.cpp
@@ -75,7 +75,12 @@ void ControllerPage::initializePage()
 
 bool ControllerPage::isComplete() const
 {
-    return (getControllerType() != NULL) &&
+    Core::IBoardType* type = getControllerType();
+
+    if (type == NULL)
+        return false;
+
+    return !type->isUSBSupported() ||
            m_connectionManager->getCurrentDevice().getConName().startsWith("USB:", Qt::CaseInsensitive);
 }
 


### PR DESCRIPTION
This adds support for configuring the Naze target using the vehicle setup wizard. Because it's a serial device and doesn't have USB I had to change the wizard slightly to handle that. Input configuration isn't supported as it requires the board to reboot and since it doesn't auto-connect (due to being a serial device) this will break the wizard. There are also a couple of other small fix-ups for the board plugin that I noticed.
