### PR TITLE
uavobjgenerator:  Ensure rebuild of flight when necessary

### DIFF
--- a/ground/uavobjgenerator/main.cpp
+++ b/ground/uavobjgenerator/main.cpp
@@ -244,6 +244,8 @@ int main(int argc, char *argv[])
         wiresharkgen.generate(parser,templatepath,outputpath);
     }
 
+    bool changed = false;
+
     /* Symlink each of these to the current dir */
     QDir dir(outputpath);
     QFileInfoList files = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
@@ -253,9 +255,20 @@ int main(int argc, char *argv[])
         dir.rmpath(file.fileName());
         dir.rename(file.absoluteFilePath(), file.fileName());
 #else
-        QFile::remove(file.fileName());
-        QFile::link(file.absoluteFilePath(), file.fileName());
+        if (QFile::symLinkTarget(file.fileName()) != file.absoluteFilePath()) {
+            QFile::remove(file.fileName());
+            QFile::link(file.absoluteFilePath(), file.fileName());
+            changed = true;
+        }
 #endif
+    }
+
+    /* If anything has changed, ensure flight stuff gets rebuilt */
+    if (changed) {
+        cout << "UAVO version updated, forcing rebuild of all" << endl ;
+        QFile touch(QString("flight/uavoversion.h"));
+        /* This updates the file modification time, so make knows */
+        touch.resize(touch.size());
     }
 
     return RETURN_OK;


### PR DESCRIPTION
This code had one remaining weakness-- on non-windows platforms, if you
edited a file and then put it back UAVobjs might not get rebuilt due to
moving to an "old" timestamp.  Now we touch the version file to ensure
that this is OK.

Tested and confirmed to work with multiple instances of moving back and forth in tree.
