### PR TITLE
GCS:Config: Ignore lack of StateEstimation object

### DIFF
--- a/ground/gcs/src/plugins/config/configattitudewidget.cpp
+++ b/ground/gcs/src/plugins/config/configattitudewidget.cpp
@@ -173,6 +173,9 @@ ConfigAttitudeWidget::ConfigAttitudeWidget(QWidget *parent) :
     m_ui->levelingStart->setEnabled(true);
     m_ui->levelingAndBiasStart->setEnabled(true);
 
+    // F1 boards don't have this object
+    setNotMandatory("StateEstimation");
+
     refreshWidgetsValues();
 }
 


### PR DESCRIPTION
F1 boards don't have this object and it generates a warning when not present and the Attitude tab is saved.

From https://github.com/d-ronin/dRonin/pull/132
