### PR TITLE
GCS: Fix segfault when board doesn't have connection diagram

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/connectiondiagram.cpp
+++ b/ground/gcs/src/plugins/setupwizard/connectiondiagram.cpp
@@ -50,14 +50,16 @@ void ConnectionDiagram::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
 
-    ui->connectionDiagram->fitInView(m_background, Qt::KeepAspectRatio);
+    if(m_background != NULL)
+        ui->connectionDiagram->fitInView(m_background, Qt::KeepAspectRatio);
 }
 
 void ConnectionDiagram::showEvent(QShowEvent *event)
 {
     QWidget::showEvent(event);
 
-    ui->connectionDiagram->fitInView(m_background, Qt::KeepAspectRatio);
+    if(m_background != NULL)
+        ui->connectionDiagram->fitInView(m_background, Qt::KeepAspectRatio);
 }
 
 void ConnectionDiagram::setupGraphicsScene()


### PR DESCRIPTION
I'm fairly sure this fixes [the crash reported in the forums a couple of days ago](http://forum.taulabs.org/viewtopic.php?p=8020#p8020) but I haven't gotten around to setting up the tools to look at crash dumps yet. I certainly the segfault fixed in this PR while testing #2036.