### PR TITLE
naze32: add "serial" to receiver options

### DIFF
--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -397,32 +397,6 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_PWM */
 		break;
 	case HWNAZE_RCVRPORT_PPMSERIAL:
-		{
-			uint8_t hw_rcvrserial;
-			HwNazeRcvrSerialGet(&hw_rcvrserial);
-			
-			HwNazeDSMxModeOptions hw_DSMxMode;
-			HwNazeDSMxModeGet(&hw_DSMxMode);
-			
-			PIOS_HAL_ConfigurePort(hw_rcvrserial,        // port type protocol
-					&pios_usart_rcvrserial_cfg,          // usart_port_cfg
-					&pios_usart_rcvrserial_cfg,          // frsky usart_port_cfg
-					&pios_usart_com_driver,              // com_driver
-					NULL,                                // i2c_id
-					NULL,                                // i2c_cfg
-					NULL,                                // ppm_cfg
-					NULL,                                // pwm_cfg
-					PIOS_LED_ALARM,                      // led_id
-					&pios_usart_dsm_hsum_rcvrserial_cfg, // usart_dsm_hsum_cfg
-					&pios_dsm_rcvrserial_cfg,            // dsm_cfg
-					hw_DSMxMode,                         // dsm_mode
-					NULL,                                // sbus_rcvr_cfg
-					NULL,                                // sbus_cfg
-					false);                              // sbus_toggle
-		}
-
-		// Fall through to set up PPM.
-
 	case HWNAZE_RCVRPORT_PPM:
 	case HWNAZE_RCVRPORT_PPMOUTPUTS:
 #if defined(PIOS_INCLUDE_PPM)
@@ -465,8 +439,12 @@ void PIOS_Board_Init(void) {
 		}
 #endif	/* PIOS_INCLUDE_PWM */
 		break;
+	}
+
+#if defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
+	switch (hw_rcvrport) {
+	case HWNAZE_RCVRPORT_PPMSERIAL:
 	case HWNAZE_RCVRPORT_SERIAL:
-#if defined(PIOS_INCLUDE_USART)
 		{
 			uint8_t hw_rcvrserial;
 			HwNazeRcvrSerialGet(&hw_rcvrserial);
@@ -490,9 +468,11 @@ void PIOS_Board_Init(void) {
 					NULL,                                // sbus_cfg
 					false);                              // sbus_toggle
 		}
-#endif	/* PIOS_INCLUDE_USART */
+		break;
+	default:
 		break;
 	}
+#endif	/* PIOS_INCLUDE_USART && PIOS_INCLUDE_COM */
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -465,6 +465,33 @@ void PIOS_Board_Init(void) {
 		}
 #endif	/* PIOS_INCLUDE_PWM */
 		break;
+	case HWNAZE_RCVRPORT_SERIAL:
+#if defined(PIOS_INCLUDE_USART)
+		{
+			uint8_t hw_rcvrserial;
+			HwNazeRcvrSerialGet(&hw_rcvrserial);
+			
+			HwNazeDSMxModeOptions hw_DSMxMode;
+			HwNazeDSMxModeGet(&hw_DSMxMode);
+			
+			PIOS_HAL_ConfigurePort(hw_rcvrserial,        // port type protocol
+					&pios_usart_rcvrserial_cfg,          // usart_port_cfg
+					&pios_usart_rcvrserial_cfg,          // frsky usart_port_cfg
+					&pios_usart_com_driver,              // com_driver
+					NULL,                                // i2c_id
+					NULL,                                // i2c_cfg
+					NULL,                                // ppm_cfg
+					NULL,                                // pwm_cfg
+					PIOS_LED_ALARM,                      // led_id
+					&pios_usart_dsm_hsum_rcvrserial_cfg, // usart_dsm_hsum_cfg
+					&pios_dsm_rcvrserial_cfg,            // dsm_cfg
+					hw_DSMxMode,                         // dsm_mode
+					NULL,                                // sbus_rcvr_cfg
+					NULL,                                // sbus_cfg
+					false);                              // sbus_toggle
+		}
+#endif	/* PIOS_INCLUDE_USART */
+		break;
 	}
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
@@ -489,6 +516,7 @@ void PIOS_Board_Init(void) {
 		case HWNAZE_RCVRPORT_PPM:
 		case HWNAZE_RCVRPORT_PPMPWM:
 		case HWNAZE_RCVRPORT_PPMSERIAL:
+		case HWNAZE_RCVRPORT_SERIAL:
 			PIOS_Servo_Init(&pios_servo_cfg);
 			break;
 		case HWNAZE_RCVRPORT_PPMOUTPUTS:
@@ -507,6 +535,7 @@ void PIOS_Board_Init(void) {
 		switch(hw_rcvrport) {
 		case HWNAZE_RCVRPORT_PPM:
 		case HWNAZE_RCVRPORT_PPMSERIAL:
+		case HWNAZE_RCVRPORT_SERIAL:
 			number_of_adc_pins += 2; // rcvr port pins also available
 			break;
 		default:

--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -4,7 +4,7 @@
 
 		<field name="MainPort" units="function" type="enum" elements="1" options="Telemetry,MSP" defaultvalue="Telemetry"/>
 
-		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Serial,PPM+Outputs,Outputs" defaultvalue="PPM"/>
+		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Serial,PPM+Outputs,Outputs,Serial" defaultvalue="PPM"/>
 
 		<field name="RcvrSerial" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,DSM,DebugConsole,ComBridge,MavLinkTX,MSP,FrSKY Sensor Hub,LighttelemetryTx,HoTT SUMD,HoTT SUMH" parent="HwShared.PortTypes" defaultvalue="Disabled"/>
 		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>


### PR DESCRIPTION
This separates the serial and ppm/pwm configuration on naze32. Now it is possible to configure the receiver port for a DMS or HoTT without PWM/PMM. This is still possible by using "PPM+SERIAL".
"SERIAL" has the advantage of 3% less CPU usage and 122 Bytes more free heap.
I was able to run an autotune procedure on the rcexplorer tricopter pcb-naze with HoTT-SUMD. Without the changes, the naze32 don't arm and there are only 4 bytes heap left.
