### PR TITLE
Fix maximim yaw_scale to match the tested value

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -558,7 +558,7 @@ static void stabilizationTask(void* parameters)
 						if (pitch_scale > 0.25f)
 							pitch_scale = 0.25f;
 						if (yaw_scale > 0.25f)
-							yaw_scale = 0.2f;
+							yaw_scale = 0.25f;
 
 						switch(ident_iteration & 0x07) {
 							case 0:


### PR DESCRIPTION
Slight bug in firmware. Fixes maximum yaw_scale to match the tested value.

From d-ronin/dRonin#262.
