### PR TITLE
PiOS HAL: fix F3 FrSky functionality

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -352,7 +352,8 @@ static void PIOS_HAL_ConfigureHSUM(const struct pios_usart_cfg *usart_hsum_cfg,
  * greatly decrease in size.
  *
  * @param[in] port_type protocol to speak on this port
- * @param[in] usart_port_cfg serial configuration for most modes on this
+ * @param[in] usart_port_cfg serial configuration for most modes on this port
+ * @param[in] usart_port_cfg serial configuration for frsky telem on this port (F3 only)
  * @param[in] com_driver communications driver for serial on this port
  * @param[out] i2c_id ID of I2C peripheral if operated in I2C mode
  * @param[in] i2c_Cfg Adapter configuration/registers for I2C mode
@@ -368,6 +369,7 @@ static void PIOS_HAL_ConfigureHSUM(const struct pios_usart_cfg *usart_hsum_cfg,
  */
 void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		const struct pios_usart_cfg *usart_port_cfg,
+		const struct pios_usart_cfg *usart_frsky_port_cfg,
 		const struct pios_com_driver *com_driver,
 		uint32_t *i2c_id,
 		const struct pios_i2c_adapter_cfg *i2c_cfg,
@@ -523,13 +525,13 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		break;
 	case HWSHARED_PORTTYPES_FRSKYSENSORHUB:
 #if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureCom(usart_frsky_port_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_frsky_sensor_hub_id;
 #endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
 		break;
 	case HWSHARED_PORTTYPES_FRSKYSPORTTELEMETRY:
 #if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureCom(usart_frsky_port_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_frsky_sport_id;
 #endif /* PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY */
 		break;

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -353,7 +353,7 @@ static void PIOS_HAL_ConfigureHSUM(const struct pios_usart_cfg *usart_hsum_cfg,
  *
  * @param[in] port_type protocol to speak on this port
  * @param[in] usart_port_cfg serial configuration for most modes on this port
- * @param[in] usart_port_cfg serial configuration for frsky telem on this port (F3 only)
+ * @param[in] usart_frsky_port_cfg serial configuration for frsky telem on this port (F3 only)
  * @param[in] com_driver communications driver for serial on this port
  * @param[out] i2c_id ID of I2C peripheral if operated in I2C mode
  * @param[in] i2c_Cfg Adapter configuration/registers for I2C mode

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -44,6 +44,7 @@ void PIOS_HAL_Panic(uint32_t led_id, int32_t code);
 
 void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		const struct pios_usart_cfg *usart_port_cfg,
+		const struct pios_usart_cfg *usart_frsky_port_cfg,
 		const struct pios_com_driver *com_driver,
 		uint32_t *i2c_id,
 		const struct pios_i2c_adapter_cfg *i2c_cfg,

--- a/flight/targets/aq32/fw/pios_board.c
+++ b/flight/targets/aq32/fw/pios_board.c
@@ -253,6 +253,7 @@ void PIOS_Board_Init(void) {
 
     HwAQ32Initialize();
     ModuleSettingsInitialize();
+	
 #if defined(PIOS_INCLUDE_RTC)
     /* Initialize the real-time clock and its associated tick */
     PIOS_RTC_Init(&pios_rtc_main_cfg);
@@ -391,6 +392,7 @@ void PIOS_Board_Init(void) {
 
     PIOS_HAL_ConfigurePort(hw_uart1,             // port type protocol
             &pios_usart1_cfg,                    // usart_port_cfg
+            &pios_usart1_cfg,                    // frsky usart_port_cfg
             &pios_usart_com_driver,              // com_driver
             NULL,                                // i2c_id
             NULL,                                // i2c_cfg
@@ -410,6 +412,7 @@ void PIOS_Board_Init(void) {
 
     PIOS_HAL_ConfigurePort(hw_uart2,             // port type protocol
             &pios_usart2_cfg,                    // usart_port_cfg
+            &pios_usart2_cfg,                    // frsky usart_port_cfg
             &pios_usart_com_driver,              // com_driver
             NULL,                                // i2c_id
             NULL,                                // i2c_cfg
@@ -429,6 +432,7 @@ void PIOS_Board_Init(void) {
 
     PIOS_HAL_ConfigurePort(hw_uart3,             // port type protocol
             &pios_usart3_cfg,                    // usart_port_cfg
+            &pios_usart3_cfg,                    // frsky usart_port_cfg
             &pios_usart_com_driver,              // com_driver
             NULL,                                // i2c_id 
             NULL,                                // i2c_cfg
@@ -454,6 +458,7 @@ void PIOS_Board_Init(void) {
 
     PIOS_HAL_ConfigurePort(hw_uart4,             // port type protocol
             &pios_usart4_cfg,                    // usart_port_cfg
+            &pios_usart4_cfg,                    // frsky usart_port_cfg
             &pios_usart_com_driver,              // com_driver
             NULL,                                // i2c_id
             NULL,                                // i2c_cfg
@@ -473,6 +478,7 @@ void PIOS_Board_Init(void) {
 
     PIOS_HAL_ConfigurePort(hw_uart6,             // port type protocol
             &pios_usart6_cfg,                    // usart_port_cfg
+            &pios_usart6_cfg,                    // frsky usart_port_cfg
             &pios_usart_com_driver,              // com_driver
             NULL,                                // i2c_id
             NULL,                                // i2c_cfg
@@ -489,6 +495,7 @@ void PIOS_Board_Init(void) {
     /* Configure the rcvr port */
     PIOS_HAL_ConfigurePort(hw_rcvrport,          // port type protocol
             NULL,                                // usart_port_cfg
+            NULL,                                // frsky usart_port_cfg
             NULL,                                // com_driver
             NULL,                                // i2c_id
             NULL,                                // i2c_cfg

--- a/flight/targets/coptercontrol/fw/pios_board.c
+++ b/flight/targets/coptercontrol/fw/pios_board.c
@@ -275,27 +275,46 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_mainport;
 	HwCopterControlMainPortGet(&hw_mainport);
 
-	PIOS_HAL_ConfigurePort(hw_mainport, &pios_usart_generic_main_cfg,
-			&pios_usart_com_driver, NULL, NULL, NULL, NULL,
-			0,
-			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
-			hw_DSMxMode, &pios_usart_sbus_main_cfg, &pios_sbus_cfg,
-			true);
+	PIOS_HAL_ConfigurePort(hw_mainport,          // port type protocol
+			&pios_usart_generic_main_cfg,        // usart_port_cfg
+			&pios_usart_generic_main_cfg,        // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver
+			NULL,                                // i2c_id
+			NULL,                                // i2c_cfg
+			NULL,                                // ppm_cfg
+			NULL,                                // pwm_cfg
+			0,                                   // led_id
+			&pios_usart_dsm_hsum_main_cfg,       // usart_dsm_hsum_cfg
+			&pios_dsm_main_cfg,                  // dsm_cfg
+			hw_DSMxMode,                         // dsm_mode
+			&pios_usart_sbus_main_cfg,           // sbus_rcvr_cfg
+			&pios_sbus_cfg,                      // sbus_cfg
+			true);                               // sbus_toggle
 
 	/* Configure the flexi port */
 	uint8_t hw_flexiport;
 	HwCopterControlFlexiPortGet(&hw_flexiport);
 
-	PIOS_HAL_ConfigurePort(hw_flexiport, &pios_usart_generic_flexi_cfg,
-			&pios_usart_com_driver,
+	PIOS_HAL_ConfigurePort(hw_flexiport,         // port type protocol
+			&pios_usart_generic_flexi_cfg,       // usart_port_cfg
+			&pios_usart_generic_flexi_cfg,       // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver
 #ifdef PIOS_INCLUDE_I2C
-			&pios_i2c_flexi_adapter_id, &pios_i2c_flexi_adapter_cfg,
+			&pios_i2c_flexi_adapter_id,          // i2c_id
+			&pios_i2c_flexi_adapter_cfg,         // i2c_cfg
 #else
-			NULL, NULL,
+			NULL,                                // i2c_id
+			NULL,                                // i2c_cfg
 #endif
-			NULL, NULL, 0,
-			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxMode, NULL, NULL, true);
+			NULL,                                // ppm_cfg
+			NULL,                                // pwm_cfg
+			0,                                   // led_id
+			&pios_usart_dsm_hsum_flexi_cfg,      // usart_dsm_hsum_cfg
+			&pios_dsm_flexi_cfg,                 // dsm_cfg
+			hw_DSMxMode,                         // dsm_mode
+			NULL,                                // sbus_rcvr_cfg
+			NULL,                                // sbus_cfg 
+			true);                               // sbus_toggle
 
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -400,17 +400,25 @@ void PIOS_Board_Init(void) {
 		{
 			uint8_t hw_rcvrserial;
 			HwNazeRcvrSerialGet(&hw_rcvrserial);
+			
 			HwNazeDSMxModeOptions hw_DSMxMode;
 			HwNazeDSMxModeGet(&hw_DSMxMode);
-			PIOS_HAL_ConfigurePort(hw_rcvrserial, 
-					&pios_usart_rcvrserial_cfg,
-					&pios_usart_com_driver,
-					NULL, NULL, NULL, NULL,
-					PIOS_LED_ALARM,
-					&pios_usart_dsm_hsum_rcvrserial_cfg,
-					&pios_dsm_rcvrserial_cfg,
-					hw_DSMxMode,
-					NULL, NULL, false);
+			
+			PIOS_HAL_ConfigurePort(hw_rcvrserial,        // port type protocol
+					&pios_usart_rcvrserial_cfg,          // usart_port_cfg
+					&pios_usart_rcvrserial_cfg,          // frsky usart_port_cfg
+					&pios_usart_com_driver,              // com_driver
+					NULL,                                // i2c_id
+					NULL,                                // i2c_cfg
+					NULL,                                // ppm_cfg
+					NULL,                                // pwm_cfg
+					PIOS_LED_ALARM,                      // led_id
+					&pios_usart_dsm_hsum_rcvrserial_cfg, // usart_dsm_hsum_cfg
+					&pios_dsm_rcvrserial_cfg,            // dsm_cfg
+					hw_DSMxMode,                         // dsm_mode
+					NULL,                                // sbus_rcvr_cfg
+					NULL,                                // sbus_cfg
+					false);                              // sbus_toggle
 		}
 
 		// Fall through to set up PPM.

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -149,11 +149,21 @@ void PIOS_Board_Init(void) {
 	}
 #endif
 
-	PIOS_HAL_ConfigurePort(hwTauLink.MainPort,
-	    &pios_usart_serial_cfg, &pios_usart_com_driver,
-	    /* no I2C, DSM, HSUM, SBUS, etc. */
-	    NULL, NULL, NULL, NULL, PIOS_LED_ALARM,
-	    NULL, NULL, 0, NULL, NULL, false);
+	PIOS_HAL_ConfigurePort(hwTauLink.MainPort,   // port type protocol
+			&pios_usart_serial_cfg,              // usart_port_cfg
+			&pios_usart_serial_cfg,              // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver
+			NULL,                                // i2c_id
+			NULL,                                // i2c_cfg
+			NULL,                                // ppm_cfg
+			NULL,                                // pwm_cfg
+			PIOS_LED_ALARM,                      // led_id
+			NULL,                                // usart_dsm_hsum_cfg
+			NULL,                                // dsm_cfg
+			0,                                   // dsm_mode
+			NULL,                                // sbus_rcvr_cfg
+			NULL,                                // sbus_cfg    
+			false);                              // sbus_toggle
 
 	// Update the com baud rate.
 	uint32_t comBaud = 9600;

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -370,6 +370,7 @@ void PIOS_Board_Init(void) {
 
 	PIOS_HAL_ConfigurePort(hw_uart1,             // port type protocol
 			&pios_usart1_cfg,                    // usart_port_cfg
+			&pios_usart1_cfg,                    // frsky usart_port_cfg
 			&pios_usart_com_driver,              // com_driver
 			&pios_i2c_usart1_adapter_id,         // i2c_id
 			&pios_i2c_usart1_adapter_cfg,        // i2c_cfg
@@ -389,6 +390,7 @@ void PIOS_Board_Init(void) {
 
 	PIOS_HAL_ConfigurePort(hw_uart2,             // port type protocol
 			&pios_usart2_cfg,                    // usart_port_cfg
+			&pios_usart2_cfg,                    // frsky usart_port_cfg
 			&pios_usart_com_driver,              // com_driver
 			NULL,                                // i2c_id
 			NULL,                                // i2c_cfg
@@ -408,6 +410,7 @@ void PIOS_Board_Init(void) {
 
 	PIOS_HAL_ConfigurePort(hw_uart3,             // port type protocol
 			&pios_usart3_cfg,                    // usart_port_cfg
+			&pios_usart3_cfg,                    // frsky usart_port_cfg
 			&pios_usart_com_driver,              // com_driver
 			&pios_i2c_usart3_adapter_id,         // i2c_id
 			&pios_i2c_usart3_adapter_cfg,        // i2c_cfg
@@ -427,6 +430,7 @@ void PIOS_Board_Init(void) {
 
 	PIOS_HAL_ConfigurePort(hw_uart4,             // port type protocol
 			&pios_usart4_cfg,                    // usart_port_cfg
+			&pios_usart4_cfg,                    // frsky usart_port_cfg
 			&pios_usart_com_driver,              // com_driver
 			NULL,                                // i2c_id
 			NULL,                                // i2c_cfg
@@ -446,6 +450,7 @@ void PIOS_Board_Init(void) {
 
 	PIOS_HAL_ConfigurePort(hw_uart5,             // port type protocol
 			&pios_usart5_cfg,                    // usart_port_cfg
+			&pios_usart5_cfg,                    // frsky usart_port_cfg
 			&pios_usart_com_driver,              // com_driver
 			NULL,                                // i2c_id
 			NULL,                                // i2c_cfg
@@ -470,6 +475,7 @@ void PIOS_Board_Init(void) {
 	case HWQUANTON_RCVRPORT_PWM:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg
@@ -487,6 +493,7 @@ void PIOS_Board_Init(void) {
 	case HWQUANTON_RCVRPORT_PWMADC:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg
@@ -507,6 +514,7 @@ void PIOS_Board_Init(void) {
 	case HWQUANTON_RCVRPORT_PPMOUTPUTSADC:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg
@@ -524,6 +532,7 @@ void PIOS_Board_Init(void) {
 	case HWQUANTON_RCVRPORT_PPMPWM:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg
@@ -539,6 +548,7 @@ void PIOS_Board_Init(void) {
 
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg
@@ -556,6 +566,7 @@ void PIOS_Board_Init(void) {
 	case HWQUANTON_RCVRPORT_PPMPWMADC:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg
@@ -571,6 +582,7 @@ void PIOS_Board_Init(void) {
 
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
 				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
 				NULL,                                   // com_driver
 				NULL,                                   // i2c_id
 				NULL,                                   // i2c_cfg

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -329,21 +329,41 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_mainport;
 	HwRevoMiniMainPortGet(&hw_mainport);
 
-	PIOS_HAL_ConfigurePort(hw_mainport, &pios_usart_main_cfg,
-			&pios_usart_com_driver, NULL, NULL, NULL, NULL, PIOS_LED_ALARM,
-			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
-			hw_DSMxMode >= HWREVOMINI_DSMXMODE_BIND3PULSES ? HWREVOMINI_DSMXMODE_AUTODETECT : hw_DSMxMode /* No bind on main port */, &pios_usart_sbus_main_cfg,
-			&pios_sbus_cfg, true);
+	PIOS_HAL_ConfigurePort(hw_mainport,          // port type protocol
+			&pios_usart_main_cfg,                // usart_port_cfg
+			&pios_usart_main_cfg,                // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver 
+			NULL,                                // i2c_id
+			NULL,                                // i2c_cfg
+			NULL,                                // ppm_cfg
+			NULL,                                // pwm_cfg
+			PIOS_LED_ALARM,                      // led_id
+			&pios_usart_dsm_hsum_main_cfg,       // usart_dsm_hsum_cfg
+			&pios_dsm_main_cfg,                  // dsm_cfg
+			hw_DSMxMode >= HWREVOMINI_DSMXMODE_BIND3PULSES ? HWREVOMINI_DSMXMODE_AUTODETECT : hw_DSMxMode /* No bind on main port */, 
+			&pios_usart_sbus_main_cfg,           // sbus_rcvr_cfg
+			&pios_sbus_cfg,                      // sbus_cfg 
+			true);                               // sbus_toggle
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
 	HwRevoMiniFlexiPortGet(&hw_flexiport);
 
-	PIOS_HAL_ConfigurePort(hw_flexiport, &pios_usart_flexi_cfg,
-			&pios_usart_com_driver, &pios_i2c_flexiport_adapter_id,
-			&pios_i2c_flexiport_adapter_cfg, NULL, NULL, PIOS_LED_ALARM,
-			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxMode, NULL, NULL, false);
+	PIOS_HAL_ConfigurePort(hw_flexiport,         // port type protocol 
+			&pios_usart_flexi_cfg,               // usart_port_cfg
+			&pios_usart_flexi_cfg,               // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver
+			&pios_i2c_flexiport_adapter_id,      // i2c_id
+			&pios_i2c_flexiport_adapter_cfg,     // i2c_cfg
+			NULL,                                // ppm_cfg
+			NULL,                                // pwm_cfg
+			PIOS_LED_ALARM,                      // led_id
+			&pios_usart_dsm_hsum_flexi_cfg,      // usart_dsm_hsum_cfg
+			&pios_dsm_flexi_cfg,                 // dsm_cfg
+			hw_DSMxMode,                         // dsm_mode
+			NULL,                                // sbus_rcvr_cfg
+			NULL,                                // sbus_cfg    
+			false);                              // sbus_toggle
 
 	HwRevoMiniData hwRevoMini;
 	HwRevoMiniGet(&hwRevoMini);

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -379,36 +379,62 @@ void PIOS_Board_Init(void)
 	/* Configure main USART port */
 	uint8_t hw_mainport;
 	HwSparkyMainPortGet(&hw_mainport);
-	PIOS_HAL_ConfigurePort(hw_mainport, &pios_main_usart_cfg,
-	                       &pios_usart_com_driver, NULL, NULL, NULL, NULL,
-	                       PIOS_LED_ALARM,
-	                       &pios_main_dsm_hsum_cfg, &pios_main_dsm_aux_cfg,
-	                       hw_DSMxMode, NULL, NULL, false);
+	
+	PIOS_HAL_ConfigurePort(hw_mainport,          // port type protocol
+	        &pios_main_usart_cfg,                // usart_port_cfg
+	        &pios_main_usart_sport_cfg,          // frsky usart_port_cfg
+	        &pios_usart_com_driver,              // com_driver
+	        NULL,                                // i2c_id
+	        NULL,                                // i2c_cfg 
+	        NULL,                                // ppm_cfg
+	        NULL,                                // pwm_cfg
+	        PIOS_LED_ALARM,                      // led_id
+	        &pios_main_dsm_hsum_cfg,             // usart_dsm_hsum_cfg
+	        &pios_main_dsm_aux_cfg,              // dsm_cfg
+	        hw_DSMxMode,                         // dsm_mode
+	        NULL,                                // sbus_rcvr_cfg
+	        NULL,                                // sbus_cfg  
+	        false);                              // sbus_toggle
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
 	HwSparkyFlexiPortGet(&hw_flexiport);
-	PIOS_HAL_ConfigurePort(hw_flexiport, &pios_flexi_usart_cfg,
-	                       &pios_usart_com_driver,
-	                       &pios_i2c_flexi_id,
-	                       &pios_i2c_flexi_cfg, NULL, NULL,
-	                       PIOS_LED_ALARM,
-	                       &pios_flexi_dsm_hsum_cfg, &pios_flexi_dsm_aux_cfg,
-	                       hw_DSMxMode, NULL, NULL, false);
+	
+	PIOS_HAL_ConfigurePort(hw_flexiport,         // port type protocol
+	        &pios_flexi_usart_cfg,               // usart_port_cfg
+	        &pios_flexi_usart_sport_cfg,         // frsky usart_port_cfg
+	        &pios_usart_com_driver,              // com_driver
+	        &pios_i2c_flexi_id,                  // i2c_id
+	        &pios_i2c_flexi_cfg,                 // i2c_cfg 
+	        NULL,                                // ppm_cfg
+	        NULL,                                // pwm_cfg
+	        PIOS_LED_ALARM,                      // led_id
+	        &pios_flexi_dsm_hsum_cfg,            // usart_dsm_hsum_cfg 
+	        &pios_flexi_dsm_aux_cfg,             // dsm_cfg
+	        hw_DSMxMode,                         // dsm_mode
+	        NULL,                                // sbus_rcvr_cfg
+	        NULL,                                // sbus_cfg 
+	        false);                              // sbus_toggle
 
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;
 	HwSparkyRcvrPortGet(&hw_rcvrport);
-	PIOS_HAL_ConfigurePort(hw_rcvrport,
-	                       NULL, /* XXX TODO: fix as part of DSM refactor */
-	                       &pios_usart_com_driver,
-	                       NULL, NULL,
-	                       &pios_ppm_cfg, NULL,
-	                       PIOS_LED_ALARM,
-	                       &pios_rcvr_dsm_hsum_cfg,
-	                       &pios_rcvr_dsm_aux_cfg,
-	                       hw_DSMxMode, &pios_rcvr_sbus_cfg,
-	                       &pios_rcvr_sbus_aux_cfg, false);
+	
+	PIOS_HAL_ConfigurePort(hw_rcvrport,          // port type protocol
+	        NULL,                                // usart_port_cfg
+	        NULL,                                // frsky usart_port_cfg
+	        &pios_usart_com_driver,              // com_driver
+	        NULL,                                // i2c_id 
+	        NULL,                                // i2c_cfg
+	        &pios_ppm_cfg,                       // ppm_cfg
+	        NULL,                                // pwm_cfg
+	        PIOS_LED_ALARM,                      // led_id
+	        &pios_rcvr_dsm_hsum_cfg,             // usart_dsm_hsum_cfg
+	        &pios_rcvr_dsm_aux_cfg,              // dsm_cfg
+	        hw_DSMxMode,                         // dsm_mode
+	        &pios_rcvr_sbus_cfg,                 // sbus_rcvr_cfg
+	        &pios_rcvr_sbus_aux_cfg,             // sbus_cfg 
+	        false);                              // sbus_toggle
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -435,23 +435,41 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_mainport;
 	HwSparky2MainPortGet(&hw_mainport);
 
-	PIOS_HAL_ConfigurePort(hw_mainport, &pios_usart_main_cfg,
-			&pios_usart_com_driver, NULL, NULL, NULL, NULL,
-			PIOS_LED_ALARM,
-			&pios_usart_dsm_hsum_main_cfg, &pios_dsm_main_cfg,
-			hw_DSMxMode, NULL, NULL, false);
+	PIOS_HAL_ConfigurePort(hw_mainport,          // port type protocol
+			&pios_usart_main_cfg,                // usart_port_cfg
+			&pios_usart_main_cfg,                // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver 
+			NULL,                                // i2c_id 
+			NULL,                                // i2c_cfg 
+			NULL,                                // i2c_cfg 
+			NULL,                                // pwm_cfg
+			PIOS_LED_ALARM,                      // led_id
+			&pios_usart_dsm_hsum_main_cfg,       // usart_dsm_hsum_cfg 
+			&pios_dsm_main_cfg,                  // dsm_cfg
+			hw_DSMxMode,                         // dsm_mode 
+			NULL,                                // sbus_rcvr_cfg 
+			NULL,                                // sbus_cfg 
+			false);                              // sbus_toggle
 
 	/* Configure FlexiPort */
 	uint8_t hw_flexiport;
 	HwSparky2FlexiPortGet(&hw_flexiport);
 
-	PIOS_HAL_ConfigurePort(hw_flexiport, &pios_usart_flexi_cfg,
-			&pios_usart_com_driver,
-			&pios_i2c_flexiport_adapter_id,
-			&pios_i2c_flexiport_adapter_cfg, NULL, NULL,
-			PIOS_LED_ALARM,
-			&pios_usart_dsm_hsum_flexi_cfg, &pios_dsm_flexi_cfg,
-			hw_DSMxMode, NULL, NULL, false);
+	PIOS_HAL_ConfigurePort(hw_flexiport,         // port type protocol
+			&pios_usart_flexi_cfg,               // usart_port_cfg
+			&pios_usart_flexi_cfg,               // frsky usart_port_cfg
+			&pios_usart_com_driver,              // com_driver
+			&pios_i2c_flexiport_adapter_id,      // i2c_id
+			&pios_i2c_flexiport_adapter_cfg,     // i2c_cfg 
+			NULL,                                // i2c_cfg 
+			NULL,                                // pwm_cfg
+			PIOS_LED_ALARM,                      // led_id
+			&pios_usart_dsm_hsum_flexi_cfg,      // usart_dsm_hsum_cfg
+			&pios_dsm_flexi_cfg,                 // dsm_cfg
+			hw_DSMxMode,                         // dsm_mode 
+			NULL,                                // sbus_rcvr_cfg 
+			NULL,                                // sbus_cfg 
+			false);                              // sbus_toggle
 
 #if defined(PIOS_INCLUDE_RFM22B)
 	HwSparky2Data hwSparky2;
@@ -478,17 +496,21 @@ void PIOS_Board_Init(void) {
 		hw_DSMxMode = HWSPARKY2_DSMXMODE_AUTODETECT; /* Do not try to bind through XOR */
 	}
 
-	PIOS_HAL_ConfigurePort(hw_rcvrport,
-			NULL, /* XXX TODO: fix as part of DSM refactor */
-			&pios_usart_com_driver,
-			NULL, NULL,
-			&pios_ppm_cfg,
-			NULL,
-			PIOS_LED_ALARM,
-			&pios_usart_dsm_hsum_rcvr_cfg,
-			&pios_dsm_rcvr_cfg,
-			hw_DSMxMode, get_sbus_rcvr_cfg(bdinfo->board_rev),
-			&pios_sbus_cfg, get_sbus_toggle(bdinfo->board_rev));
+	PIOS_HAL_ConfigurePort(hw_rcvrport,           // port type protocol
+			NULL,                                 // usart_port_cfg
+			NULL,                                 // frsky usart_port_cfg
+			&pios_usart_com_driver,               // com_driver
+			NULL,                                 // i2c_id
+			NULL,                                 // i2c_cfg
+			&pios_ppm_cfg,                        // ppm_cfg
+			NULL,                                 // pwm_cfg
+			PIOS_LED_ALARM,                       // led_id
+			&pios_usart_dsm_hsum_rcvr_cfg,        // usart_dsm_hsum_cfg
+			&pios_dsm_rcvr_cfg,                   // dsm_cfg
+			hw_DSMxMode,                          // dsm_mode
+			get_sbus_rcvr_cfg(bdinfo->board_rev), // sbus_rcvr_cfg
+			&pios_sbus_cfg,                       // sbus_cfg
+			get_sbus_toggle(bdinfo->board_rev));  // sbus_toggle
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();


### PR DESCRIPTION
On F3 targets we were passing in the same serial port configuration as the
normal one, but it requires the inversion of the lines to communicate correctly.

Ported from https://github.com/d-ronin/dronin/pull/57/
