### PR TITLE
UAVObjectParser: Allow for cloneof with different default values

### DIFF
--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -164,6 +164,7 @@ private:
     quint32 updateHash(QString& value, quint32 hash);
     int resolveFieldParent(ObjectInfo *item, FieldInfo *field);
     int checkDefaultValues(FieldInfo *field);
+    QStringList parseDefaults(const QDomNode &elemAttr);
 };
 
 #endif // UAVOBJECTPARSER_H


### PR DESCRIPTION
This teaches the parser to recognize the "defaultvalue" tag when doing "cloneof". This allows very similar UAVObjects with different initial values.

This has been very handy in internal testing.
