### PR TITLE
Attitude: increase stack size to 2504 from 2200

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -79,7 +79,7 @@
 #include "velocityactual.h"
 
 // Private constants
-#define STACK_SIZE_BYTES 2200
+#define STACK_SIZE_BYTES 2504
 #define TASK_PRIORITY PIOS_THREAD_PRIO_HIGH
 #define FAILSAFE_TIMEOUT_MS 10
 


### PR DESCRIPTION
"Static stack analysis indicates function will use 2440 at peak, primarily through world magnetic model.  This is a nasty one, because most attempts to dynamically measure stack won't cause home position
update.  Hence only at the beginning of real navigation flights have we been blowing stack for quite some time!"

From https://github.com/d-ronin/dRonin/pull/275
