### PR TITLE
GCS/SetupWizard: enable spin while armed for multis

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -223,6 +223,7 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
             data.TimerUpdateFreq[1] = updateFrequency;
             data.TimerPwmResolution[0] = resolution;
             data.TimerPwmResolution[1] = resolution;
+            data.MotorsSpinWhileArmed = ActuatorSettings::MOTORSSPINWHILEARMED_TRUE;
             break;
         case VehicleConfigurationSource::MULTI_ROTOR_QUAD_X:
         case VehicleConfigurationSource::MULTI_ROTOR_QUAD_PLUS:
@@ -232,6 +233,7 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
             data.TimerPwmResolution[0] = resolution;
             data.TimerPwmResolution[1] = resolution;
             data.TimerPwmResolution[2] = resolution;
+            data.MotorsSpinWhileArmed = ActuatorSettings::MOTORSSPINWHILEARMED_TRUE;
             break;
         case VehicleConfigurationSource::MULTI_ROTOR_HEXA:
         case VehicleConfigurationSource::MULTI_ROTOR_HEXA_COAX_Y:
@@ -248,6 +250,7 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
             data.TimerPwmResolution[1] = resolution;
             data.TimerPwmResolution[2] = resolution;
             data.TimerPwmResolution[3] = resolution;
+            data.MotorsSpinWhileArmed = ActuatorSettings::MOTORSSPINWHILEARMED_TRUE;
             break;
         default:
             break;


### PR DESCRIPTION
This makes the default multirotor configuration spin motors when armed, which provides a nice visual warning.

From https://github.com/d-ronin/dRonin/pull/465.

Signed-off-by: James Cotton peabody124@gmail.com
