### PR TITLE
ADC: Runtime configuration / cleanup

### DIFF
--- a/flight/PiOS/STM32F10x/pios_internal_adc.c
+++ b/flight/PiOS/STM32F10x/pios_internal_adc.c
@@ -31,6 +31,8 @@
 #include <pios_internal_adc_priv.h>
 #include "pios_queue.h"
 
+#define PIOS_ADC_MAX_SAMPLES ((((PIOS_ADC_NUM_CHANNELS + PIOS_ADC_USE_ADC2) >> PIOS_ADC_USE_ADC2) << PIOS_ADC_USE_ADC2)* PIOS_ADC_MAX_OVERSAMPLING * 2)
+
 #if defined(PIOS_INCLUDE_FREERTOS)
 #include "FreeRTOS.h"
 #endif /* defined(PIOS_INCLUDE_FREERTOS) */

--- a/flight/PiOS/STM32F4xx/pios_internal_adc.c
+++ b/flight/PiOS/STM32F4xx/pios_internal_adc.c
@@ -53,22 +53,6 @@
 
 #include "pios_queue.h"
 
-#if !defined(PIOS_ADC_MAX_SAMPLES)
-#define PIOS_ADC_MAX_SAMPLES 0
-#endif
-
-#if !defined(PIOS_ADC_MAX_OVERSAMPLING)
-#define PIOS_ADC_MAX_OVERSAMPLING 0
-#endif
-
-#if !defined(PIOS_ADC_USE_ADC2)
-#define PIOS_ADC_USE_ADC2 0
-#endif
-
-#if !defined(PIOS_ADC_NUM_CHANNELS)
-#define PIOS_ADC_NUM_CHANNELS 0
-#endif
-
 // Private types
 enum pios_adc_dev_magic {
 	PIOS_INTERNAL_ADC_DEV_MAGIC = 0x58375124,
@@ -84,13 +68,14 @@ struct pios_internal_adc_dev {
 	volatile uint8_t adc_oversample;
 	uint8_t dma_block_size;
 	uint16_t dma_half_buffer_size;
+	uint32_t max_samples;
 	enum pios_adc_dev_magic magic;
 };
 
 static struct pios_internal_adc_dev * pios_adc_dev;
 
 // Private functions
-static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate();
+static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate(const struct pios_internal_adc_cfg * cfg);
 static bool PIOS_INTERNAL_ADC_validate(struct pios_internal_adc_dev *);
 
 #if defined(PIOS_INCLUDE_ADC)
@@ -111,54 +96,51 @@ const struct pios_adc_driver pios_internal_adc_driver = {
                 .lsb_voltage = PIOS_INTERNAL_ADC_LSB_Voltage,
 };
 
-struct dma_config {
-	GPIO_TypeDef	*port;
-	uint32_t		pin;
-	uint32_t		channel;
-};
-
 struct adc_accumulator {
 	uint32_t		accumulator;
 	uint32_t		count;
 };
 
-#if defined(PIOS_INCLUDE_ADC)
-static const struct dma_config config[] = PIOS_DMA_PIN_CONFIG;
-#define PIOS_ADC_NUM_PINS	(sizeof(config) / sizeof(config[0]))
+// Buffers to hold the ADC data
+static struct adc_accumulator * accumulator;
+static uint16_t * adc_raw_buffer_0;
+static uint16_t * adc_raw_buffer_1;
 
-static struct adc_accumulator accumulator[PIOS_ADC_NUM_PINS];
 
-// Two buffers here for double buffering
-static uint16_t adc_raw_buffer[2][PIOS_ADC_MAX_SAMPLES][PIOS_ADC_NUM_PINS];
-#endif
-
-#if defined(PIOS_INCLUDE_ADC)
 static void init_pins(void)
 {
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+		return;
+	}
+
 	/* Setup analog pins */
 	GPIO_InitTypeDef GPIO_InitStructure;
 	GPIO_StructInit(&GPIO_InitStructure);
 	GPIO_InitStructure.GPIO_Speed	= GPIO_Speed_2MHz;
 	GPIO_InitStructure.GPIO_Mode	= GPIO_Mode_AIN;
 	
-	for (int32_t i = 0; i < PIOS_ADC_NUM_PINS; i++) {
-		if (config[i].port == NULL)
+	for (int32_t i = 0; i < pios_adc_dev->cfg->adc_pin_count; i++) {
+		if (pios_adc_dev->cfg->adc_pins[i].port == NULL)
 			continue;
-		GPIO_InitStructure.GPIO_Pin = config[i].pin;
-		GPIO_Init(config[i].port, &GPIO_InitStructure);
+		GPIO_InitStructure.GPIO_Pin = pios_adc_dev->cfg->adc_pins[i].pin;
+		GPIO_Init(pios_adc_dev->cfg->adc_pins[i].port, &GPIO_InitStructure);
 	}
 }
 
 static void init_dma(void)
 {
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+		return;
+	}
+
 	/* Disable interrupts */
 	DMA_ITConfig(pios_adc_dev->cfg->dma.rx.channel, pios_adc_dev->cfg->dma.irq.flags, DISABLE);
 
 	/* Configure DMA channel */
 	DMA_DeInit(pios_adc_dev->cfg->dma.rx.channel);
 	DMA_InitTypeDef DMAInit = pios_adc_dev->cfg->dma.rx.init;
-	DMAInit.DMA_Memory0BaseAddr		= (uint32_t)&adc_raw_buffer[0];
-	DMAInit.DMA_BufferSize			= sizeof(adc_raw_buffer[0]) / sizeof(uint16_t);
+	DMAInit.DMA_Memory0BaseAddr		= (uint32_t)&adc_raw_buffer_0[0];
+	DMAInit.DMA_BufferSize			= pios_adc_dev->max_samples * pios_adc_dev->cfg->adc_pin_count;
 	DMAInit.DMA_DIR					= DMA_DIR_PeripheralToMemory;
 	DMAInit.DMA_PeripheralInc		= DMA_PeripheralInc_Disable;
 	DMAInit.DMA_MemoryInc			= DMA_MemoryInc_Enable;
@@ -174,7 +156,7 @@ static void init_dma(void)
 	DMA_Init(pios_adc_dev->cfg->dma.rx.channel, &DMAInit);	/* channel is actually stream ... */
 
 	/* configure for double-buffered mode and interrupt on every buffer flip */
-	DMA_DoubleBufferModeConfig(pios_adc_dev->cfg->dma.rx.channel, (uint32_t)&adc_raw_buffer[1], DMA_Memory_0);
+	DMA_DoubleBufferModeConfig(pios_adc_dev->cfg->dma.rx.channel, (uint32_t)&adc_raw_buffer_1[0], DMA_Memory_0);
 	DMA_DoubleBufferModeCmd(pios_adc_dev->cfg->dma.rx.channel, ENABLE);
 	DMA_ITConfig(pios_adc_dev->cfg->dma.rx.channel, DMA_IT_TC, ENABLE);
 	//DMA_ITConfig(pios_adc_dev->cfg->dma.rx.channel, DMA_IT_HT, ENABLE);
@@ -189,6 +171,10 @@ static void init_dma(void)
 
 static void init_adc(void)
 {
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+		return;
+	}
+
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
 
 	ADC_DeInit();
@@ -212,16 +198,16 @@ static void init_adc(void)
 	ADC_InitStructure.ADC_ContinuousConvMode		= ENABLE;
 	ADC_InitStructure.ADC_ExternalTrigConvEdge		= ADC_ExternalTrigConvEdge_None;
 	ADC_InitStructure.ADC_DataAlign					= ADC_DataAlign_Right;
-	ADC_InitStructure.ADC_NbrOfConversion			= ((PIOS_ADC_NUM_PINS)/* >> 1*/);
+	ADC_InitStructure.ADC_NbrOfConversion			= pios_adc_dev->cfg->adc_pin_count;
 	ADC_Init(pios_adc_dev->cfg->adc_dev_master, &ADC_InitStructure);
 
 	/* Enable DMA request */
 	ADC_DMACmd(pios_adc_dev->cfg->adc_dev_master, ENABLE);
 
 	/* Configure input scan */
-	for (int32_t i = 0; i < PIOS_ADC_NUM_PINS; i++) {
+	for (int32_t i = 0; i < pios_adc_dev->cfg->adc_pin_count; i++) {
 		ADC_RegularChannelConfig(pios_adc_dev->cfg->adc_dev_master,
-				config[i].channel,
+				pios_adc_dev->cfg->adc_pins[i].adc_channel,
 				i+1,
 				ADC_SampleTime_56Cycles);		/* XXX this is totally arbitrary... */
 	}
@@ -233,7 +219,6 @@ static void init_adc(void)
 	ADC_ContinuousModeCmd(pios_adc_dev->cfg->adc_dev_master, ENABLE);
 	ADC_SoftwareStartConv(pios_adc_dev->cfg->adc_dev_master);
 }
-#endif
 
 static bool PIOS_INTERNAL_ADC_validate(struct pios_internal_adc_dev * dev)
 {
@@ -243,13 +228,40 @@ static bool PIOS_INTERNAL_ADC_validate(struct pios_internal_adc_dev * dev)
 	return (dev->magic == PIOS_INTERNAL_ADC_DEV_MAGIC);
 }
 
-static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate()
+static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate(const struct pios_internal_adc_cfg * cfg)
 {
 	struct pios_internal_adc_dev * adc_dev;
-	
+
 	adc_dev = (struct pios_internal_adc_dev *)PIOS_malloc(sizeof(*adc_dev));
-	if (!adc_dev) return (NULL);
-	
+	if (!adc_dev){
+		return NULL;
+	}
+
+	// Maxmimum number of samples (XXX: not sure where the dependency on the ADC used comes from..)
+	bool use_adc_2 = cfg->adc_dev_master == ADC2;
+	adc_dev->max_samples = (((cfg->adc_pin_count + use_adc_2) >> use_adc_2) << use_adc_2) * PIOS_ADC_MAX_OVERSAMPLING * 2;
+
+	accumulator = (struct adc_accumulator *)PIOS_malloc_no_dma(cfg->adc_pin_count * sizeof(struct adc_accumulator));
+	if (!accumulator){
+		PIOS_free(adc_dev);
+		return NULL;
+	}
+
+	adc_raw_buffer_0 = (uint16_t *)PIOS_malloc(adc_dev->max_samples * cfg->adc_pin_count * sizeof(uint16_t));
+	if (!adc_raw_buffer_0){
+		PIOS_free(adc_dev);
+		PIOS_free(accumulator);
+		return NULL;
+	}
+
+	adc_raw_buffer_1 = (uint16_t *)PIOS_malloc(adc_dev->max_samples * cfg->adc_pin_count * sizeof(uint16_t));
+	if (!adc_raw_buffer_1){
+		PIOS_free(adc_dev);
+		PIOS_free(accumulator);
+		PIOS_free(adc_raw_buffer_0);
+		return NULL;
+	}
+
 	adc_dev->magic = PIOS_INTERNAL_ADC_DEV_MAGIC;
 	return(adc_dev);
 }
@@ -259,13 +271,15 @@ static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate()
  */
 int32_t PIOS_INTERNAL_ADC_Init(uint32_t * internal_adc_id, const struct pios_internal_adc_cfg * cfg)
 {
-        pios_adc_dev = PIOS_INTERNAL_ADC_Allocate();
+	pios_adc_dev = PIOS_INTERNAL_ADC_Allocate(cfg);
 	if (pios_adc_dev == NULL)
 		return -1;
 	
 	pios_adc_dev->cfg = cfg;
 	pios_adc_dev->callback_function = NULL;
-	
+
+
+
 #if defined(PIOS_INCLUDE_FREERTOS) || defined(PIOS_INCLUDE_CHIBIOS)
 	pios_adc_dev->data_queue = NULL;
 #endif
@@ -301,14 +315,19 @@ static int32_t PIOS_INTERNAL_ADC_PinGet(uint32_t internal_adc_id, uint32_t pin)
 {
 #if defined(PIOS_INCLUDE_ADC)
 	int32_t	result;
-	
-	/* Check if pin exists */
-	if (pin >= PIOS_ADC_NUM_PINS) {
+
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
 		return -1;
 	}
-	
-	if (accumulator[pin].accumulator <= 0)
+
+	/* Check if pin exists */
+	if (pin >= pios_adc_dev->cfg->adc_pin_count) {
 		return -2;
+	}
+
+	if (accumulator[pin].accumulator <= 0){
+		return -3;
+	}
 
 	/* return accumulated result and clear accumulator */
 	result = accumulator[pin].accumulator / (accumulator[pin].count ?: 1);
@@ -377,12 +396,15 @@ void accumulate(uint16_t *buffer, uint32_t count)
 {
 #if defined(PIOS_INCLUDE_ADC)
 	uint16_t	*sp = buffer;
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+		return;
+	}
 
 	/*
 	 * Accumulate sampled values.
 	 */
 	while (count--) {
-		for (int i = 0; i < PIOS_ADC_NUM_PINS; i++) {
+		for (int i = 0; i < pios_adc_dev->cfg->adc_pin_count; i++) {
 			accumulator[i].accumulator += *sp++;
 			accumulator[i].count++;
 			/*
@@ -428,9 +450,12 @@ void PIOS_INTERNAL_ADC_DMA_Handler(void)
 		DMA_ClearITPendingBit(pios_adc_dev->cfg->dma.rx.channel, pios_adc_dev->cfg->full_flag);
 
 		/* accumulate results from the buffer that was just completed */
-		accumulate(&adc_raw_buffer[DMA_GetCurrentMemoryTarget(pios_adc_dev->cfg->dma.rx.channel) ? 0 : 1][0][0],
-				PIOS_ADC_MAX_SAMPLES);
-
+		if (DMA_GetCurrentMemoryTarget(pios_adc_dev->cfg->dma.rx.channel) == 0){
+			accumulate(adc_raw_buffer_0, pios_adc_dev->max_samples);
+		}
+		else {
+			accumulate(adc_raw_buffer_1, pios_adc_dev->max_samples);
+		}
 	}
 #endif
 }
@@ -441,11 +466,14 @@ void PIOS_INTERNAL_ADC_DMA_Handler(void)
   * \param[in] device_pin pin to check if available
   * \return true if available
   */
-static bool PIOS_INTERNAL_ADC_Available(uint32_t adc_id, uint32_t device_pin) {
+static bool PIOS_INTERNAL_ADC_Available(uint32_t internal_adc_id, uint32_t device_pin) {
+	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *)internal_adc_id;
+	if(!PIOS_INTERNAL_ADC_validate(adc_dev)){
+			return 0;
+	}
 	/* Check if pin exists */
-	return (!(device_pin >= PIOS_ADC_NUM_CHANNELS));
+	return (!(device_pin >= adc_dev->cfg->adc_pin_count));
 }
-
 
 /**
   * @brief Checks the number of available ADC channels on the device
@@ -457,7 +485,7 @@ static uint8_t PIOS_INTERNAL_ADC_Number_of_Channels(uint32_t internal_adc_id)
 	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *)internal_adc_id;
 	if(!PIOS_INTERNAL_ADC_validate(adc_dev))
 			return 0;
-	return PIOS_ADC_NUM_CHANNELS;
+	return adc_dev->cfg->adc_pin_count;
 }
 
 /**
@@ -469,7 +497,7 @@ static float PIOS_INTERNAL_ADC_LSB_Voltage(uint32_t internal_adc_id)
 	if (!PIOS_INTERNAL_ADC_validate(adc_dev)) {
 		return 0;
 	}
-        return VREF_PLUS / (((uint32_t)1 << 12) - 1);
+	return VREF_PLUS / (((uint32_t)1 << 12) - 1);
 }
 #endif /* PIOS_INCLUDE_ADC */
 

--- a/flight/PiOS/STM32F4xx/pios_internal_adc.c
+++ b/flight/PiOS/STM32F4xx/pios_internal_adc.c
@@ -109,7 +109,7 @@ static uint16_t * adc_raw_buffer_1;
 
 static void init_pins(void)
 {
-	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)) {
 		return;
 	}
 
@@ -129,7 +129,7 @@ static void init_pins(void)
 
 static void init_dma(void)
 {
-	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)) {
 		return;
 	}
 
@@ -171,7 +171,7 @@ static void init_dma(void)
 
 static void init_adc(void)
 {
-	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)) {
 		return;
 	}
 
@@ -233,7 +233,7 @@ static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate(const struct pi
 	struct pios_internal_adc_dev * adc_dev;
 
 	adc_dev = (struct pios_internal_adc_dev *)PIOS_malloc(sizeof(*adc_dev));
-	if (!adc_dev){
+	if (!adc_dev) {
 		return NULL;
 	}
 
@@ -242,20 +242,20 @@ static struct pios_internal_adc_dev * PIOS_INTERNAL_ADC_Allocate(const struct pi
 	adc_dev->max_samples = (((cfg->adc_pin_count + use_adc_2) >> use_adc_2) << use_adc_2) * PIOS_ADC_MAX_OVERSAMPLING * 2;
 
 	accumulator = (struct adc_accumulator *)PIOS_malloc_no_dma(cfg->adc_pin_count * sizeof(struct adc_accumulator));
-	if (!accumulator){
+	if (!accumulator) {
 		PIOS_free(adc_dev);
 		return NULL;
 	}
 
 	adc_raw_buffer_0 = (uint16_t *)PIOS_malloc(adc_dev->max_samples * cfg->adc_pin_count * sizeof(uint16_t));
-	if (!adc_raw_buffer_0){
+	if (!adc_raw_buffer_0) {
 		PIOS_free(adc_dev);
 		PIOS_free(accumulator);
 		return NULL;
 	}
 
 	adc_raw_buffer_1 = (uint16_t *)PIOS_malloc(adc_dev->max_samples * cfg->adc_pin_count * sizeof(uint16_t));
-	if (!adc_raw_buffer_1){
+	if (!adc_raw_buffer_1) {
 		PIOS_free(adc_dev);
 		PIOS_free(accumulator);
 		PIOS_free(adc_raw_buffer_0);
@@ -316,7 +316,7 @@ static int32_t PIOS_INTERNAL_ADC_PinGet(uint32_t internal_adc_id, uint32_t pin)
 #if defined(PIOS_INCLUDE_ADC)
 	int32_t	result;
 
-	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)) {
 		return -1;
 	}
 
@@ -325,7 +325,7 @@ static int32_t PIOS_INTERNAL_ADC_PinGet(uint32_t internal_adc_id, uint32_t pin)
 		return -2;
 	}
 
-	if (accumulator[pin].accumulator <= 0){
+	if (accumulator[pin].accumulator <= 0) {
 		return -3;
 	}
 
@@ -396,7 +396,7 @@ void accumulate(uint16_t *buffer, uint32_t count)
 {
 #if defined(PIOS_INCLUDE_ADC)
 	uint16_t	*sp = buffer;
-	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)){
+	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev)) {
 		return;
 	}
 
@@ -450,7 +450,7 @@ void PIOS_INTERNAL_ADC_DMA_Handler(void)
 		DMA_ClearITPendingBit(pios_adc_dev->cfg->dma.rx.channel, pios_adc_dev->cfg->full_flag);
 
 		/* accumulate results from the buffer that was just completed */
-		if (DMA_GetCurrentMemoryTarget(pios_adc_dev->cfg->dma.rx.channel) == 0){
+		if (DMA_GetCurrentMemoryTarget(pios_adc_dev->cfg->dma.rx.channel) == 0) {
 			accumulate(adc_raw_buffer_0, pios_adc_dev->max_samples);
 		}
 		else {
@@ -468,7 +468,7 @@ void PIOS_INTERNAL_ADC_DMA_Handler(void)
   */
 static bool PIOS_INTERNAL_ADC_Available(uint32_t internal_adc_id, uint32_t device_pin) {
 	struct pios_internal_adc_dev * adc_dev = (struct pios_internal_adc_dev *)internal_adc_id;
-	if(!PIOS_INTERNAL_ADC_validate(adc_dev)){
+	if(!PIOS_INTERNAL_ADC_validate(adc_dev)) {
 			return 0;
 	}
 	/* Check if pin exists */

--- a/flight/PiOS/STM32F4xx/pios_internal_adc.c
+++ b/flight/PiOS/STM32F4xx/pios_internal_adc.c
@@ -68,7 +68,7 @@ struct pios_internal_adc_dev {
 	volatile uint8_t adc_oversample;
 	uint8_t dma_block_size;
 	uint16_t dma_half_buffer_size;
-	uint32_t max_samples;
+	uint16_t max_samples;
 	enum pios_adc_dev_magic magic;
 };
 

--- a/flight/PiOS/inc/pios_internal_adc.h
+++ b/flight/PiOS/inc/pios_internal_adc.h
@@ -31,8 +31,6 @@
 #ifndef PIOS_INTERNAL_ADC_H
 #define PIOS_INTERNAL_ADC_H
 
-// Maximum of 50 oversampled points
-#define PIOS_ADC_MAX_SAMPLES ((((PIOS_ADC_NUM_CHANNELS + PIOS_ADC_USE_ADC2) >> PIOS_ADC_USE_ADC2) << PIOS_ADC_USE_ADC2)* PIOS_ADC_MAX_OVERSAMPLING * 2)
 extern void PIOS_INTERNAL_ADC_DMA_Handler();
 typedef void (*ADCCallback) (float * data);
 

--- a/flight/PiOS/inc/pios_internal_adc_priv.h
+++ b/flight/PiOS/inc/pios_internal_adc_priv.h
@@ -44,6 +44,9 @@ struct adc_pin {
 	GPIO_TypeDef *port; 	/**< port of the pin ex:GPIOC */
 	uint32_t pin; 		/**< port pin number ex:GPIO_Pin_3 */
 	uint8_t adc_channel; 	/**< adc channel corresponding to the pin ex:ADC_Channel_9 */
+#if !defined(STM32F40_41xxx)
+	bool is_master_channel;	/**< true if this pin belongs to the master adc */
+#endif /* !STM32F40_41xxx */
 };
 
 /**
@@ -51,9 +54,13 @@ struct adc_pin {
  */
 struct pios_internal_adc_cfg {
 	ADC_TypeDef* adc_dev_master;	/**< ADC master ex:ADC1 */
+#if !defined(STM32F40_41xxx)
+	ADC_TypeDef* adc_dev_slave;	/**< ADC slave to use in ADC dual mode leave unset or NULL for single mode */
+#endif /* !STM32F40_41xxx */
 	struct stm32_dma dma;		/**< DMA configuration structure */
 	uint32_t half_flag;		/**< DMA half buffer flag ex:DMA1_IT_HT1 */
 	uint32_t full_flag;		/**< DMA buffer full flag ex:DMA1_IT_TC1 */
+	uint32_t oversampling;	/**< oversampling */
 	uint8_t adc_pin_count;	/**< Number of ADC pins to use */
 	struct adc_pin adc_pins[];	/**< Array of pins to use */
 };

--- a/flight/PiOS/inc/pios_internal_adc_priv.h
+++ b/flight/PiOS/inc/pios_internal_adc_priv.h
@@ -44,7 +44,6 @@ struct adc_pin {
 	GPIO_TypeDef *port; 	/**< port of the pin ex:GPIOC */
 	uint32_t pin; 		/**< port pin number ex:GPIO_Pin_3 */
 	uint8_t adc_channel; 	/**< adc channel corresponding to the pin ex:ADC_Channel_9 */
-	bool is_master_channel;	/**< true if this pin belongs to the master adc */
 };
 
 /**
@@ -52,15 +51,11 @@ struct adc_pin {
  */
 struct pios_internal_adc_cfg {
 	ADC_TypeDef* adc_dev_master;	/**< ADC master ex:ADC1 */
-	ADC_TypeDef* adc_dev_slave;	/**< ADC slave to use in ADC dual mode leave unset or NULL for single mode */
-	TIM_TypeDef* timer;		/**<  */
 	struct stm32_dma dma;		/**< DMA configuration structure */
 	uint32_t half_flag;		/**< DMA half buffer flag ex:DMA1_IT_HT1 */
 	uint32_t full_flag;		/**< DMA buffer full flag ex:DMA1_IT_TC1 */
-	uint16_t max_downsample;	/**< maximum downsample */
-	uint32_t oversampling;		/**< oversampling */
-	uint8_t number_of_used_pins;	/**< number of pins to use. Normally the size of the adc_pins array */
-	struct adc_pin *adc_pins;	/**< pointer to the array of pins to use */
+	uint8_t adc_pin_count;	/**< Number of ADC pins to use */
+	struct adc_pin adc_pins[];	/**< Array of pins to use */
 };
 
 extern int32_t PIOS_INTERNAL_ADC_Init(uint32_t * internal_adc_id, const struct pios_internal_adc_cfg * cfg);

--- a/flight/targets/aq32/board-info/board_hw_defs.c
+++ b/flight/targets/aq32/board-info/board_hw_defs.c
@@ -1889,7 +1889,14 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	.full_flag = DMA_IT_TCIF4,
 
 	.adc_dev_master = ADC1,
-	.adc_dev_slave  = NULL,
+	.adc_pins =  {                                                                                \
+		{ GPIOC, GPIO_Pin_0,     ADC_Channel_10 },                /* Internal Voltage Monitor */  \
+		{ GPIOC, GPIO_Pin_4,     ADC_Channel_14 },                /* External Voltage Monitor */  \
+		{ GPIOC, GPIO_Pin_5,     ADC_Channel_15 },                /* External Current Monitor */  \
+		{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
+		{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
+	},
+	.adc_pin_count = 5,
 };
 
 void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/aq32/board-info/pios_board.h
+++ b/flight/targets/aq32/board-info/pios_board.h
@@ -222,24 +222,7 @@ extern uintptr_t pios_com_debug_id;
 // ADC
 //-------------------------
 #define PIOS_ADC_SUB_DRIVER_MAX_INSTANCES       3
-
-//-------------------------
-#define PIOS_DMA_PIN_CONFIG                                                                   \
-{                                                                                             \
-	{ GPIOC, GPIO_Pin_0,     ADC_Channel_10 },                /* Internal Voltage Monitor */  \
-	{ GPIOC, GPIO_Pin_4,     ADC_Channel_14 },                /* External Voltage Monitor */  \
-	{ GPIOC, GPIO_Pin_5,     ADC_Channel_15 },                /* External Current Monitor */  \
-	{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
-	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
-}
-
-/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_internal_adc.h */
-/* which is annoying because this then determines the rate at which we generate buffer turnover events */
-/* the objective here is to get enough buffer space to support 100Hz averaging rate */
-#define PIOS_ADC_NUM_CHANNELS           5
 #define PIOS_ADC_MAX_OVERSAMPLING       2
-#define PIOS_ADC_USE_ADC2               0
-
 #define VREF_PLUS			3.3
 
 //-------------------------

--- a/flight/targets/colibri/board-info/board_hw_defs.c
+++ b/flight/targets/colibri/board-info/board_hw_defs.c
@@ -2182,6 +2182,13 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 		},
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
+	.adc_pins = {                                                                                 \
+		{ GPIOA, GPIO_Pin_0,     ADC_Channel_0 },                                                 \
+		{ GPIOA, GPIO_Pin_1,     ADC_Channel_1 },                                                 \
+		{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
+		{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
+	},
+	.adc_pin_count = 4,
 };
 
 void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/colibri/board-info/pios_board.h
+++ b/flight/targets/colibri/board-info/pios_board.h
@@ -224,23 +224,8 @@ extern uintptr_t pios_com_debug_id;
 // ADC
 //-------------------------
 #define PIOS_ADC_SUB_DRIVER_MAX_INSTANCES       3
-
-// PIOS_ADC_PinGet(0) = IN7
-// PIOS_ADC_PinGet(1) = IN8
-//-------------------------
 #define PIOS_DMA_PIN_CONFIG                                                                   \
-{                                                                                             \
-	{ GPIOA, GPIO_Pin_0,     ADC_Channel_0 },                                                 \
-	{ GPIOA, GPIO_Pin_1,     ADC_Channel_1 },                                                 \
-	{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
-	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
-	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
-}
 
-/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
-/* which is annoying because this then determines the rate at which we generate buffer turnover events */
-/* the objective here is to get enough buffer space to support 100Hz averaging rate */
-#define PIOS_ADC_NUM_CHANNELS           5
 #define PIOS_ADC_MAX_OVERSAMPLING       2
 #define PIOS_ADC_USE_ADC2               0
 

--- a/flight/targets/flyingf3/board-info/board_hw_defs.c
+++ b/flight/targets/flyingf3/board-info/board_hw_defs.c
@@ -2744,8 +2744,11 @@ static const struct pios_internal_adc_cfg internal_adc_cfg_rcflyer_shield = {
 	.oversampling = 32,
 	.adc_dev_master = ADC1,
 	.adc_dev_slave = ADC2,
-	.number_of_used_pins = 2,
-	.adc_pins = (struct adc_pin[]){{GPIOC,GPIO_Pin_3,ADC_Channel_9,true},{GPIOC,GPIO_Pin_4,ADC_Channel_5,false},},
+	.adc_pin_count = 2,
+	.adc_pins = {
+		{GPIOC,GPIO_Pin_3,ADC_Channel_9,true},
+		{GPIOC,GPIO_Pin_4,ADC_Channel_5,false},
+	},
 };
 #endif //PIOS_INCLUDE_ADC
 

--- a/flight/targets/flyingf4/board-info/board_hw_defs.c
+++ b/flight/targets/flyingf4/board-info/board_hw_defs.c
@@ -1777,7 +1777,13 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	},
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
-	
+	.adc_pins = {                                                                    \
+		{GPIOC, GPIO_Pin_1,     ADC_Channel_11         },                            \
+		{GPIOC, GPIO_Pin_2,     ADC_Channel_12         },                            \
+		{NULL,  0,              ADC_Channel_Vrefint    },  /* Voltage reference */   \
+		{NULL,  0,              ADC_Channel_TempSensor },  /* Temperature sensor */  \
+	},
+	.adc_pin_count = 4,
 };
 
 void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/flyingf4/board-info/pios_board.h
+++ b/flight/targets/flyingf4/board-info/pios_board.h
@@ -222,26 +222,7 @@ extern uintptr_t pios_com_debug_id;
 // ADC
 //-------------------------
 #define PIOS_ADC_SUB_DRIVER_MAX_INSTANCES       3
-
-// PIOS_ADC_PinGet(0) = PC_11
-// PIOS_ADC_PinGet(1) = PC_12
-//-------------------------
-#define PIOS_DMA_PIN_CONFIG                                                       \
-{                                                                                 \
-    { GPIOC, GPIO_Pin_1,     ADC_Channel_11         },                            \
-    { GPIOC, GPIO_Pin_2,     ADC_Channel_12         },                            \
-    { NULL,  0,              ADC_Channel_Vrefint    },  /* Voltage reference */   \
-    { NULL,  0,              ADC_Channel_TempSensor },  /* Temperature sensor */  \
-    { GPIOC, GPIO_Pin_1,     ADC_Channel_11         }                             \
-}
-
-/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
-/* which is annoying because this then determines the rate at which we generate buffer turnover events */
-/* the objective here is to get enough buffer space to support 100Hz averaging rate */
-#define PIOS_ADC_NUM_CHANNELS           4
 #define PIOS_ADC_MAX_OVERSAMPLING       2
-#define PIOS_ADC_USE_ADC2               0
-
 #define VREF_PLUS                       3.3
 
 

--- a/flight/targets/naze32/board-info/board_hw_defs.c
+++ b/flight/targets/naze32/board-info/board_hw_defs.c
@@ -257,9 +257,9 @@ static const struct pios_internal_adc_cfg internal_adc_cfg = {
 			},
 		}
 	},
-	.number_of_used_pins = 4, // this is the max number, can be reduced at runtime (due to port config)
+	.adc_pin_count = 4, // this is the max number, can be reduced at runtime (due to port config)
 	.adc_dev_master = ADC1,
-	.adc_pins = (struct adc_pin[]){
+	.adc_pins = {
 		{GPIOA, GPIO_Pin_4, ADC_Channel_4, true},  // VBat
 		{GPIOA, GPIO_Pin_5, ADC_Channel_5, true},  // ADC Pad
 		{GPIOA, GPIO_Pin_1, ADC_Channel_1, true},  // RC IN 2

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2255,6 +2255,13 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	},
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
+	.adc_pins = {                                                                                 \
+		{ GPIOA, GPIO_Pin_0,     ADC_Channel_0 },                                                 \
+		{ GPIOA, GPIO_Pin_1,     ADC_Channel_1 },                                                 \
+		{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
+		{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
+	},
+	.adc_pin_count = 4
 };
 
 void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/quanton/board-info/pios_board.h
+++ b/flight/targets/quanton/board-info/pios_board.h
@@ -233,24 +233,8 @@ extern uintptr_t pios_com_debug_id;
 
 // PIOS_ADC_PinGet(0) = IN7
 // PIOS_ADC_PinGet(1) = IN8
-//-------------------------
-#define PIOS_DMA_PIN_CONFIG                                                                   \
-{                                                                                             \
-	{ GPIOA, GPIO_Pin_0,     ADC_Channel_0 },                                                 \
-	{ GPIOA, GPIO_Pin_1,     ADC_Channel_1 },                                                 \
-	{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
-	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
-	{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
-}
-
-/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
-/* which is annoying because this then determines the rate at which we generate buffer turnover events */
-/* the objective here is to get enough buffer space to support 100Hz averaging rate */
-#define PIOS_ADC_NUM_CHANNELS           5
 #define PIOS_ADC_MAX_OVERSAMPLING       2
-#define PIOS_ADC_USE_ADC2               0
-
-#define VREF_PLUS			3.3
+#define VREF_PLUS                     3.3
 
 //-------------------------
 // USB

--- a/flight/targets/revomini/board-info/board_hw_defs.c
+++ b/flight/targets/revomini/board-info/board_hw_defs.c
@@ -1676,7 +1676,13 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	},
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
-
+	.adc_pins = {                                                                                           \
+		{GPIOC, GPIO_Pin_1,     ADC_Channel_11},                                                \
+		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                                                \
+		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
+		{NULL,  0,              ADC_Channel_TempSensor},        /* Temperature sensor */        \
+	},
+	.adc_pin_count = 4,
 };
 
 struct stm32_gpio pios_current_sonar_pin ={

--- a/flight/targets/revomini/board-info/pios_board.h
+++ b/flight/targets/revomini/board-info/pios_board.h
@@ -243,28 +243,8 @@ extern uint32_t pios_packet_handler;
 
 //-------------------------
 // ADC
-// PIOS_ADC_PinGet(0) = Current sensor
-// PIOS_ADC_PinGet(1) = Voltage sensor
-// PIOS_ADC_PinGet(4) = VREF
-// PIOS_ADC_PinGet(5) = Temperature sensor
-//-------------------------
-#define PIOS_DMA_PIN_CONFIG                                                                 \
-{                                                                                           \
-	{GPIOC, GPIO_Pin_1,     ADC_Channel_11},                                                \
-	{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                                                \
-	{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
-	{NULL,  0,              ADC_Channel_TempSensor},        /* Temperature sensor */        \
-	{GPIOC, GPIO_Pin_2,     ADC_Channel_12}  \
-}
-
-/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
-/* which is annoying because this then determines the rate at which we generate buffer turnover events */
-/* the objective here is to get enough buffer space to support 100Hz averaging rate */
-#define PIOS_ADC_NUM_CHANNELS           4
 #define PIOS_ADC_MAX_OVERSAMPLING       2
-#define PIOS_ADC_USE_ADC2               0
-
-#define VREF_PLUS			3.3
+#define VREF_PLUS                     3.3
 
 //-------------------------
 // USB

--- a/flight/targets/sparky/board-info/board_hw_defs.c
+++ b/flight/targets/sparky/board-info/board_hw_defs.c
@@ -1420,12 +1420,12 @@ static struct pios_internal_adc_cfg internal_adc_cfg = {
 	.half_flag = DMA1_IT_HT1,
 	.full_flag = DMA1_IT_TC1,
 	.oversampling = 32,
-	.number_of_used_pins = 3,
-	.adc_pins = (struct adc_pin[]){
+	.adc_pins = {
 		{GPIOA,GPIO_Pin_1,ADC_Channel_2,true},
 		{GPIOA,GPIO_Pin_4,ADC_Channel_1,false},
 		{GPIOA,GPIO_Pin_7,ADC_Channel_4,false},
 	},
+	.adc_pin_count = 3,
 	.adc_dev_master = ADC1,
 	.adc_dev_slave = ADC2,
 };

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -467,7 +467,7 @@ void PIOS_Board_Init(void)
 
 #if defined(PIOS_INCLUDE_ADC)
 	if (number_of_adc_ports > 0) {
-		internal_adc_cfg.number_of_used_pins = number_of_adc_ports;
+		internal_adc_cfg.adc_pin_count = number_of_adc_ports;
 		uint32_t internal_adc_id;
 		if (PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg) < 0)
 			PIOS_Assert(0);

--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -1808,7 +1808,13 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	},
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
-
+	.adc_pins = {                                                                               \
+		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Current sensor */            \
+		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Voltage sensor */            \
+		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
+		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \
+	},
+	.adc_pin_count = 4
 };
 
 struct stm32_gpio pios_current_sonar_pin ={

--- a/flight/targets/sparky2/board-info/pios_board.h
+++ b/flight/targets/sparky2/board-info/pios_board.h
@@ -241,28 +241,9 @@ extern uint32_t pios_packet_handler;
 
 //-------------------------
 // ADC
-// PIOS_ADC_PinGet(0) = Current sensor
-// PIOS_ADC_PinGet(1) = Voltage sensor
-// PIOS_ADC_PinGet(4) = VREF
-// PIOS_ADC_PinGet(5) = Temperature sensor
 //-------------------------
-#define PIOS_DMA_PIN_CONFIG                                                                 \
-{                                                                                           \
-	{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                                                \
-	{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                                                \
-	{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
-	{NULL,  0,              ADC_Channel_TempSensor},        /* Temperature sensor */        \
-	{GPIOC, GPIO_Pin_2,     ADC_Channel_12}  \
-}
-
-/* we have to do all this to satisfy the PIOS_ADC_MAX_SAMPLES define in pios_adc.h */
-/* which is annoying because this then determines the rate at which we generate buffer turnover events */
-/* the objective here is to get enough buffer space to support 100Hz averaging rate */
-#define PIOS_ADC_NUM_CHANNELS           4
 #define PIOS_ADC_MAX_OVERSAMPLING       2
-#define PIOS_ADC_USE_ADC2               0
-
-#define VREF_PLUS			3.3
+#define VREF_PLUS                     3.3
 
 //-------------------------
 // USB


### PR DESCRIPTION
Changes the ADC code to make the pins runtime configurable using a struct defined in `board_hw_defs.c` instead of a `define` in `pios_board.h`. This allows e.g. to have different ADC pin configurations for a board that can be selected by the user using the hardware config UAVO. Also removes all unused parameters from `struct pios_internal_adc_cfg`.

I have tested this on an F4 board, someone should test this on Quanton and Sparky2. I will modify the code for the other targets once everyone is happy.
