### PR TITLE
openlrs: fix cast to not erroneously quantize battery data

### DIFF
--- a/flight/PiOS/Common/pios_openlrs.c
+++ b/flight/PiOS/Common/pios_openlrs.c
@@ -942,8 +942,8 @@ static void pios_openlrs_rx_loop(struct pios_openlrs_dev *openlrs_dev)
 						FlightBatteryStateGet(&bat);
 						// FrSky protocol normally uses 3.3V at 255 but
 						// divider from display can be set internally
-						tx_buf[2] = (uint8_t) bat.Voltage / 25.0f * 255;
-						tx_buf[3] = (uint8_t) bat.Current / 60.0f * 255;
+						tx_buf[2] = (uint8_t) (bat.Voltage / 25.0f * 255);
+						tx_buf[3] = (uint8_t) (bat.Current / 60.0f * 255);
 					} else {
 						tx_buf[2] = 0; // these bytes carry analog info. package
 						tx_buf[3] = 0; // battery here

--- a/flight/PiOS/Common/pios_openlrs.c
+++ b/flight/PiOS/Common/pios_openlrs.c
@@ -1064,6 +1064,10 @@ uint8_t PIOS_OpenLRS_RSSI_Get(void)
 	if(openlrs_status.FailsafeActive == OPENLRSSTATUS_FAILSAFEACTIVE_ACTIVE)
 		return 0;
 	else {
+		// Check object handle exists
+		if (OpenLRSHandle() == NULL)
+			return 0;
+
 		OpenLRSData openlrs_data;
 		OpenLRSGet(&openlrs_data);
 		


### PR DESCRIPTION
This fixes a bug reported by @CrazyCoder that made the OpenLRS send
the battery voltage and current incorrectly resolved.

Signed-off-by: James Cotton peabody124@gmail.com
