### PR TITLE
Increase stack for battery module.

### DIFF
--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -38,7 +38,7 @@
 
 // ****************
 // Private constants
-#define STACK_SIZE_BYTES            496
+#define STACK_SIZE_BYTES            576
 #define TASK_PRIORITY               PIOS_THREAD_PRIO_LOW
 #define SAMPLE_PERIOD_MS            500
 // Private types


### PR DESCRIPTION
See #2057 for more details, but after increasing it by 128, I was able
to get it to report 124 bytes free after a bit of jostling (mostly
toying with power levels from a bench supply).

I'm not 100% sure that this is the cause, but I was getting some strange
behavior resulting in watchdog reboots on this particular build.  This
experiment with the battery module indicates it's *possible* that the
battery module was the cause of these issues.

This change increases it by 80 which should be enough to keep things
contained based on current observations.