### PR TITLE
ManualControl: ignore attempts at arming when not safe

### DIFF
--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -67,13 +67,15 @@ static uint32_t lastSysTime;
 
 // Private functions
 static void manualControlTask(void *parameters);
-static bool ok_to_arm(void);
 static FlightStatusControlSourceOptions control_source_select();
 
 // Private functions for control events
 static int32_t control_event_arm();
 static int32_t control_event_arming();
 static int32_t control_event_disarm();
+
+// This is exposed to transmitter_control
+bool ok_to_arm(void);
 
 /**
  * Module starting
@@ -270,7 +272,7 @@ static FlightStatusControlSourceOptions control_source_select()
  * @brief Determine if the aircraft is safe to arm based on alarms
  * @returns True if safe to arm, false otherwise
  */
-static bool ok_to_arm(void)
+bool ok_to_arm(void)
 {
 	// read alarms
 	SystemAlarmsData alarms;

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -107,6 +107,9 @@ static bool updateRcvrActivity(struct rcvr_activity_fsm * fsm);
 static void manual_control_settings_updated(UAVObjEvent * ev);
 static void set_loiter_command(ManualControlCommandData * cmd);
 
+// Exposed from manualcontrol to prevent attempts to arm when unsafe
+extern bool ok_to_arm();
+
 #define assumptions (assumptions1 && assumptions3 && assumptions5 && assumptions_flightmode && assumptions_channelcount)
 
 //! Initialize the transmitter control mode
@@ -510,6 +513,10 @@ static void set_armed_if_changed(uint8_t new_arm) {
  * Check sticks to determine if they are in the arming position
  */
 static bool arming_position(ManualControlCommandData * cmd, ManualControlSettingsData * settings) {
+
+	// If system is not appropriate to arm, do not even attempt
+	if (!ok_to_arm())
+		return false;
 
 	bool lowThrottle = cmd->Throttle <= 0;
 

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -111,14 +111,11 @@ static void set_loiter_command(ManualControlCommandData * cmd);
 extern bool ok_to_arm();
 
 #define assumptions (assumptions1 && assumptions3 && assumptions5 && assumptions_flightmode && assumptions_channelcount)
+DONT_BUILD_IF(!assumptions, TransmitterControlAssumptions);
 
 //! Initialize the transmitter control mode
 int32_t transmitter_control_initialize()
 {
-	/* Check the assumptions about uavobject enum's are correct */
-	if(!assumptions)
-		return -1;
-
 	AccessoryDesiredInitialize();
 	ManualControlCommandInitialize();
 	FlightStatusInitialize();


### PR DESCRIPTION
Previously transmitter_control did not account for the state of
the system's safety to arm when checking the sticks. This could
result in the inner module (transmitter_control) considering
itself armed and constantly trying to fire arm events at the
outer module. As soon as the error condition cleared (e.g. GPS
lock occuring) the system would arm and process inputs.
