### PR TITLE
Scopes context menu

### DIFF
--- a/ground/gcs/src/plugins/scope/plotdata.h
+++ b/ground/gcs/src/plugins/scope/plotdata.h
@@ -83,6 +83,7 @@ public:
     virtual bool readAndResetUpdatedFlag() = 0;
     virtual void plotNewData(PlotData *, ScopeConfig *, ScopeGadgetWidget *) = 0;
     virtual void deletePlots(PlotData *) = 0;
+    virtual void clearPlots() = 0;
 
     QwtScaleWidget *rightAxis;
 

--- a/ground/gcs/src/plugins/scope/plotdata.h
+++ b/ground/gcs/src/plugins/scope/plotdata.h
@@ -82,7 +82,7 @@ public:
     virtual void setUpdatedFlagToTrue() = 0;
     virtual bool readAndResetUpdatedFlag() = 0;
     virtual void plotNewData(PlotData *, ScopeConfig *, ScopeGadgetWidget *) = 0;
-    virtual void clearPlots(PlotData *) = 0;
+    virtual void deletePlots(PlotData *) = 0;
 
     QwtScaleWidget *rightAxis;
 

--- a/ground/gcs/src/plugins/scope/scopegadget.cpp
+++ b/ground/gcs/src/plugins/scope/scopegadget.cpp
@@ -53,6 +53,8 @@ void ScopeGadget::loadConfiguration(IUAVGadgetConfiguration* config)
         return;
 
     scopeGadgetWidget->clearPlotWidget();
+    scopeGadgetWidget->setScopeName(config->name());
+
     sgConfig->getScope()->loadConfiguration(scopeGadgetWidget);
 }
 

--- a/ground/gcs/src/plugins/scope/scopegadgetwidget.cpp
+++ b/ground/gcs/src/plugins/scope/scopegadgetwidget.cpp
@@ -337,7 +337,7 @@ void ScopeGadgetWidget::clearPlotWidget()
     if(m_scope){
         // Clear the plots
         foreach(PlotData* plotData, m_dataSources.values()) {
-            plotData->clearPlots(plotData);
+            plotData->deletePlots(plotData);
         }
 
         // Clear the data

--- a/ground/gcs/src/plugins/scope/scopegadgetwidget.h
+++ b/ground/gcs/src/plugins/scope/scopegadgetwidget.h
@@ -93,6 +93,7 @@ public:
     void startTimer(int);
     QwtPlotGrid *m_grid;
     QwtLegend *m_legend;
+    void setScopeName(QString val) {scopeName = val;}
 
 protected:
     void mousePressEvent(QMouseEvent *e);
@@ -117,6 +118,7 @@ private:
     double m_xWindowSize;
     static QTimer *replotTimer;
     QList<QString> m_connectedUAVObjects;
+    QString scopeName;
 
 };
 

--- a/ground/gcs/src/plugins/scope/scopegadgetwidget.h
+++ b/ground/gcs/src/plugins/scope/scopegadgetwidget.h
@@ -109,6 +109,10 @@ private slots:
     void showCurve(const QVariant & itemInfo, bool on, int index);
     void startPlotting();
     void stopPlotting();
+    void popUpMenu(const QPoint &mousePosition);
+    void clearPlot();
+    void copyToClipboardAsImage();
+    void showOptionDialog();
 
 private:
     QMutex mutex;
@@ -119,7 +123,6 @@ private:
     static QTimer *replotTimer;
     QList<QString> m_connectedUAVObjects;
     QString scopeName;
-
 };
 
 

--- a/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.cpp
@@ -193,3 +193,13 @@ void HistogramData::deletePlots(PlotData *histogramData)
 
     delete histogramData;
 }
+
+
+/**
+ * @brief HistogramScopeConfig::clearPlots Clear all plot data
+ */
+void HistogramData::clearPlots()
+{
+    histogramBins->clear();
+    histogramInterval->clear();
+}

--- a/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.cpp
@@ -175,9 +175,9 @@ bool HistogramData::append(UAVObject* obj)
 }
 
 /**
- * @brief HistogramScopeConfig::clearPlots Clear all plot data
+ * @brief HistogramScopeConfig::deletePlots Delete all plot data
  */
-void HistogramData::clearPlots(PlotData *histogramData)
+void HistogramData::deletePlots(PlotData *histogramData)
 {
     histogram->detach();
 

--- a/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.h
@@ -55,6 +55,7 @@ public:
     virtual void removeStaleData(){}
     virtual void plotNewData(PlotData *, ScopeConfig *, ScopeGadgetWidget *);
     virtual void deletePlots(PlotData *);
+    void clearPlots();
 
     QwtIntervalSeriesData *getIntervalSeriesData(){return intervalSeriesData;}
     void setHistogram(QwtPlotHistogram *val){histogram = val;}

--- a/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes2d/histogramplotdata.h
@@ -54,7 +54,7 @@ public:
 
     virtual void removeStaleData(){}
     virtual void plotNewData(PlotData *, ScopeConfig *, ScopeGadgetWidget *);
-    virtual void clearPlots(PlotData *);
+    virtual void deletePlots(PlotData *);
 
     QwtIntervalSeriesData *getIntervalSeriesData(){return intervalSeriesData;}
     void setHistogram(QwtPlotHistogram *val){histogram = val;}

--- a/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.cpp
@@ -246,9 +246,9 @@ void TimeSeriesPlotData::removeStaleDataTimeout()
 
 
 /**
- * @brief ScatterplotData::clearPlots Clear all plot data
+ * @brief ScatterplotData::deletePlots Delete all plot data
  */
-void ScatterplotData::clearPlots(PlotData *scatterplotData)
+void ScatterplotData::deletePlots(PlotData *scatterplotData)
 {
     curve->detach();
 

--- a/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.cpp
@@ -255,3 +255,13 @@ void ScatterplotData::deletePlots(PlotData *scatterplotData)
     delete curve;
     delete scatterplotData;
 }
+
+
+/**
+ * @brief ScatterplotData::clearPlots Clear all plot data
+ */
+void ScatterplotData::clearPlots()
+{
+    yData->clear();
+    xData->clear();
+}

--- a/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.h
@@ -49,6 +49,7 @@ public:
     ~ScatterplotData(){}
 
     virtual void deletePlots(PlotData *);
+    void clearPlots();
 
     void setCurve(QwtPlotCurve *val){curve = val;}
 

--- a/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes2d/scatterplotdata.h
@@ -48,7 +48,7 @@ public:
         Plot2dData(uavObject, uavField){curve = 0;}
     ~ScatterplotData(){}
 
-    virtual void clearPlots(PlotData *);
+    virtual void deletePlots(PlotData *);
 
     void setCurve(QwtPlotCurve *val){curve = val;}
 

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.cpp
@@ -214,9 +214,9 @@ bool SpectrogramData::append(UAVObject* multiObj)
 
 
 /**
- * @brief SpectrogramScopeConfig::clearPlots Clear all plot data
+ * @brief SpectrogramScopeConfig::deletePlots Delete all plot data
  */
-void SpectrogramData::clearPlots(PlotData *spectrogramData)
+void SpectrogramData::deletePlots(PlotData *spectrogramData)
 {
     spectrogram->detach();
 

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.cpp
@@ -227,3 +227,15 @@ void SpectrogramData::deletePlots(PlotData *spectrogramData)
     delete spectrogram;
     delete spectrogramData;
 }
+
+
+/**
+ * @brief SpectrogramScopeConfig::clearPlots Clear all plot data
+ */
+void SpectrogramData::clearPlots()
+{
+    timeDataHistory->clear();
+    zDataHistory->clear();
+
+    resetAxisRanges();
+}

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
@@ -66,7 +66,7 @@ public:
     double readAndResetAutoscaleValue(){double tmpVal = autoscaleValueUpdated; autoscaleValueUpdated = 0; return tmpVal;}
 
     virtual void plotNewData(PlotData *, ScopeConfig *, ScopeGadgetWidget *);
-    virtual void clearPlots(PlotData *);
+    virtual void deletePlots(PlotData *);
     virtual void setXMaximum(double val);
     virtual void setYMaximum(double val);
     virtual void setZMaximum(double val);

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
@@ -70,6 +70,8 @@ public:
     virtual void setXMaximum(double val);
     virtual void setYMaximum(double val);
     virtual void setZMaximum(double val);
+    void clearPlots();
+
 
     QwtMatrixRasterData *getRasterData(){return rasterData;}
     void setSpectrogram(QwtPlotSpectrogram *val){spectrogram = val;}
@@ -84,6 +86,7 @@ private:
     double timeHorizon;
     unsigned int windowWidth;
     double autoscaleValueUpdated;
+
 };
 
 #endif // SPECTROGRAMDATA_H


### PR DESCRIPTION
@m-thread [did this a long time ago](https://github.com/librepilot/LibrePilot/commit/6c476d2a58bd6b4582eb4e89c25c7ad5bc12c494). I had to do a bit of work to get it into the refactored scopes, but now it's ready.

This provides a right-click context menu in the scopes. Currently there are three items:
- clear plot
- copy plot to clipboard
- open up plot settings

The only pathology I've detected is that when opening the config dialog on OSX it's forgets its last size. Not very nice, because it requires resizing the config dialog every time.

@tracernz you might be interested in this as well.
