### PR TITLE
vtol_follower_fsm: rth: don't rise so much immediately

### DIFF
--- a/shared/uavobjectdefinition/altitudeholdsettings.xml
+++ b/shared/uavobjectdefinition/altitudeholdsettings.xml
@@ -1,10 +1,10 @@
 <xml>
     <object name="AltitudeHoldSettings" singleinstance="true" settings="true">
         <description>Settings for the @ref AltitudeHold module</description>
-        <field name="PositionKp" units="(m/s)/m" type="float" elements="1" defaultvalue="1.0"/>
-        <field name="VelocityKp" units="throttle/m" type="float" elements="1" defaultvalue="0.3"/>
-        <field name="VelocityKi" units="throttle/m/s" type="float" elements="1" defaultvalue="0.3"/>
-        <field name="AttitudeComp" units="%" type="uint16" elements="1" defaultvalue="100"/>
+        <field name="PositionKp" units="(m/s)/m" type="float" elements="1" defaultvalue="0.8"/>
+        <field name="VelocityKp" units="throttle/m" type="float" elements="1" defaultvalue="0.20"/>
+        <field name="VelocityKi" units="throttle/m/s" type="float" elements="1" defaultvalue="0.25"/>
+        <field name="AttitudeComp" units="%" type="uint16" elements="1" defaultvalue="120"/>
         <field name="MaxClimbRate" units="dm/s" type="uint8" elements="1" defaultvalue="40"/>
         <field name="MaxDescentRate" units="dm/s" type="uint8" elements="1" defaultvalue="15"/>
         <field name="Expo" units="" type="uint8" elements="1" defaultvalue="40"/>


### PR DESCRIPTION
Previously this would climb all the way to the minimum altitude
immediately.  IMO this doesn't match the intent of the initial RTH
pause (rise is in the next state).  It has also caused issues
when a burst of full throttle from the combined effect of altitude
error and the impulse from application of the mode destabilized
flaky quads.

On the other hand, if we're too low, it's advantageous to rise
at least a small amount immediately.  It's also good to not set our
hold position too low from any immediate altimeter error.
So climb 1.5m right away.