### PR TITLE
autotune: add a prediction counter

### DIFF
--- a/shared/uavobjectdefinition/systemident.xml
+++ b/shared/uavobjectdefinition/systemident.xml
@@ -6,6 +6,7 @@
 	<field name="Bias" units="" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0"/>
 	<field name="Noise" units="(deg/s)^2" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0"/>
 	<field name="Period" units="ms" type="float" elements="1" defaultvalue="0"/>
+	<field name="NumAfPredicts" units="" type="uint32" elements="1" defaultvalue="0"/>
         <access gcs="readonly" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="onchange" period="1000"/>


### PR DESCRIPTION
1. Autotune now says how many times it ran; this can be compared to the expected value (20,000) to see if points are being dropped.
2. Autotune now only updates the systemident object every 256 cycles to save a little CPU and to not spam telemetry links.
