### PR TITLE
flight: remove support for original coptercontrol (not CC3D)

### DIFF
--- a/flight/Modules/Attitude/smallf1/attitude.c
+++ b/flight/Modules/Attitude/smallf1/attitude.c
@@ -73,15 +73,6 @@ static void AttitudeTask(void *parameters);
 
 static float gyro_correct_int[3] = {0,0,0};
 
-#ifdef COPTERCONTROL
-static struct pios_queue *gyro_queue;
-
-static int32_t updateSensors(AccelsData *, GyrosData *);
-#define ADXL345_ACCEL_SCALE  (GRAVITY * 0.004f)
-/* 0.004f is gravity / LSB */
-
-#endif
-
 static int32_t updateSensorsDigital(AccelsData * accelsData, GyrosData * gyrosData);
 static void updateAttitude(AccelsData *, GyrosData *);
 static void settingsUpdatedCb(UAVObjEvent * objEv);
@@ -179,29 +170,6 @@ static void AttitudeTask(void *parameters)
 {
 	AlarmsClear(SYSTEMALARMS_ALARM_ATTITUDE);
 
-#ifdef COPTERCONTROL
-	// Set critical error and wait until the accel is producing data
-	while(PIOS_ADXL345_FifoElements() == 0) {
-		AlarmsSet(SYSTEMALARMS_ALARM_ATTITUDE, SYSTEMALARMS_ALARM_CRITICAL);
-		PIOS_WDG_UpdateFlag(PIOS_WDG_ATTITUDE);
-	}
-
-	const struct pios_board_info * bdinfo = &pios_board_info_blob;
-
-	bool cc3d = bdinfo->board_rev == 0x02;
-
-	if (!cc3d) {
-#if defined(PIOS_INCLUDE_ADC)
-		// Create queue for passing gyro data, allow 2 back samples in case
-		gyro_queue = PIOS_Queue_Create(1, sizeof(float) * 4);
-		PIOS_Assert(gyro_queue != NULL);
-		PIOS_ADC_SetQueue(PIOS_INTERNAL_ADC,gyro_queue);
-
-		PIOS_SENSORS_SetMaxGyro(500);
-#endif
-	}
-#endif
-	
 	// Force settings update to make sure rotation loaded
 	settingsUpdatedCb(AttitudeSettingsHandle());
 	
@@ -282,14 +250,7 @@ static void AttitudeTask(void *parameters)
 		GyrosData gyros;
 		int32_t retval = 0;
 
-#ifdef COPTERCONTROL
-		if (cc3d)
-			retval = updateSensorsDigital(&accels, &gyros);
-		else
-			retval = updateSensors(&accels, &gyros);
-#else
 		retval = updateSensorsDigital(&accels, &gyros);
-#endif
 
 		// During power on set to angle from accel
 		if (complimentary_filter_status == CF_POWERON) {
@@ -313,69 +274,6 @@ static void AttitudeTask(void *parameters)
 		}
 	}
 }
-
-#ifdef COPTERCONTROL
-/**
- * Get an update from the sensors
- * @param[in] attitudeRaw Populate the UAVO instead of saving right here
- * @return 0 if successfull, -1 if not
- */
-static int32_t updateSensors(AccelsData * accelsData, GyrosData * gyrosData)
-{
-	struct pios_adxl345_data accel_data;
-	float gyro[4];
-
-	// Only wait the time for two nominal updates before setting an alarm
-	if (PIOS_Queue_Receive(gyro_queue, (void * const) gyro, PIOS_INTERNAL_ADC_UPDATE_RATE * 2) == false) {
-		AlarmsSet(SYSTEMALARMS_ALARM_ATTITUDE, SYSTEMALARMS_ALARM_ERROR);
-		return -1;
-	}
-
-	// Do not read raw sensor data in simulation mode
-	if (GyrosReadOnly() || AccelsReadOnly())
-		return 0;
-
-	// No accel data available
-	if(PIOS_ADXL345_FifoElements() == 0)
-		return -1;
-
-	// Convert the ADC data into the standard normalized format
-	struct pios_sensor_gyro_data gyros;
-	gyros.temperature = gyro[0];
-	gyros.x = -(gyro[1] - GYRO_NEUTRAL) * IDG_GYRO_GAIN;
-	gyros.y = (gyro[2] - GYRO_NEUTRAL) * IDG_GYRO_GAIN;
-	gyros.z = -(gyro[3] - GYRO_NEUTRAL) * IDG_GYRO_GAIN;
-
-	// Convert the ADXL345 data into the standard normalized format
-	int32_t x = 0;
-	int32_t y = 0;
-	int32_t z = 0;
-	uint8_t i = 0;
-	uint8_t samples_remaining;
-	do {
-		i++;
-		samples_remaining = PIOS_ADXL345_Read(&accel_data);
-		x +=  accel_data.x;
-		y += -accel_data.y;
-		z += -accel_data.z;
-	} while ( (i < 32) && (samples_remaining > 0) );
-
-	struct pios_sensor_accel_data accels;
-
-	accels.x = ((float) x / i) * ADXL345_ACCEL_SCALE;
-	accels.y = ((float) y / i) * ADXL345_ACCEL_SCALE;
-	accels.z = ((float) z / i) * ADXL345_ACCEL_SCALE;
-
-	// Apply rotation / calibration and assign to the UAVO
-	update_gyros(&gyros, gyrosData);
-	update_accels(&accels, accelsData);
-
-	GyrosSet(gyrosData);
-	AccelsSet(accelsData);
-
-	return 0;
-}
-#endif
 
 /**
  * Get an update from the sensors

--- a/flight/targets/coptercontrol/bl/pios_board.c
+++ b/flight/targets/coptercontrol/bl/pios_board.c
@@ -76,16 +76,7 @@ void PIOS_Board_Init(void)
 	PIOS_USB_DESC_HID_ONLY_Init();
 
 	uintptr_t pios_usb_id;
-	switch(bdinfo->board_rev) {
-		case BOARD_REVISION_CC:
-			PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg_cc);
-			break;
-		case BOARD_REVISION_CC3D:
-			PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg_cc3d);
-			break;
-		default:
-			PIOS_Assert(0);
-	}
+	PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg_cc3d);
 #if defined(PIOS_INCLUDE_USB_HID) && defined(PIOS_INCLUDE_COM_MSG)
 	uintptr_t pios_usb_hid_id;
 	if (PIOS_USB_HID_Init(&pios_usb_hid_id, &pios_usb_hid_cfg, pios_usb_id)) {

--- a/flight/targets/coptercontrol/board-info/board_hw_defs.c
+++ b/flight/targets/coptercontrol/board-info/board_hw_defs.c
@@ -37,24 +37,6 @@
 #if defined(PIOS_INCLUDE_LED)
 
 #include <pios_led_priv.h>
-static const struct pios_led pios_leds_cc[] = {
-	[PIOS_LED_HEARTBEAT] = {
-		.pin = {
-			.gpio = GPIOA,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_6,
-				.GPIO_Mode  = GPIO_Mode_Out_PP,
-				.GPIO_Speed = GPIO_Speed_50MHz,
-			},
-		},
-	},
-};
-
-static const struct pios_led_cfg pios_led_cfg_cc = {
-	.leds     = pios_leds_cc,
-	.num_leds = NELEMENTS(pios_leds_cc),
-};
-
 static const struct pios_led pios_leds_cc3d[] = {
 	[PIOS_LED_HEARTBEAT] = {
 		.pin = {
@@ -77,7 +59,6 @@ static const struct pios_led_cfg pios_led_cfg_cc3d = {
 const struct pios_led_cfg * PIOS_BOARD_HW_DEFS_GetLedCfg (uint32_t board_revision)
 {
 	switch (board_revision) {
-	case BOARD_REVISION_CC:		return &pios_led_cfg_cc;
 	case BOARD_REVISION_CC3D:	return &pios_led_cfg_cc3d;
 	default:			return NULL;
 	}
@@ -297,102 +278,6 @@ static const struct pios_spi_cfg pios_spi_flash_accel_cfg_cc3d = {
 		}},
 };
 
-static const struct pios_spi_cfg pios_spi_flash_accel_cfg_cc = {
-	.regs   = SPI2,
-	.init   = {
-		.SPI_Mode              = SPI_Mode_Master,
-		.SPI_Direction         = SPI_Direction_2Lines_FullDuplex,
-		.SPI_DataSize          = SPI_DataSize_8b,
-		.SPI_NSS               = SPI_NSS_Soft,
-		.SPI_FirstBit          = SPI_FirstBit_MSB,
-		.SPI_CRCPolynomial     = 7,
-		.SPI_CPOL              = SPI_CPOL_High,
-		.SPI_CPHA              = SPI_CPHA_2Edge,
-		.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_8, 
-	},
-	.use_crc = false,
-	.dma = {
-		.ahb_clk  = RCC_AHBPeriph_DMA1,
-		
-		.irq = {
-			.flags   = (DMA1_FLAG_TC4 | DMA1_FLAG_TE4 | DMA1_FLAG_HT4 | DMA1_FLAG_GL4),
-			.init    = {
-				.NVIC_IRQChannel                   = DMA1_Channel4_IRQn,
-				.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_HIGH,
-				.NVIC_IRQChannelSubPriority        = 0,
-				.NVIC_IRQChannelCmd                = ENABLE,
-			},
-		},
-		
-		.rx = {
-			.channel = DMA1_Channel4,
-			.init    = {
-				.DMA_PeripheralBaseAddr = (uint32_t)&(SPI2->DR),
-				.DMA_DIR                = DMA_DIR_PeripheralSRC,
-				.DMA_PeripheralInc      = DMA_PeripheralInc_Disable,
-				.DMA_MemoryInc          = DMA_MemoryInc_Enable,
-				.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte,
-				.DMA_MemoryDataSize     = DMA_MemoryDataSize_Byte,
-				.DMA_Mode               = DMA_Mode_Normal,
-				.DMA_Priority           = DMA_Priority_High,
-				.DMA_M2M                = DMA_M2M_Disable,
-			},
-		},
-		.tx = {
-			.channel = DMA1_Channel5,
-			.init    = {
-				.DMA_PeripheralBaseAddr = (uint32_t)&(SPI2->DR),
-				.DMA_DIR                = DMA_DIR_PeripheralDST,
-				.DMA_PeripheralInc      = DMA_PeripheralInc_Disable,
-				.DMA_MemoryInc          = DMA_MemoryInc_Enable,
-				.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte,
-				.DMA_MemoryDataSize     = DMA_MemoryDataSize_Byte,
-				.DMA_Mode               = DMA_Mode_Normal,
-				.DMA_Priority           = DMA_Priority_High,
-				.DMA_M2M                = DMA_M2M_Disable,
-			},
-		},
-	},
-	.sclk = {
-		.gpio = GPIOB,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_13,
-			.GPIO_Speed = GPIO_Speed_10MHz,
-			.GPIO_Mode  = GPIO_Mode_AF_PP,
-		},
-	},
-	.miso = {
-		.gpio = GPIOB,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_14,
-			.GPIO_Speed = GPIO_Speed_10MHz,
-			.GPIO_Mode  = GPIO_Mode_IN_FLOATING,
-		},
-	},
-	.mosi = {
-		.gpio = GPIOB,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_15,
-			.GPIO_Speed = GPIO_Speed_10MHz,
-			.GPIO_Mode  = GPIO_Mode_AF_PP,
-		},
-	},
-	.slave_count = 2,
-	.ssel = {{
-		.gpio = GPIOB,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_12,
-			.GPIO_Speed = GPIO_Speed_50MHz,
-			.GPIO_Mode  = GPIO_Mode_Out_PP,
-		}},{
-			.gpio = GPIOA,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_7,
-				.GPIO_Speed = GPIO_Speed_50MHz,
-				.GPIO_Mode  = GPIO_Mode_Out_PP,
-			},
-		}},
-};
 
 static uint32_t pios_spi_flash_accel_id;
 void PIOS_SPI_flash_accel_irq_handler(void)
@@ -494,48 +379,6 @@ static const struct pios_flash_chip pios_flash_chip_w25x40 = {
 };
 #endif /* PIOS_INCLUDE_FLASH_JEDEC */
 
-static const struct pios_flash_partition pios_flash_partition_table_w25x40[] = {
-#if defined(PIOS_INCLUDE_FLASH_INTERNAL)
-	{
-		.label        = FLASH_PARTITION_LABEL_BL,
-		.chip_desc    = &pios_flash_chip_internal,
-		.first_sector = 0,
-		.last_sector  = 11,
-		.chip_offset   = 0,
-		.size          = (11 - 0 + 1) * FLASH_SECTOR_1KB,
-	},
-
-	{
-		.label        = FLASH_PARTITION_LABEL_FW,
-		.chip_desc    = &pios_flash_chip_internal,
-		.first_sector = 12,
-		.last_sector  = 127,
-		.chip_offset  = (12 * FLASH_SECTOR_1KB),
-		.size         = (127 - 12 + 1) * FLASH_SECTOR_1KB,
-	},
-#endif /* PIOS_INCLUDE_FLASH_INTERNAL */
-
-#if defined(PIOS_INCLUDE_FLASH_JEDEC)
-	{
-		.label        = FLASH_PARTITION_LABEL_SETTINGS,
-		.chip_desc    = &pios_flash_chip_w25x40,
-		.first_sector = 0,
-		.last_sector  = 63,
-		.chip_offset  = 0,
-		.size         = (63 - 0 + 1) * FLASH_SECTOR_4KB,
-	},
-
-	{
-		.label        = FLASH_PARTITION_LABEL_WAYPOINTS,
-		.chip_desc    = &pios_flash_chip_w25x40,
-		.first_sector = 64,
-		.last_sector  = 127,
-		.chip_offset  = (64 * FLASH_SECTOR_4KB),
-		.size         = (127 - 64 + 1) * FLASH_SECTOR_4KB,
-	},
-#endif	/* PIOS_INCLUDE_FLASH_JEDEC */
-};
-
 static const struct pios_flash_partition pios_flash_partition_table_m25p16[] = {
 #if defined(PIOS_INCLUDE_FLASH_INTERNAL)
 	{
@@ -583,12 +426,11 @@ const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32
 	PIOS_Assert(num_partitions);
 
 	switch (board_revision) {
-	case BOARD_REVISION_CC:
-		*num_partitions = NELEMENTS(pios_flash_partition_table_w25x40);
-		return pios_flash_partition_table_w25x40;
 	case BOARD_REVISION_CC3D:
 		*num_partitions = NELEMENTS(pios_flash_partition_table_m25p16);
 		return pios_flash_partition_table_m25p16;
+	default:
+		break;
 	}
 
 	return NULL;
@@ -1479,25 +1321,6 @@ void PIOS_I2C_flexi_adapter_er_irq_handler(void)
 
 #if defined(PIOS_INCLUDE_USB)
 #include "pios_usb_priv.h"
-
-static const struct pios_usb_cfg pios_usb_main_cfg_cc = {
-	.irq = {
-		.init    = {
-			.NVIC_IRQChannel                   = USB_LP_CAN1_RX0_IRQn,
-			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
-			.NVIC_IRQChannelSubPriority        = 0,
-			.NVIC_IRQChannelCmd                = ENABLE,
-		},
-	},
-	.vsense = {
-		.gpio = GPIOC,
-		.init = {
-			.GPIO_Pin   = GPIO_Pin_15,
-			.GPIO_Speed = GPIO_Speed_10MHz,
-			.GPIO_Mode  = GPIO_Mode_AF_OD,
-		},
-	}
-};
 
 static const struct pios_usb_cfg pios_usb_main_cfg_cc3d = {
 	.irq = {

--- a/flight/targets/coptercontrol/fw/pios_board.c
+++ b/flight/targets/coptercontrol/fw/pios_board.c
@@ -109,6 +109,10 @@ void PIOS_Board_Init(void) {
 
 	const struct pios_board_info * bdinfo = &pios_board_info_blob;
 
+	if (bdinfo->board_rev != BOARD_REVISION_CC3D) {
+		/* Reject.. go back to bootloader */
+	}
+
 #if defined(PIOS_INCLUDE_LED)
 	const struct pios_led_cfg * led_cfg = PIOS_BOARD_HW_DEFS_GetLedCfg(bdinfo->board_rev);
 	PIOS_Assert(led_cfg);
@@ -117,34 +121,13 @@ void PIOS_Board_Init(void) {
 
 #if defined(PIOS_INCLUDE_SPI)
 	/* Set up the SPI interface to the serial flash */
-
-	switch(bdinfo->board_rev) {
-		case BOARD_REVISION_CC:
-			if (PIOS_SPI_Init(&pios_spi_flash_accel_id, &pios_spi_flash_accel_cfg_cc)) {
-				PIOS_Assert(0);
-			}
-			break;
-		case BOARD_REVISION_CC3D:
-			if (PIOS_SPI_Init(&pios_spi_flash_accel_id, &pios_spi_flash_accel_cfg_cc3d)) {
-				PIOS_Assert(0);
-			}
-			break;
-		default:
-			PIOS_Assert(0);
+	if (PIOS_SPI_Init(&pios_spi_flash_accel_id, &pios_spi_flash_accel_cfg_cc3d)) {
+		PIOS_Assert(0);
 	}
 
 #endif
 
-	switch(bdinfo->board_rev) {
-		case BOARD_REVISION_CC:
-			PIOS_Flash_Jedec_Init(&pios_external_flash_id, pios_spi_flash_accel_id, 1, &flash_w25x_cfg);
-			break;
-		case BOARD_REVISION_CC3D:
-			PIOS_Flash_Jedec_Init(&pios_external_flash_id, pios_spi_flash_accel_id, 0, &flash_m25p_cfg);
-			break;
-		default:
-			PIOS_DEBUG_Assert(0);
-	}
+	PIOS_Flash_Jedec_Init(&pios_external_flash_id, pios_spi_flash_accel_id, 0, &flash_m25p_cfg);
 
 	PIOS_Flash_Internal_Init(&pios_internal_flash_id, &flash_internal_cfg);
 
@@ -228,16 +211,7 @@ void PIOS_Board_Init(void) {
 
 	uintptr_t pios_usb_id;
 	
-	switch(bdinfo->board_rev) {
-		case BOARD_REVISION_CC:
-			PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg_cc);
-			break;
-		case BOARD_REVISION_CC3D:
-			PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg_cc3d);
-			break;
-		default:
-			PIOS_Assert(0);
-	}
+	PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg_cc3d);
 
 #if defined(PIOS_INCLUDE_USB_CDC)
 
@@ -398,99 +372,78 @@ void PIOS_Board_Init(void) {
 
 	PIOS_SENSORS_Init();
 
-	switch(bdinfo->board_rev) {
-		case BOARD_REVISION_CC:
-			// Revision 1 with invensense gyros, start the ADC
-#if defined(PIOS_INCLUDE_ADC)
-		{
-			uint32_t internal_adc_id;
-			PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg);
-			PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
-		}
-#endif
-#if defined(PIOS_INCLUDE_ADXL345)
-			PIOS_ADXL345_Init(pios_spi_flash_accel_id, 0);
-#endif
-			break;
-		case BOARD_REVISION_CC3D:
-			// Revision 2 with L3GD20 gyros, start a SPI interface and connect to it
-			GPIO_PinRemapConfig(GPIO_Remap_SWJ_JTAGDisable, ENABLE);
+	// Revision 2 with L3GD20 gyros, start a SPI interface and connect to it
+	GPIO_PinRemapConfig(GPIO_Remap_SWJ_JTAGDisable, ENABLE);
 #if defined(PIOS_INCLUDE_MPU6000)
-			// Set up the SPI interface to the serial flash 
-			if (PIOS_SPI_Init(&pios_spi_gyro_id, &pios_spi_gyro_cfg)) {
-				PIOS_Assert(0);
-			}
-			PIOS_MPU6000_Init(pios_spi_gyro_id,0,&pios_mpu6000_cfg);
-			PIOS_MPU6000_Test();
+	// Set up the SPI interface to the serial flash 
+	if (PIOS_SPI_Init(&pios_spi_gyro_id, &pios_spi_gyro_cfg)) {
+		PIOS_Assert(0);
+	}
+	PIOS_MPU6000_Init(pios_spi_gyro_id,0,&pios_mpu6000_cfg);
 
-			uint8_t hw_gyro_range;
-			HwCopterControlGyroRangeGet(&hw_gyro_range);
-			switch(hw_gyro_range) {
-				case HWCOPTERCONTROL_GYRORANGE_250:
-					PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_250_DEG);
-					break;
-				case HWCOPTERCONTROL_GYRORANGE_500:
-					PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_500_DEG);
-					break;
-				case HWCOPTERCONTROL_GYRORANGE_1000:
-					PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_1000_DEG);
-					break;
-				case HWCOPTERCONTROL_GYRORANGE_2000:
-					PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_2000_DEG);
-					break;
-			}
+	uint8_t hw_gyro_range;
+	HwCopterControlGyroRangeGet(&hw_gyro_range);
+	switch(hw_gyro_range) {
+		case HWCOPTERCONTROL_GYRORANGE_250:
+			PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_250_DEG);
+			break;
+		case HWCOPTERCONTROL_GYRORANGE_500:
+			PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_500_DEG);
+			break;
+		case HWCOPTERCONTROL_GYRORANGE_1000:
+			PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_1000_DEG);
+			break;
+		case HWCOPTERCONTROL_GYRORANGE_2000:
+			PIOS_MPU6000_SetGyroRange(PIOS_MPU60X0_SCALE_2000_DEG);
+			break;
+	}
 
-			uint8_t hw_accel_range;
-			HwCopterControlAccelRangeGet(&hw_accel_range);
-			switch(hw_accel_range) {
-				case HWCOPTERCONTROL_ACCELRANGE_2G:
-					PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_2G);
-					break;
-				case HWCOPTERCONTROL_ACCELRANGE_4G:
-					PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_4G);
-					break;
-				case HWCOPTERCONTROL_ACCELRANGE_8G:
-					PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_8G);
-					break;
-				case HWCOPTERCONTROL_ACCELRANGE_16G:
-					PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_16G);
-					break;
-			}
+	uint8_t hw_accel_range;
+	HwCopterControlAccelRangeGet(&hw_accel_range);
+	switch(hw_accel_range) {
+		case HWCOPTERCONTROL_ACCELRANGE_2G:
+			PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_2G);
+			break;
+		case HWCOPTERCONTROL_ACCELRANGE_4G:
+			PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_4G);
+			break;
+		case HWCOPTERCONTROL_ACCELRANGE_8G:
+			PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_8G);
+			break;
+		case HWCOPTERCONTROL_ACCELRANGE_16G:
+			PIOS_MPU6000_SetAccelRange(PIOS_MPU60X0_ACCEL_16G);
+			break;
+	}
 
-			// the filter has to be set before rate else divisor calculation will fail
-			uint8_t hw_mpu6000_dlpf;
-			HwCopterControlMPU6000DLPFGet(&hw_mpu6000_dlpf);
-			enum pios_mpu60x0_filter mpu6000_dlpf = \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
-			    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
-			    pios_mpu6000_cfg.default_filter;
-			PIOS_MPU6000_SetLPF(mpu6000_dlpf);
+	// the filter has to be set before rate else divisor calculation will fail
+	uint8_t hw_mpu6000_dlpf;
+	HwCopterControlMPU6000DLPFGet(&hw_mpu6000_dlpf);
+	enum pios_mpu60x0_filter mpu6000_dlpf = \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_256) ? PIOS_MPU60X0_LOWPASS_256_HZ : \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_188) ? PIOS_MPU60X0_LOWPASS_188_HZ : \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_98) ? PIOS_MPU60X0_LOWPASS_98_HZ : \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_42) ? PIOS_MPU60X0_LOWPASS_42_HZ : \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_20) ? PIOS_MPU60X0_LOWPASS_20_HZ : \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_10) ? PIOS_MPU60X0_LOWPASS_10_HZ : \
+	    (hw_mpu6000_dlpf == HWCOPTERCONTROL_MPU6000DLPF_5) ? PIOS_MPU60X0_LOWPASS_5_HZ : \
+	    pios_mpu6000_cfg.default_filter;
+	PIOS_MPU6000_SetLPF(mpu6000_dlpf);
 
-			uint8_t hw_mpu6000_samplerate;
-			HwCopterControlMPU6000RateGet(&hw_mpu6000_samplerate);
-			uint16_t mpu6000_samplerate = \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_200) ? 200 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_333) ? 333 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_500) ? 500 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_666) ? 666 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_1000) ? 1000 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_2000) ? 2000 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_4000) ? 4000 : \
-			    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_8000) ? 8000 : \
-			    pios_mpu6000_cfg.default_samplerate;
-			PIOS_MPU6000_SetSampleRate(mpu6000_samplerate);
+	uint8_t hw_mpu6000_samplerate;
+	HwCopterControlMPU6000RateGet(&hw_mpu6000_samplerate);
+	uint16_t mpu6000_samplerate = \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_200) ? 200 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_333) ? 333 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_500) ? 500 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_666) ? 666 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_1000) ? 1000 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_2000) ? 2000 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_4000) ? 4000 : \
+	    (hw_mpu6000_samplerate == HWCOPTERCONTROL_MPU6000RATE_8000) ? 8000 : \
+	    pios_mpu6000_cfg.default_samplerate;
+	PIOS_MPU6000_SetSampleRate(mpu6000_samplerate);
 
 #endif /* PIOS_INCLUDE_MPU6000 */
-
-			break;
-		default:
-			PIOS_Assert(0);
-	}
 
 	PIOS_GPIO_Init();
 


### PR DESCRIPTION
This retains support for CC3D but removes the old CC code base. CopterControl
boards aren't widely available and probably barely used (sensor drift was worse
on them than on CC3D), so this isn't likely much of a loss.
