### PR TITLE
Flight: remove all double precision math

### DIFF
--- a/flight/Libraries/WorldMagModel.c
+++ b/flight/Libraries/WorldMagModel.c
@@ -328,7 +328,7 @@ int WMM_AssociatedLegendreFunction(WMMtype_CoordSpherical * CoordSpherical, uint
 {
 	float sin_phi = sinf(CoordSpherical->phig * DEG2RAD);	/* sin  (geocentric latitude) */
 
-	if (nMax <= 16 || (1 - fabs(sin_phi)) < 1.0e-10)	/* If nMax is less tha 16 or at the poles */
+	if (nMax <= 16 || (1 - fabsf(sin_phi)) < 1.0e-10f)	/* If nMax is less tha 16 or at the poles */
 	{
 		if (WMM_PcupLow(LegendreFunction->Pcup, LegendreFunction->dPcup, sin_phi, nMax) < 0)
 		    return -1;  // error
@@ -414,7 +414,7 @@ int WMM_Summation(WMMtype_LegendreFunction * LegendreFunction,
 	}
 
 	cos_phi = cosf(CoordSpherical->phig * DEG2RAD);
-	if (fabs(cos_phi) > 1.0e-10)
+	if (fabsf(cos_phi) > 1.0e-10f)
 	{
 		MagneticResults->By = MagneticResults->By / cos_phi;
 	}
@@ -494,7 +494,7 @@ int WMM_SecVarSummation(WMMtype_LegendreFunction * LegendreFunction,
 		}
 	}
 	cos_phi = cosf(CoordSpherical->phig * DEG2RAD);
-	if (fabs(cos_phi) > 1.0e-10)
+	if (fabsf(cos_phi) > 1.0e-10f)
 	{
 		MagneticResults->By = MagneticResults->By / cos_phi;
 	}
@@ -671,7 +671,7 @@ int WMM_PcupHigh(float *Pcup, float *dPcup, float x, uint16_t nMax)
 	float       *PreSqr = pre_sqr;
   
 
-	if (fabs(x) == 1.0)
+	if (fabsf(x) == 1.0f)
 	{
 		// Error in PcupHigh: derivative cannot be calculated at poles
 		return -2;

--- a/flight/Libraries/WorldMagModel.c
+++ b/flight/Libraries/WorldMagModel.c
@@ -1114,7 +1114,7 @@ int WMM_DateToYear(uint16_t month, uint16_t day, uint16_t year)
 		temp += MonthDays[i - 1];
 	temp += day;
 	
-	decimal_date = year + (temp - 1) / (365.0 + ExtraDay);
+	decimal_date = year + (temp - 1) / (365.0f + ExtraDay);
 
 	return 0;   // OK
 }

--- a/flight/Libraries/math/coordinate_conversions.c
+++ b/flight/Libraries/math/coordinate_conversions.c
@@ -221,13 +221,13 @@ uint8_t RotFrom2Vectors(const float v1b[3], const float v1e[3], const float v2b[
 
 	// The first rows of rot matrices chosen in direction of v1
 	mag = VectorMagnitude(v1b);
-	if (fabs(mag) < 1e-30)
+	if (fabsf(mag) < 1e-30f)
 		return (-1);
 	for (i=0;i<3;i++)
 		Rib[0][i]=v1b[i]/mag;
 
 	mag = VectorMagnitude(v1e);
-	if (fabs(mag) < 1e-30)
+	if (fabsf(mag) < 1e-30f)
 		return (-1);
 	for (i=0;i<3;i++)
 		Rie[0][i]=v1e[i]/mag;
@@ -235,14 +235,14 @@ uint8_t RotFrom2Vectors(const float v1b[3], const float v1e[3], const float v2b[
 	// The second rows of rot matrices chosen in direction of v1xv2
 	CrossProduct(v1b,v2b,&Rib[1][0]);
 	mag = VectorMagnitude(&Rib[1][0]);
-	if (fabs(mag) < 1e-30)
+	if (fabsf(mag) < 1e-30f)
 		return (-1);
 	for (i=0;i<3;i++)
 		Rib[1][i]=Rib[1][i]/mag;
 
 	CrossProduct(v1e,v2e,&Rie[1][0]);
 	mag = VectorMagnitude(&Rie[1][0]);
-	if (fabs(mag) < 1e-30)
+	if (fabsf(mag) < 1e-30f)
 		return (-1);
 	for (i=0;i<3;i++)
 		Rie[1][i]=Rie[1][i]/mag;

--- a/flight/Libraries/paths.c
+++ b/flight/Libraries/paths.c
@@ -185,7 +185,7 @@ static void path_vector(const float *start_point,
 	status->correction_direction[1] = (status->error > 0) ? -normal[1] : normal[1];
 	
 	// Now just want magnitude of error
-	status->error = fabs(status->error);
+	status->error = fabsf(status->error);
 
 	// Compute direction to travel
 	status->path_direction[0] = path_north / dist_path;
@@ -254,7 +254,7 @@ static void path_circle(const float * center_point,
 	status->path_direction[0] = normal[0];
 	status->path_direction[1] = normal[1];
 
-	status->error = fabs(status->error);
+	status->error = fabsf(status->error);
 }
 
 /**
@@ -321,9 +321,9 @@ static void path_curve(const float * start_point,
 	d = sqrtf(radius * radius / (p_n * p_n + p_e * p_e) - 0.25f);
 
 	float radius_sign = (radius > 0) ? 1 : -1;
-	float m_radius = fabs(radius);
+	float m_radius = fabsf(radius);
 
-	if (fabs(p_n) < 1e-3 && fabs(p_e) < 1e-3) {
+	if (fabsf(p_n) < 1e-3f && fabsf(p_e) < 1e-3f) {
 		center[0] = m_n;
 		center[1] = m_e;
 	} else {
@@ -380,7 +380,7 @@ static void path_curve(const float * start_point,
 
 	status->fractional_progress = dot / (dist_path * dist_path);
 
-	status->error = fabs(status->error);
+	status->error = fabsf(status->error);
 }
 
 /**

--- a/flight/Modules/Airspeed/gps_airspeed.c
+++ b/flight/Modules/Airspeed/gps_airspeed.c
@@ -114,7 +114,7 @@ void gps_airspeedGet(float *v_air_GPS)
 	float cosDiff=(Rbe[0][0]*gps->RbeCol1_old[0]) + (Rbe[0][1]*gps->RbeCol1_old[1]) + (Rbe[0][2]*gps->RbeCol1_old[2]);
 	
 	//If there's more than a 5 degree difference between two fuselage measurements, then we have sufficient delta to continue.
-	if (fabs(cosDiff) < cos(5.0f*DEG2RAD)) {
+	if (fabsf(cosDiff) < cos(5.0f*DEG2RAD)) {
 		GPSVelocityData gpsVelData;
 		GPSVelocityGet(&gpsVelData);
 		

--- a/flight/Modules/Airspeed/gps_airspeed.c
+++ b/flight/Modules/Airspeed/gps_airspeed.c
@@ -114,7 +114,7 @@ void gps_airspeedGet(float *v_air_GPS)
 	float cosDiff=(Rbe[0][0]*gps->RbeCol1_old[0]) + (Rbe[0][1]*gps->RbeCol1_old[1]) + (Rbe[0][2]*gps->RbeCol1_old[2]);
 	
 	//If there's more than a 5 degree difference between two fuselage measurements, then we have sufficient delta to continue.
-	if (fabsf(cosDiff) < cos(5.0f*DEG2RAD)) {
+	if (fabsf(cosDiff) < cosf(5.0f*DEG2RAD)) {
 		GPSVelocityData gpsVelData;
 		GPSVelocityGet(&gpsVelData);
 		

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -1448,7 +1448,7 @@ static void check_home_location()
 		homeLocation.Altitude = gps.Altitude; // Altitude referenced to mean sea level geoid (likely EGM 1996, but no guarantees)
 
 		// Compute home ECEF coordinates and the rotation matrix into NED
-		double LLA[3] = { ((double)homeLocation.Latitude) / 10e6, ((double)homeLocation.Longitude) / 10e6, ((double)homeLocation.Altitude) };
+		float LLA[3] = { homeLocation.Latitude / 10e6f, homeLocation.Longitude / 10e6f, homeLocation.Altitude };
 
 		// Compute magnetic flux direction at home location
 		if (WMM_GetMagVector(LLA[0], LLA[1], LLA[2], gpsTime.Month, gpsTime.Day, gpsTime.Year, &homeLocation.Be[0]) >= 0)

--- a/flight/Modules/Attitude/smallf1/attitude.c
+++ b/flight/Modules/Attitude/smallf1/attitude.c
@@ -45,6 +45,7 @@
 #include "attitudesettings.h"
 #include "flightstatus.h"
 #include "manualcontrolcommand.h"
+#include "misc_math.h"
 #include "coordinate_conversions.h"
 #include <pios_board_info.h>
 #include "pios_queue.h"
@@ -641,7 +642,7 @@ static void updateAttitude(AccelsData * accelsData, GyrosData * gyrosData)
 	
 	// If quaternion has become inappropriately short or is nan reinit.
 	// THIS SHOULD NEVER ACTUALLY HAPPEN
-	if((fabs(qmag) < 1e-3) || (qmag != qmag)) {
+	if((fabsf(qmag) < 1e-3f) || IS_NOT_FINITE(qmag)) {
 		q[0] = 1;
 		q[1] = 0;
 		q[2] = 0;

--- a/flight/Modules/GPS/UBX.c
+++ b/flight/Modules/GPS/UBX.c
@@ -215,7 +215,7 @@ static void parse_ubx_nav_sol (const struct UBX_NAV_SOL *sol, GPSPositionData *G
 {
 	if (check_msgtracker(sol->iTOW, SOL_RECEIVED)) {
 		GpsPosition->Satellites = sol->numSV;
-		GpsPosition->Accuracy = sol->pAcc / 100.0;
+		GpsPosition->Accuracy = sol->pAcc / 100.0f;
 
 		if (sol->flags & STATUS_FLAGS_GPSFIX_OK) {
 			switch (sol->gpsFix) {

--- a/flight/Modules/ManualControl/tablet_control.c
+++ b/flight/Modules/ManualControl/tablet_control.c
@@ -145,7 +145,7 @@ int32_t tablet_control_select(bool reset_controller)
 
 			float DeltaN = NED[0] - positionActual.North;
 			float DeltaE = NED[1] - positionActual.East;
-			float dist = sqrt(DeltaN * DeltaN + DeltaE * DeltaE);
+			float dist = sqrtf(DeltaN * DeltaN + DeltaE * DeltaE);
 
 			// If outside the follow radius code to the nearest point on the border
 			// otherwise stay in the same location

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -488,9 +488,9 @@ static void updateStats()
 	idleCounterClear = 1;
 	
 #if defined(PIOS_INCLUDE_ADC) && defined(PIOS_ADC_USE_TEMP_SENSOR)
-	float temp_voltage = 3.3 * PIOS_ADC_DevicePinGet(PIOS_INTERNAL_ADC, 0) / ((1 << 12) - 1);
-	const float STM32_TEMP_V25 = 1.43; /* V */
-	const float STM32_TEMP_AVG_SLOPE = 4.3; /* mV/C */
+	float temp_voltage = 3.3f * PIOS_ADC_DevicePinGet(PIOS_INTERNAL_ADC, 0) / ((1 << 12) - 1);
+	const float STM32_TEMP_V25 = 1.43f; /* V */
+	const float STM32_TEMP_AVG_SLOPE = 4.3f; /* mV/C */
 	stats.CPUTemp = (temp_voltage-STM32_TEMP_V25) * 1000 / STM32_TEMP_AVG_SLOPE + 25;
 #endif
 	SystemStatsSet(&stats);

--- a/flight/PiOS/Common/pios_rfm22b.c
+++ b/flight/PiOS/Common/pios_rfm22b.c
@@ -2228,7 +2228,7 @@ static void rfm22_synchronizeClock(struct pios_rfm22b_dev *rfm22b_dev)
 	uint16_t time_delta = start_time % frequency_hop_cycle_time;
 
 	// Calculate the adjustment for the preamble
-	uint8_t offset = (uint8_t) ceil(35000.0F / data_rate[rfm22b_dev->datarate]);
+	uint8_t offset = (uint8_t) ceilf(35000.0F / data_rate[rfm22b_dev->datarate]);
 
 	rfm22b_dev->time_delta = frequency_hop_cycle_time - time_delta + offset;
 }


### PR DESCRIPTION
except for picoc.

as things stand now:

```
Michaels-MBP:taulabs mlyle$ grep ^__aeabi build/fw_sparky2/*.lst | cut -d ':' -f 1 | sort | uniq -c
   1 build/fw_sparky2/frsky_packing.lst
   9 build/fw_sparky2/picoc_clibrary.lst
  11 build/fw_sparky2/picoc_library.lst
  13 build/fw_sparky2/picoc_platform.lst
   1 build/fw_sparky2/pios_ms5611.lst
```

The frsky stuff is __aeabi_uldivmod; the pios_ms5611 is __aeabi_l2f.
