### PR TITLE
GCS:RawHID: Fix open() bug that caused segfaults

### DIFF
--- a/ground/gcs/src/plugins/rawhid/rawhid.cpp
+++ b/ground/gcs/src/plugins/rawhid/rawhid.cpp
@@ -344,6 +344,7 @@ bool RawHID::open(OpenMode mode)
         m_writeThread->start();
     } else {
         qDebug() << "Failed to open USB device";
+        return false;
     }
 
     return QIODevice::open(mode);


### PR DESCRIPTION
Fixes #1594

Mirrored at https://github.com/d-ronin/dRonin/pull/94
