### PR TITLE
GCS: Remove WelcomeMode object

### DIFF
--- a/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
@@ -54,6 +54,7 @@ WelcomePlugin::WelcomePlugin()
 WelcomePlugin::~WelcomePlugin()
 {
     if (m_welcomeMode) {
+        removeObject(m_welcomeMode);
         m_welcomeMode->deleteLater();
     }
 }


### PR DESCRIPTION
One too many lines removed in #2101, results in m_welcomeMode and not being cleaned up and a subsequent warning on exiting GCS.

From https://github.com/d-ronin/dRonin/pull/203.
