### PR TITLE
Uploader: Fix pixelation and scaling when displaying artwork and button

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploader.ui
+++ b/ground/gcs/src/plugins/uploader/uploader.ui
@@ -149,11 +149,14 @@ Rescue is possible in USB mode only.</string>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="statusPic">
+       <property name="maximumSize">
+        <size>
+         <width>48</width>
+         <height>48</height>
+        </size>
+       </property>
        <property name="text">
         <string/>
-       </property>
-       <property name="scaledContents">
-        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -214,7 +214,7 @@ void UploaderGadgetWidget::DeviceInformationUpdate(deviceInfo board)
     m_widget->radioCap_lbl->setVisible(board.board->queryCapabilities(Core::IBoardType::BOARD_CAPABILITIES_RADIO));
     m_widget->deviceInformationMainLayout->setVisible(true);
     m_widget->deviceInformationNoInfo->setVisible(false);
-    m_widget->boardPic->setPixmap(board.board->getBoardPicture().scaled(200, 200, Qt::KeepAspectRatio));
+    m_widget->boardPic->setPixmap(board.board->getBoardPicture().scaled(200, 200, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     FirmwareLoadedUpdate(loadedFile);
 }
 


### PR DESCRIPTION
1. Uses a smoothing transform on rescaled board images. This helps prevent pixelated artwork.
2. Fix scaling of status icon on OS X.

Solutions found at https://github.com/d-ronin/dRonin/pull/152 and https://github.com/d-ronin/dRonin/pull/490.
