### PR TITLE
Add statistics library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -960,6 +960,7 @@ $(eval $(call SIM_TEMPLATE,simulation,Simulation,'sim ',posix,elf))
 ##############################
 
 ALL_UNITTESTS := logfs i2c_vm misc_math coordinate_conversions error_correcting streamfs dsm timeutils
+ALL_UNITTESTS += statistics
 ALL_PYTHON_UNITTESTS := python_ut_test
 
 UT_OUT_DIR := $(BUILD_DIR)/unit_tests

--- a/flight/Libraries/math/statistics.c
+++ b/flight/Libraries/math/statistics.c
@@ -6,10 +6,26 @@
  * @{
  *
  * @file       statistics.c
- * @author     Kenn Sebesta, Copyright (C) 2015.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
  * @brief      Statistics support
+ * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 
 #include "statistics.h"
 

--- a/flight/Libraries/math/statistics.c
+++ b/flight/Libraries/math/statistics.c
@@ -135,3 +135,124 @@ float get_linear_variance(const struct linear_mean_and_std_dev *X)
 
 	return variance;
 }
+
+
+/**
+ * @brief initialize_circular_sums Because floating point values are used,
+ * there will be some loss of precision. Thus, it is important to periodically reset the parameters.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Directional_statistics
+ * @param X struct holding the stochastic parameters
+ * @param num_samples number of samples
+ * @param y vector of samples
+ */
+void initialize_circular_sums(struct circular_mean_and_std_dev *X, uint16_t window_size, uint16_t num_samples, const float y_R[])
+{
+	X->window_size = window_size;
+
+	X->T0 = num_samples;
+	X->T0_2 = num_samples * num_samples;
+
+	// Reinitialize the accumulators
+	X->S1 = 0;
+	X->C1 = 0;
+
+	for (int i=0; i<num_samples; i++) {
+		// Sum of elements
+		X->S1 += sin(/*(double)*/y_R[i]);
+		X->C1 += cos(/*(double)*/y_R[i]);
+	}
+}
+
+
+/**
+ * @brief incremental_update_circular_sums  Basically functions like a FIFO, but in the
+ * sense that it is adding and removing cumulative data. NOTE: Because this uses float point values and there
+ * will be some loss of precision, it is expected that the parameters must be periodically reset.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Directional_statistics
+ * @param X struct holding the stochastic parameters
+ * @param x_oldest The chronologically oldest element in the buffer.
+ * @param x_new The chronologically newest element, to be added to the buffer.
+ */
+void incremental_update_circular_sums(struct circular_mean_and_std_dev *X, const float y_oldest, const float y_new)
+{
+	// Grow T0, number of samples, until reaching the desired size of the sample set
+	if (X->T0 < X->window_size) {
+		X->T0++; //
+		X->T0_2 = X->T0*X->T0; // Squared number of samples
+
+		// If the array isn't at full size yet, then simply add the new values to the sum
+		X->S1 += sin(y_new);
+		X->C1 += cos(y_new);
+	} else {
+		X->S1 += -sin(y_oldest) + sin(y_new);
+		X->C1 += -cos(y_oldest) + cos(y_new);
+	}
+}
+
+
+/**
+ * @brief get_circular_mean This recognizes that the mean for a dataset of angles is calculated
+ * by a rolling sum of sines and cosines of angles.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Directional_statistics
+ * @param X struct holding the stochastic parameters
+ * @return the mean for the dataset represented by the stochastic parameters
+ */
+float get_circular_mean(const struct circular_mean_and_std_dev *X)
+{
+	float circular_mean = atan2f(X->S1, X->C1);
+
+	return circular_mean;
+}
+
+
+/**
+ * @brief get_circular_standard_deviation This recognizes that the standard deviation for a dataset
+ * can be calculated by a rolling sum of number of data points and sum of sines and cosines of angles.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Directional_statistics
+ * @param X struct holding the stochastic parameters
+ * @return circular_std_dev the standard deviation for the dataset represented by the stochastic parameters
+ */
+float get_circular_standard_deviation(const struct circular_mean_and_std_dev *X)
+{
+	float circular_std_dev;
+
+	// Calculate R^2, the norm of the average vector
+	double R2 = (X->S1*X->S1 + X->C1*X->C1) / X->T0_2;
+
+	if (R2 <= 1) {
+		circular_std_dev = sqrtf(-log(R2));
+	} else {
+		circular_std_dev = 0;
+	}
+
+	return circular_std_dev;
+}
+
+
+/**
+ * @brief get_angular_deviation This recognizes that the angular deviation for a dataset
+ * can be calculated by a rolling sum of number of data points and sum of sines and cosines of angles.
+ *
+ * Cf. "CircStat: A MATLAB Toolbox for Circular Statistics", http://www.kyb.tuebingen.mpg.de/fileadmin/user_upload/files/publications/J-Stat-Softw-2009-Berens_6037[0].pdf
+ * @param X struct holding the stochastic parameters
+ * @return angular_deviation the standard deviation for the dataset represented by the stochastic parameters
+ */
+float get_angular_deviation(const struct circular_mean_and_std_dev *X)
+{
+	float angular_deviation;
+
+	// Calculate R^2, the norm of the average vector
+	double R2 = (X->S1*X->S1 + X->C1*X->C1) / X->T0_2;
+
+	if (R2 <= 1) {
+		angular_deviation = sqrtf(2*(1 - sqrt(R2)));
+	} else {
+		angular_deviation = 0;
+	}
+
+	return angular_deviation;
+}

--- a/flight/Libraries/math/statistics.c
+++ b/flight/Libraries/math/statistics.c
@@ -1,0 +1,137 @@
+/**
+ ******************************************************************************
+ * @addtogroup TauLabsMath Tau Labs math support libraries
+ * @{
+ * @addtogroup TauLabsStatistics Tau Labs statistics math support libraries
+ * @{
+ *
+ * @file       statistics.c
+ * @author     Kenn Sebesta, Copyright (C) 2015.
+ * @brief      Statistics support
+ *
+ *****************************************************************************/
+
+#include "statistics.h"
+
+#include <math.h>
+
+/**
+ * @brief initialize_linear_sums Because floating point values are used,
+ * there will be some loss of precision. Thus, it is important to periodically reset the parameters.
+ * Cf. https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+ * Cf. http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
+ * @param X struct holding the statistical parameters
+ * @param window_size desired window size
+ * @param num_samples number of samples available in vector
+ * @param y vector of samples
+ */
+void initialize_linear_sums(struct linear_mean_and_std_dev *X, uint16_t window_size, uint16_t num_samples, const float y[])
+{
+	X->window_size = window_size;
+	X->T0 = num_samples;
+
+	// Reinitialize the accumulators
+	X->T1 = 0;
+	X->T2 = 0;
+
+	for (int i=0; i<num_samples; i++) {
+		// Sum of elements
+		X->T1 += (double)y[i];
+
+		// Sum of squares of elements
+		X->T2 += (double)y[i]*(double)y[i];
+	}
+}
+
+
+/**
+ * @brief incremental_update_linear_sums  Basically functions like a FIFO, but in the
+ * sense that it is adding and removing cumulative data. NOTE: Because this uses floating point values and
+ * there will be some loss of precision, it is expected that the parameters must be periodically reset.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+ * Cf. http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
+ * @param X struct holding the stochastic parameters
+ * @param y_oldest The chronologically oldest element in the buffer.
+ * @param y_new The chronologically newest element, to be added to the buffer.
+ */
+void incremental_update_linear_sums(struct linear_mean_and_std_dev *X,
+      float y_oldest,
+      const float y_new)
+{
+	// Grow T0, number of samples, until reaching the desired size of the sample set
+	if (X->T0 < X->window_size) {
+		X->T0++; //
+
+		// Set this equal to 0 so that the earliest element isn't removed when
+		// the series hasn't yet reached the window size
+		y_oldest = 0;
+	}
+
+	// Update T1, sum of elements
+	X->T1 += (double)(-y_oldest + y_new);
+
+	// Update T2, sum of squares of elements
+	X->T2 += (double)(-y_oldest*y_oldest) + (double)(y_new*y_new);
+}
+
+
+/**
+ * @brief get_linear_mean Calculate the mean as the sum of the elements, divided by the
+ * number of elements. Classic!
+ * @param X struct holding the stochastic parameters
+ * @return the mean for the dataset represented by the stochastic parameters
+ */
+float get_linear_mean(const struct linear_mean_and_std_dev *X)
+{
+	float mean = X->T1 / X->T0;
+	return mean;
+}
+
+
+/**
+ * @brief get_linear_standard_deviation This recognizes that the standard deviation for a dataset
+ * can be calculated by a rolling sum of number of elements, sum of elements, and sum of
+ * elements squared. The decision is made to use the slightly less correct std. deviation
+ * calculation which divdes by N, instead of N-1. For large datasets, this makes only a
+ * small scalar difference. This results in a slight gain of computational efficiency.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+ * Cf. http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
+ * @param X struct holding the stochastic parameters
+ * @return std_dev the standard deviation for the dataset represented by the stochastic parameters
+ */
+float get_linear_standard_deviation(const struct linear_mean_and_std_dev *X)
+{
+	float std_dev;
+
+	// sigma = sqrt(T0*T2 - T1^2)/T0
+	double radicand = X->T0*X->T2 - X->T1*X->T1;
+
+	// Check for sanity
+	if (radicand > 0 && X->T0 > 0) {
+		std_dev = sqrtf(radicand) / X->T0;
+	} else {
+		std_dev = 0;
+	}
+	return std_dev;
+}
+
+
+/**
+ * @brief get_linear_variance This recognizes that the variance (standard deviation squared)
+ * for a dataset can be calculated by a rolling sum of number of elements, sum of elements,
+ * and sum of elements squared.
+ *
+ * Cf. https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+ * Cf. http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
+ * @param X struct holding the stochastic parameters
+ * @return std_dev the variance (standard deviation squared) for the dataset represented by the stochastic parameters
+ */
+float get_linear_variance(const struct linear_mean_and_std_dev *X)
+{
+	// sigma^2 = T2/T0 - (T1/T0)^2
+	float variance = (X->T2*X->T0 - X->T1*X->T1) / (X->T0*X->T0);
+
+	return variance;
+}

--- a/flight/Libraries/math/statistics.c
+++ b/flight/Libraries/math/statistics.c
@@ -194,6 +194,40 @@ float get_linear_variance(const struct linear_mean_and_std_dev *X)
 
 
 /**
+ * @brief pearson_correlation Calculates the Pearson correlation for a covariance between two
+ * variables. This is the variance divided by the sqrt of the muliple of the autovariances
+ * @param x_autovariance
+ * @param y_autovariance
+ * @param variance
+ * @return
+ */
+float pearson_correlation(const float x_autovariance, const float y_autovariance, const float variance)
+{
+	// If either autovariance is 0 (or close to), then we don't know what the correlation is.
+	// The other variable could be static or it could be varying. The result is either -Inf
+	// or +Inf, depending on from which direction the first autovariance value is
+	// approaching 0. Rather than try to calculate this, we simply return an impossible
+	// value to indicate which
+	if (x_autovariance < 1e-5f) {
+		return -2;
+	} else if (y_autovariance < 1e-5f) {
+		return 2;
+	}
+
+	// Precalculate the denominator squared
+	float den2 = x_autovariance * y_autovariance;
+
+	// Check that the denominator hasn't suffered an underflow as the result of
+	// multiplying the two autovariances together
+	if (den2 > 1e-32f) {
+		return variance / sqrtf(den2);
+	} else {
+		return 0;
+	}
+}
+
+
+/**
  * @brief initialize_circular_sums Because floating point values are used,
  * there will be some loss of precision. Thus, it is important to periodically reset the parameters.
  *

--- a/flight/Libraries/math/statistics.h
+++ b/flight/Libraries/math/statistics.h
@@ -24,6 +24,14 @@ struct linear_mean_and_std_dev {
 	uint16_t window_size;
 };
 
+struct circular_mean_and_std_dev {
+	uint16_t T0;
+	uint32_t T0_2;
+	double S1;
+	double C1;
+	uint16_t window_size;
+};
+
 /* All below functions inspired by
  * http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
  */
@@ -32,5 +40,18 @@ void incremental_update_linear_sums(struct linear_mean_and_std_dev *X, float x_o
 float get_linear_mean(const struct linear_mean_and_std_dev *X);
 float get_linear_standard_deviation(const struct linear_mean_and_std_dev *X);
 float get_linear_variance(const struct linear_mean_and_std_dev *X);
+
+/* All four below functions inspired by
+ * https://en.wikipedia.org/wiki/Directional_statistics
+ */
+void initialize_circular_sums(struct circular_mean_and_std_dev *X, uint16_t window_size, uint16_t num_samples, const float x[]);
+void incremental_update_circular_sums(struct circular_mean_and_std_dev *X, const float x_oldest, const float x_new);
+float get_circular_mean(const struct circular_mean_and_std_dev *X);
+float get_circular_standard_deviation(const struct circular_mean_and_std_dev *X);
+
+/* Inspired by "CircStat: A MATLAB Toolbox for Circular Statistics",
+ * http://www.kyb.tuebingen.mpg.de/fileadmin/user_upload/files/publications/J-Stat-Softw-2009-Berens_6037[0].pdf
+ */
+float get_angular_deviation(const struct circular_mean_and_std_dev *X);
 
 #endif /* STATISTICS_H */

--- a/flight/Libraries/math/statistics.h
+++ b/flight/Libraries/math/statistics.h
@@ -6,10 +6,26 @@
  * @{
  *
  * @file       statistics.h
- * @author     Kenn Sebesta, Copyright (C) 2015.
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
  * @brief      Statistics support
+ * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 
 #ifndef STATISTICS_H
 #define STATISTICS_H

--- a/flight/Libraries/math/statistics.h
+++ b/flight/Libraries/math/statistics.h
@@ -32,6 +32,11 @@ struct circular_mean_and_std_dev {
 	uint16_t window_size;
 };
 
+void bayes_filter(double *belief_H0, double *belief_H1,
+                double p_sense_condition_H0, double p_sense_condition_H1,
+                double p_H0_Ux_H0, double p_H0_Ux_H1,
+                double p_H1_Ux_H0, double p_H1_Ux_H1);
+
 /* All below functions inspired by
  * http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
  */

--- a/flight/Libraries/math/statistics.h
+++ b/flight/Libraries/math/statistics.h
@@ -1,0 +1,36 @@
+/**
+ ******************************************************************************
+ * @addtogroup TauLabsMath Tau Labs math support libraries
+ * @{
+ * @addtogroup TauLabsStatistics Tau Labs statistics math support libraries
+ * @{
+ *
+ * @file       statistics.h
+ * @author     Kenn Sebesta, Copyright (C) 2015.
+ * @brief      Statistics support
+ *
+ *****************************************************************************/
+
+#ifndef STATISTICS_H
+#define STATISTICS_H
+
+#include "stdint.h"
+
+// Public types
+struct linear_mean_and_std_dev {
+	uint16_t T0;
+	double T1;
+	double T2;
+	uint16_t window_size;
+};
+
+/* All below functions inspired by
+ * http://math.stackexchange.com/questions/102978/incremental-computation-of-standard-deviation
+ */
+void initialize_linear_sums(struct linear_mean_and_std_dev *X, uint16_t window_size, uint16_t num_samples, const float x[]);
+void incremental_update_linear_sums(struct linear_mean_and_std_dev *X, float x_oldest, const float x_new);
+float get_linear_mean(const struct linear_mean_and_std_dev *X);
+float get_linear_standard_deviation(const struct linear_mean_and_std_dev *X);
+float get_linear_variance(const struct linear_mean_and_std_dev *X);
+
+#endif /* STATISTICS_H */

--- a/flight/Libraries/math/statistics.h
+++ b/flight/Libraries/math/statistics.h
@@ -45,6 +45,7 @@ void incremental_update_linear_sums(struct linear_mean_and_std_dev *X, float x_o
 float get_linear_mean(const struct linear_mean_and_std_dev *X);
 float get_linear_standard_deviation(const struct linear_mean_and_std_dev *X);
 float get_linear_variance(const struct linear_mean_and_std_dev *X);
+float pearson_correlation(const float x_autovariance, const float y_autovariance, const float variance);
 
 /* All four below functions inspired by
  * https://en.wikipedia.org/wiki/Directional_statistics

--- a/flight/tests/statistics/Makefile
+++ b/flight/tests/statistics/Makefile
@@ -1,0 +1,42 @@
+###############################################################################
+# @file       Makefile
+# @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+# @addtogroup 
+# @{
+# @addtogroup 
+# @{
+# @brief Makefile for unit test
+###############################################################################
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#
+
+WHEREAMI := $(dir $(lastword $(MAKEFILE_LIST)))
+TOP      := $(realpath $(WHEREAMI)/../../../)
+include $(TOP)/make/firmware-defs.mk
+
+EXTRAINCDIRS += $(SHAREDAPIDIR)
+EXTRAINCDIRS += $(FLIGHTLIB)/math
+
+CFLAGS += -O0
+CFLAGS += -Wall -Werror
+CFLAGS += -g
+CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
+
+CONLYFLAGS += -std=gnu99
+
+SRC := $(FLIGHTLIB)/math/statistics.c
+
+include $(TOP)/make/unittest.mk

--- a/flight/tests/statistics/unittest.cpp
+++ b/flight/tests/statistics/unittest.cpp
@@ -1,13 +1,29 @@
 /**
  ******************************************************************************
  * @file       unittest.cpp
- * @author     Kenn Sebesta, Copyright (C) 2016
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
  * @addtogroup UnitTests
  * @{
  * @addtogroup UnitTests
  * @{
  * @brief Unit test
+ * @see        The GNU Public License (GPL) Version 3
  *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 
 /*
  * NOTE: This program uses the Google Test infrastructure to drive the unit test

--- a/flight/tests/statistics/unittest.cpp
+++ b/flight/tests/statistics/unittest.cpp
@@ -237,3 +237,227 @@ TEST_F(CalculateLinearUpdate, StandardDeviation) {
   EXPECT_NEAR(0, std_dev2, eps);
 };
 
+
+//--------------
+// To use a test fixture, derive a class from testing::Test.
+class CircularStatistics : public testing::Test {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+  // Test arrays. These are global to all instances
+  static const float test_array0[TEST_ARRAY_LENGTH_SMALL];
+  static const float test_array1[TEST_ARRAY_LENGTH_SMALL];
+  static const float test_array2[TEST_ARRAY_LENGTH_SMALL];
+
+  // Test structures. These are unique to each instance
+  struct circular_mean_and_std_dev test_struct_0;
+  struct circular_mean_and_std_dev test_struct_1;
+  struct circular_mean_and_std_dev test_struct_2;
+
+  static const double eps;
+  static const float newest_y;
+  static const double pi;
+};
+
+// Initialize static constants
+const double CircularStatistics::eps = 1e-6;
+const float CircularStatistics::newest_y = 6;
+const double CircularStatistics::pi = 3.14159265358979323846264338327950288;
+const float CircularStatistics::test_array0[] = {0, 1, 2, 3, 4, 5};
+const float CircularStatistics::test_array1[] = {-2*pi, -1*pi, 0*pi, 0*pi, 1*pi, 2*pi};
+const float CircularStatistics::test_array2[] = {0, 0, 0, 0, 0, 0};
+
+// Test fixture for incremental_update_linear_sums()
+class Initialize : public CircularStatistics {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+};
+
+
+TEST_F(Initialize, InitializeMeanAndStandardDeviation) {
+  initialize_circular_sums(&test_struct_0,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_0.T0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL*TEST_ARRAY_LENGTH_SMALL, (int)test_struct_0.T0_2);
+  EXPECT_NEAR(0.176161649722379, test_struct_0.S1, eps);
+  EXPECT_NEAR(-0.235818462679834, test_struct_0.C1, eps);
+
+  initialize_circular_sums(&test_struct_1,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array1);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_1.T0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL*TEST_ARRAY_LENGTH_SMALL, (int)test_struct_1.T0_2);
+  EXPECT_NEAR(0, test_struct_1.S1, eps);
+  EXPECT_NEAR(2, test_struct_1.C1, eps);
+
+  initialize_circular_sums(&test_struct_2,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array2);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_2.T0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL*TEST_ARRAY_LENGTH_SMALL, (int)test_struct_2.T0_2);
+  EXPECT_NEAR(0, test_struct_2.S1, eps);
+  EXPECT_NEAR(6, test_struct_2.C1, eps);
+};
+
+
+// Test fixture for incremental_update_circular_sums()
+class IncrementalCircularUpdate : public CircularStatistics {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+};
+
+
+TEST_F(IncrementalCircularUpdate, IncrementalCircularUpdateMeanAndStandardDeviation) {
+  initialize_circular_sums(&test_struct_0,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array0);
+  incremental_update_circular_sums(&test_struct_0,
+                                   test_array0[0],
+                                   newest_y);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_0.T0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL*TEST_ARRAY_LENGTH_SMALL, (int)test_struct_0.T0_2);
+  EXPECT_NEAR(-0.103253848476547, test_struct_0.S1, eps);
+  EXPECT_NEAR(-0.275648176029468, test_struct_0.C1, eps);
+
+  initialize_circular_sums(&test_struct_1,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array1);
+  incremental_update_circular_sums(&test_struct_1,
+                                   test_array1[0],
+                                   newest_y);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_1.T0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL*TEST_ARRAY_LENGTH_SMALL, (int)test_struct_1.T0_2);
+  EXPECT_NEAR(-0.279415498198926, test_struct_1.S1, eps);
+  EXPECT_NEAR(1.96017028665037, test_struct_1.C1, eps);
+
+  initialize_circular_sums(&test_struct_2,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array2);
+  incremental_update_circular_sums(&test_struct_2,
+                                   test_array2[0],
+                                   newest_y);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_2.T0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL*TEST_ARRAY_LENGTH_SMALL, (int)test_struct_2.T0_2);
+  EXPECT_NEAR(-0.279415498198926, test_struct_2.S1, eps);
+  EXPECT_NEAR(5.96017028665037, test_struct_2.C1, eps);
+};
+
+
+/**
+ * @brief TEST_F This tests that a structure with a partially full data
+ * array grows correctly
+ */
+TEST_F(IncrementalCircularUpdate, IncrementallyGrowMeanAndStandardDeviation) {
+  initialize_circular_sums(&test_struct_0,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL - 2,
+                           test_array0);
+  incremental_update_circular_sums(&test_struct_0,
+                                   test_array0[0],
+                                   test_array0[TEST_ARRAY_LENGTH_SMALL - 2]);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL - 1, test_struct_0.T0);
+  EXPECT_EQ((TEST_ARRAY_LENGTH_SMALL-1) * (TEST_ARRAY_LENGTH_SMALL-1), (int)test_struct_0.T0_2);
+  EXPECT_NEAR(1.13508592438552, test_struct_0.S1, eps);
+  EXPECT_NEAR(-0.51948064814306, test_struct_0.C1, eps);
+
+  initialize_circular_sums(&test_struct_1,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL-2,
+                           test_array1);
+  incremental_update_circular_sums(&test_struct_1,
+                                   test_array1[0],
+                                   test_array1[TEST_ARRAY_LENGTH_SMALL - 2]);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL - 1, test_struct_1.T0);
+  EXPECT_EQ((TEST_ARRAY_LENGTH_SMALL-1) * (TEST_ARRAY_LENGTH_SMALL-1), (int)test_struct_1.T0_2);
+  EXPECT_NEAR(0, test_struct_1.S1, eps);
+  EXPECT_NEAR(1, test_struct_1.C1, eps);
+
+  initialize_circular_sums(&test_struct_2,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL-2,
+                           test_array2);
+  incremental_update_circular_sums(&test_struct_2,
+                                   test_array2[0],
+                                   test_array2[TEST_ARRAY_LENGTH_SMALL - 2]);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL - 1, test_struct_2.T0);
+  EXPECT_EQ((TEST_ARRAY_LENGTH_SMALL-1) * (TEST_ARRAY_LENGTH_SMALL-1), (int)test_struct_2.T0_2);
+  EXPECT_NEAR(0, test_struct_2.S1, eps);
+  EXPECT_NEAR(5, test_struct_2.C1, eps);
+};
+
+
+// Test fixture for incremental_update_circular_sums()
+class CalculateCircularStatistics : public CircularStatistics {
+protected:
+  virtual void SetUp() {
+    initialize_circular_sums(&test_struct_0,
+                             TEST_ARRAY_LENGTH_SMALL,
+                             TEST_ARRAY_LENGTH_SMALL,
+                             test_array0);
+    initialize_circular_sums(&test_struct_1,
+                             TEST_ARRAY_LENGTH_SMALL,
+                             TEST_ARRAY_LENGTH_SMALL,
+                             test_array1);
+    initialize_circular_sums(&test_struct_2,
+                             TEST_ARRAY_LENGTH_SMALL,
+                             TEST_ARRAY_LENGTH_SMALL,
+                             test_array2);
+   }
+
+  virtual void TearDown() {
+  }
+};
+
+TEST_F(CalculateCircularStatistics, Mean) {
+  float mean0 = get_circular_mean(&test_struct_0);
+  EXPECT_NEAR(2.5, mean0, eps);
+
+  float mean1 = get_circular_mean(&test_struct_1);
+  EXPECT_NEAR(0, mean1, eps);
+
+  float mean2 = get_circular_mean(&test_struct_2);
+  EXPECT_NEAR(0, mean2, eps);
+};
+
+
+TEST_F(CalculateCircularStatistics, StandardDeviation) {
+  float std_dev0 = get_circular_standard_deviation(&test_struct_0);
+  EXPECT_NEAR(2.45549889531754, std_dev0, eps);
+
+  float std_dev1 = get_circular_standard_deviation(&test_struct_1);
+  EXPECT_NEAR(1.48230380736751, std_dev1, eps);
+
+  float std_dev2 = get_circular_standard_deviation(&test_struct_2);
+  EXPECT_NEAR(0, std_dev2, eps);
+};
+
+TEST_F(CalculateCircularStatistics, AngularDeviation) {
+  float angular_deviation0 = get_angular_deviation(&test_struct_0);
+  EXPECT_NEAR(1.3790875853232, angular_deviation0, eps);
+
+  float angular_deviation1 = get_angular_deviation(&test_struct_1);
+  EXPECT_NEAR(1.15470053837925, angular_deviation1, eps);
+
+  float angular_deviation2 = get_angular_deviation(&test_struct_2);
+  EXPECT_NEAR(0, angular_deviation2, eps);
+};

--- a/flight/tests/statistics/unittest.cpp
+++ b/flight/tests/statistics/unittest.cpp
@@ -1,0 +1,33 @@
+/**
+ ******************************************************************************
+ * @file       unittest.cpp
+ * @author     Kenn Sebesta, Copyright (C) 2016
+ * @addtogroup UnitTests
+ * @{
+ * @addtogroup UnitTests
+ * @{
+ * @brief Unit test
+ *****************************************************************************/
+
+/*
+ * NOTE: This program uses the Google Test infrastructure to drive the unit test
+ *
+ * Main site for Google Test: http://code.google.com/p/googletest/
+ * Documentation and examples: http://code.google.com/p/googletest/wiki/Documentation
+ */
+
+#include "gtest/gtest.h"
+
+#include <stdio.h>		/* printf */
+#include <stdlib.h>		/* abort */
+#include <string.h>		/* memset */
+#include <stdint.h>		/* uint*_t */
+
+extern "C" {
+
+#include "statistics.h"		/* API for statistics functions */
+
+}
+
+#include <math.h>		/* fabs() */
+

--- a/flight/tests/statistics/unittest.cpp
+++ b/flight/tests/statistics/unittest.cpp
@@ -31,3 +31,209 @@ extern "C" {
 
 #include <math.h>		/* fabs() */
 
+#define TEST_ARRAY_LENGTH_SMALL 6
+
+// To use a test fixture, derive a class from testing::Test.
+class LinearStatistics : public testing::Test {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+  // Test arrays. These are global to all instances
+  static const float test_array0[TEST_ARRAY_LENGTH_SMALL];
+  static const float test_array1[TEST_ARRAY_LENGTH_SMALL];
+  static const float test_array2[TEST_ARRAY_LENGTH_SMALL];
+
+  // Test structures. These are unique to each instance
+  struct linear_mean_and_std_dev test_struct_0;
+  struct linear_mean_and_std_dev test_struct_1;
+  struct linear_mean_and_std_dev test_struct_2;
+
+  static const double eps;
+  static const float newest_y;
+};
+
+// Initialize static constants
+const double LinearStatistics::eps = 1e-6;
+const float LinearStatistics::newest_y = 6;
+const float LinearStatistics::test_array0[] = {0, 1, 2, 3, 4, 5};
+const float LinearStatistics::test_array1[] = {-2, -1, 0, 0, 1, 2};
+const float LinearStatistics::test_array2[] = {0, 0, 0, 0, 0, 0};
+
+// Test fixture for incremental_update_linear_sums()
+class InitializeLinear : public LinearStatistics {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+};
+
+
+/**
+ * @brief TEST_F Test that we are properly initializing the structures
+ */
+TEST_F(InitializeLinear, InitializeMeanAndStandardDeviation) {
+  initialize_linear_sums(&test_struct_0,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         test_array0);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_0.T0);
+  EXPECT_NEAR(15, test_struct_0.T1, eps);
+  EXPECT_NEAR(55, test_struct_0.T2, eps);
+
+  initialize_linear_sums(&test_struct_1,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         test_array1);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_1.T0);
+  EXPECT_NEAR(0, test_struct_1.T1, eps);
+  EXPECT_NEAR(10, test_struct_1.T2, eps);
+
+  initialize_linear_sums(&test_struct_2,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         test_array2);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_2.T0);
+  EXPECT_NEAR(0, test_struct_2.T1, eps);
+  EXPECT_NEAR(0, test_struct_2.T2, eps);
+};
+
+
+// Test fixture for incremental_update_linear_sums()
+class IncrementalLinearUpdate : public LinearStatistics {
+protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+};
+
+
+TEST_F(IncrementalLinearUpdate, IncrementalLinearUpdateMeanAndStandardDeviation) {
+  initialize_linear_sums(&test_struct_0,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         test_array0);
+  incremental_update_linear_sums(&test_struct_0,
+                                 test_array0[0],
+                                 newest_y);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_0.T0);
+  EXPECT_NEAR(21, test_struct_0.T1, eps);
+  EXPECT_NEAR(91, test_struct_0.T2, eps);
+
+  initialize_linear_sums(&test_struct_1,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         test_array1);
+  incremental_update_linear_sums(&test_struct_1,
+                                 test_array1[0],
+                                 newest_y);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_1.T0);
+  EXPECT_NEAR(8, test_struct_1.T1, eps);
+  EXPECT_NEAR(42, test_struct_1.T2, eps);
+
+  initialize_linear_sums(&test_struct_2,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         test_array2);
+  incremental_update_linear_sums(&test_struct_2,
+                                 test_array2[0],
+                                 newest_y);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL, test_struct_2.T0);
+  EXPECT_NEAR(6, test_struct_2.T1, eps);
+  EXPECT_NEAR(36, test_struct_2.T2, eps);
+};
+
+
+/**
+ * @brief TEST_F This tests that a structure with a partially full data
+ * array grows correctly
+ */
+TEST_F(IncrementalLinearUpdate, IncrementallyGrowMeanAndStandardDeviation) {
+  initialize_linear_sums(&test_struct_0,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL - 2,
+                         test_array0);
+  incremental_update_linear_sums(&test_struct_0,
+                                 test_array0[0],
+                                 test_array0[TEST_ARRAY_LENGTH_SMALL - 2]);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL - 1, test_struct_0.T0);
+  EXPECT_NEAR(10, test_struct_0.T1, eps);
+  EXPECT_NEAR(30, test_struct_0.T2, eps);
+
+  initialize_linear_sums(&test_struct_1,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL-2,
+                         test_array1);
+  incremental_update_linear_sums(&test_struct_1,
+                                 test_array1[0],
+                                 test_array1[TEST_ARRAY_LENGTH_SMALL - 2]);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL - 1, test_struct_1.T0);
+  EXPECT_NEAR(-2, test_struct_1.T1, eps);
+  EXPECT_NEAR(6, test_struct_1.T2, eps);
+
+  initialize_linear_sums(&test_struct_2,
+                         TEST_ARRAY_LENGTH_SMALL,
+                         TEST_ARRAY_LENGTH_SMALL-2,
+                         test_array2);
+  incremental_update_linear_sums(&test_struct_2,
+                                 test_array2[0],
+                                 test_array2[TEST_ARRAY_LENGTH_SMALL - 2]);
+  EXPECT_EQ(TEST_ARRAY_LENGTH_SMALL - 1, test_struct_2.T0);
+  EXPECT_NEAR(0, test_struct_2.T1, eps);
+  EXPECT_NEAR(0, test_struct_2.T2, eps);
+};
+
+
+// Test fixture for incremental_update_linear_sums()
+class CalculateLinearUpdate : public LinearStatistics {
+protected:
+  virtual void SetUp() {
+    initialize_linear_sums(&test_struct_0,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array0);
+    initialize_linear_sums(&test_struct_1,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array1);
+    initialize_linear_sums(&test_struct_2,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           TEST_ARRAY_LENGTH_SMALL,
+                           test_array2);
+   }
+
+  virtual void TearDown() {
+  }
+};
+
+TEST_F(CalculateLinearUpdate, Mean) {
+  float mean0 = get_linear_mean(&test_struct_0);
+  EXPECT_NEAR(2.5, mean0, eps);
+
+  float mean1 = get_linear_mean(&test_struct_1);
+  EXPECT_NEAR(0, mean1, eps);
+
+  float mean2 = get_linear_mean(&test_struct_2);
+  EXPECT_NEAR(0, mean2, eps);
+};
+
+
+TEST_F(CalculateLinearUpdate, StandardDeviation) {
+  float std_dev0 = get_linear_standard_deviation(&test_struct_0);
+  EXPECT_NEAR(1.70782512765993, std_dev0, eps);
+
+  float std_dev1 = get_linear_standard_deviation(&test_struct_1);
+  EXPECT_NEAR(1.29099444873581, std_dev1, eps);
+
+  float std_dev2 = get_linear_standard_deviation(&test_struct_2);
+  EXPECT_NEAR(0, std_dev2, eps);
+};
+


### PR DESCRIPTION
This adds a statistics library to Tau Labs. It has several functions:
1. Calculate linear mean and standard deviation
2. Calculate linear variance
3. Calculate Pearson's coefficient
4. Calculate circular mean and standard deviation
5. Calculate angular deviation
6. Calculate a Bayesian update (concerning dynamic systems)

In addition, there is a full set of unit tests. They have been tested against MATLAB (with the caveat below that linear standard deviation has an efficiency shortcut[*] ).

I wrote this library for internal analysis of sensors and have been very happy with the in-flight results. I am submitting it in hopes that others find it useful.

@mlyle You might find this useful as well. I'm especially keen to know if you see interesting compiler optimizations that I've missed.
## 

[*] The linear standard deviation is calculated using the less frequent division by N instead of N-1. This is theoretically less accurate, but for the purposes of evaluating standard deviation over 100 samples only leads to a loss of 1% accuracy, which seems worthwhile if this function will be executed frequently.
## 
