### PR TITLE
GCS:UAVTalk: Clear queues properly

### DIFF
--- a/ground/gcs/src/plugins/uavtalk/telemetrymonitor.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymonitor.cpp
@@ -130,7 +130,7 @@ void TelemetryMonitor::startRetrievingObjects()
     TELEMETRYMONITOR_QXTLOG_DEBUG(QString("%0 connectionStatus changed to CON_RETRIEVING_OBJECT").arg(Q_FUNC_INFO));
     connectionStatus = CON_RETRIEVING_OBJECTS;
     // Get all objects, add metaobjects, settings and data objects with OnChange update mode to the queue
-    queue.empty();
+    queue.clear();
     retries = 0;
     objectRetrieveTimeout->start(OBJECT_RETRIEVE_TIMEOUT);
     foreach(UAVObjectManager::ObjectMap map, objMngr->getObjects().values())
@@ -298,7 +298,7 @@ void TelemetryMonitor::transactionCompleted(UAVObject* obj, bool success)
     else
     {
         TELEMETRYMONITOR_QXTLOG_DEBUG(QString("%0 connection lost while retrieving objects, stopped object retrievel").arg(Q_FUNC_INFO));
-        queue.empty();
+        queue.clear();
         objectRetrieveTimeout->stop();
         sessionRetrieveTimeout->stop();
         sessionInitialRetrieveTimeout->stop();
@@ -411,7 +411,7 @@ void TelemetryMonitor::sessionObjUnpackedCB(UAVObject *obj)
 
 void TelemetryMonitor::objectRetrieveTimeoutCB()
 {
-    queue.empty();
+    queue.clear();
 }
 
 void TelemetryMonitor::sessionInitialRetrieveTimeoutCB()


### PR DESCRIPTION
The empty() function just returns whether the queue is empty, this was not the intent of the code. I went through the code and superficially confirmed that there are no other mistakes of this kind.

From https://github.com/d-ronin/dRonin/pull/140
