### PR TITLE
package: restore firmware to linux packages.

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -77,8 +77,7 @@ help:
 	@echo "       This usually is safe."
 	@echo
 
-# Clean and build uavobjects since all parts depend on them
-uavobjects: all_clean
+uavobjects: 
 	$(V1) $(MAKE) -C $(ROOT_DIR) $@
 
 matlab: uavobjects


### PR DESCRIPTION
Fixes #2054 .  There was an interaction between the packaging scripts
in make standalone triggering an all_clean and the Jenkins packaging scripts
assuming that previous flight targets would still exist.  It's compounded
by the fact that there's basically no error checking on packaging.