### PR TITLE
GCS performance increases through UAVObject manager

### DIFF
--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
@@ -3,6 +3,7 @@
  *
  * @file       uavobjectfield.cpp
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
  * @see        The GNU Public License (GPL) Version 3
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
@@ -113,10 +113,10 @@ void UAVObjectField::limitsInitialize(const QString &limits)
         return;
     QStringList stringPerElement=limits.split(",");
     quint32 index=0;
-    foreach (QString str, stringPerElement) {
+    foreach (const QString &str, stringPerElement) {
         QStringList ruleList=str.split(";");
         QList<LimitStruct> limitList;
-        foreach(QString rule,ruleList)
+        foreach(const QString &rule,ruleList)
         {
             QString _str=rule.trimmed();
             if(_str.isEmpty())
@@ -148,7 +148,7 @@ void UAVObjectField::limitsInitialize(const QString &limits)
                 else
                     qDebug()<<"limits parsing failed (invalid property) on UAVObjectField"<<name;
                 valuesPerElement.removeAt(0);
-                foreach(QString _value,valuesPerElement)
+                foreach(const QString &_value,valuesPerElement)
                 {
                     QString value=_value.trimmed();
                     switch (type)
@@ -201,7 +201,7 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
     if(!elementLimits.keys().contains(index))
         return true;
 
-    foreach(LimitStruct struc,elementLimits.value(index))
+    foreach(const LimitStruct &struc,elementLimits.value(index))
     {
         if((struc.board!=board) && board!=0 && struc.board!=0)
             continue;
@@ -213,7 +213,7 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
             case INT8:
             case INT16:
             case INT32:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toInt()==vars.toInt())
                         return true;
                 }
@@ -223,7 +223,7 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
             case UINT16:
             case UINT32:
             case BITFIELD:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toUInt()==vars.toUInt())
                         return true;
                 }
@@ -231,14 +231,14 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
                 break;
             case ENUM:
             case STRING:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toString()==vars.toString())
                         return true;
                 }
                 return false;
                 break;
             case FLOAT32:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toFloat()==vars.toFloat())
                         return true;
                 }
@@ -254,7 +254,7 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
             case INT8:
             case INT16:
             case INT32:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toInt()==vars.toInt())
                         return false;
                 }
@@ -264,7 +264,7 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
             case UINT16:
             case UINT32:
             case BITFIELD:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toUInt()==vars.toUInt())
                         return false;
                 }
@@ -272,14 +272,14 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
                 break;
             case ENUM:
             case STRING:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toString()==vars.toString())
                         return false;
                 }
                 return true;
                 break;
             case FLOAT32:
-                foreach (QVariant vars, struc.values) {
+                foreach (const QVariant &vars, struc.values) {
                     if(var.toFloat()==vars.toFloat())
                         return false;
                 }
@@ -419,7 +419,7 @@ QVariant UAVObjectField::getMaxLimit(quint32 index,int board)
 {
     if(!elementLimits.keys().contains(index))
         return QVariant();
-    foreach(LimitStruct struc,elementLimits.value(index))
+    foreach(const LimitStruct &struc,elementLimits.value(index))
     {
         if((struc.board!=board) && board!=0 && struc.board!=0)
             continue;

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
@@ -136,6 +136,9 @@ void UAVObjectManager::addObject(UAVObject* obj)
     QMap<quint32,UAVObject*> list;
     list.insert(obj->getInstID(),obj);
     objects.insert(obj->getObjID(),list);
+
+    objectsByName.insert(obj->getName(), list);
+
     emit newObject(obj);
 }
 
@@ -216,7 +219,7 @@ QVector <QVector<UAVMetaObject*> > UAVObjectManager::getMetaObjectsVector()
  */
 UAVObject* UAVObjectManager::getObject(const QString& name, quint32 instId)
 {
-    return getObject(&name, 0, instId);
+    return getObject(name, 0, instId);
 }
 
 /**
@@ -231,16 +234,16 @@ UAVObject* UAVObjectManager::getObject(quint32 objId, quint32 instId)
 /**
  * Helper function for the public getObject() functions.
  */
-UAVObject* UAVObjectManager::getObject(const QString* name, quint32 objId, quint32 instId)
+UAVObject* UAVObjectManager::getObject(const QString& name, quint32 objId, quint32 instId)
 {
     QMutexLocker locker(mutex);
     if(name != NULL)
     {
-        foreach(const ObjectMap &map, objects)
-        {
-            if(map.first()->getName().compare(name) == 0)
-                return map.value(instId,NULL);
+        if (objectsByName.contains(name)) {
+            return objectsByName.value(name).value(instId);
         }
+
+        return NULL;
     }
     else if(objects.contains(objId))
         return objects.value(objId).value(instId);

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
@@ -147,7 +147,7 @@ QVector< QVector<UAVObject*> > UAVObjectManager::getObjectsVector()
 {
     QMutexLocker locker(mutex);
     QVector< QVector<UAVObject*> > vector;
-    foreach(ObjectMap map,objects.values())
+    foreach (const ObjectMap &map,objects.values())
     {
         QVector<UAVObject*> vec = map.values().toVector();
         vector.append(vec);
@@ -167,7 +167,7 @@ QVector< QVector<UAVDataObject*> > UAVObjectManager::getDataObjectsVector()
 {
     QMutexLocker locker(mutex);
     QVector< QVector<UAVDataObject*> > vector;
-    foreach(ObjectMap map,objects.values())
+    foreach (const ObjectMap &map,objects.values())
     {
         UAVDataObject* obj = dynamic_cast<UAVDataObject*>(map.first());
         if(obj!=NULL)
@@ -192,7 +192,7 @@ QVector <QVector<UAVMetaObject*> > UAVObjectManager::getMetaObjectsVector()
 {
     QMutexLocker locker(mutex);
     QVector< QVector<UAVMetaObject*> > vector;
-    foreach(ObjectMap map,objects.values())
+    foreach(const ObjectMap &map,objects.values())
     {
         UAVMetaObject* obj = dynamic_cast<UAVMetaObject*>(map.first());
         if(obj!=NULL)
@@ -236,7 +236,7 @@ UAVObject* UAVObjectManager::getObject(const QString* name, quint32 objId, quint
     QMutexLocker locker(mutex);
     if(name != NULL)
     {
-        foreach(ObjectMap map,objects)
+        foreach(const ObjectMap &map, objects)
         {
             if(map.first()->getName().compare(name) == 0)
                 return map.value(instId,NULL);
@@ -271,7 +271,7 @@ QVector<UAVObject*> UAVObjectManager::getObjectInstancesVector(const QString* na
     QMutexLocker locker(mutex);
     if(name != NULL)
     {
-        foreach(ObjectMap map,objects)
+        foreach(const ObjectMap &map,objects)
         {
             if(map.first()->getName().compare(name) == 0)
                 return map.values().toVector();
@@ -306,7 +306,7 @@ qint32 UAVObjectManager::getNumInstances(const QString* name, quint32 objId)
     QMutexLocker locker(mutex);
     if(name != NULL)
     {
-        foreach(ObjectMap map,objects)
+        foreach(const ObjectMap &map,objects)
         {
             if(map.first()->getName().compare(name) == 0)
                 return map.count();

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
@@ -4,6 +4,7 @@
  * @file       uavobjectmanager.cpp
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
  * @see        The GNU Public License (GPL) Version 3
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.h
@@ -65,10 +65,11 @@ signals:
 private:
     static const quint32 MAX_INSTANCES = 1000;
     QHash<quint32, QMap<quint32,UAVObject*> > objects;
+    QHash<QString, QMap<quint32,UAVObject*> > objectsByName;
     QMutex* mutex;
 
     void addObject(UAVObject* obj);
-    UAVObject* getObject(const QString* name, quint32 objId, quint32 instId);
+    UAVObject* getObject(const QString& name, quint32 objId, quint32 instId);
     QVector<UAVObject*> getObjectInstancesVector(const QString* name, quint32 objId);
     qint32 getNumInstances(const QString* name, quint32 objId);
 };


### PR DESCRIPTION
As discovered at https://github.com/d-ronin/dRonin/pull/254 and https://github.com/d-ronin/dRonin/pull/312.
- Uses `consts` to reduce memory usage
- Uses `QHash` instead of manually searching through list.

Used daily locally, and seems to work fine for d-ronin users as well. Will merge soon unless there are objections.
