### PR TITLE
UAVOGen:GCS: Work around QML int8 bug, export UAVO classes to QML

### DIFF
--- a/ground/gcs/share/taulabs/pfd/default/PfdIndicators.qml
+++ b/ground/gcs/share/taulabs/pfd/default/PfdIndicators.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.0
-import "convertint8.js" as CInt8
 
 Item {
     id: sceneItem
@@ -15,7 +14,7 @@ Item {
         elementName: "gcstelemetry-"+statusName
         sceneSize: sceneItem.sceneSize
 
-        property string statusName : ["Disconnected","HandshakeReq","HandshakeAck","Connected"][CInt8.ConvertInt8(GCSTelemetryStats.Status)]
+        property string statusName : ["Disconnected","HandshakeReq","HandshakeAck","Connected"][GCSTelemetryStats.Status]
 
         // Force refresh of the arrow image when elementName changes
         onElementNameChanged: { generateSource() }
@@ -40,12 +39,12 @@ Item {
     // GPS status text
     Text {
         id: gps_text
-        text: "GPS: " + CInt8.ConvertInt8(GPSPosition.Satellites) + "\nPDP: " + GPSPosition.PDOP.toFixed(2) + "\nACC: " + GPSPosition.Accuracy.toFixed(2)
+        text: "GPS: " + GPSPosition.Satellites + "\nPDP: " + GPSPosition.PDOP.toFixed(2) + "\nACC: " + GPSPosition.Accuracy.toFixed(2)
         color: "white"
         font.family: "Arial"
         font.pixelSize: telemetry_status.height * 0.55
 
-        visible: CInt8.ConvertInt8(GPSPosition.Satellites)
+        visible: GPSPosition.Satellites
 
         property variant scaledBounds: svgRenderer.scaledElementBounds("pfd.svg", "gps-txt")
         x: Math.floor(scaledBounds.x * sceneItem.width)

--- a/ground/gcs/src/plugins/uavobjects/uavobjects.pro
+++ b/ground/gcs/src/plugins/uavobjects/uavobjects.pro
@@ -1,6 +1,7 @@
 TEMPLATE = lib
 TARGET = UAVObjects
 DEFINES += UAVOBJECTS_LIBRARY
+QT += qml
 include(../../taulabsgcsplugin.pri)
 include(uavobjects_dependencies.pri)
 

--- a/ground/gcs/src/plugins/uavobjects/uavobjectsinittemplate.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectsinittemplate.cpp
@@ -29,6 +29,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc., 
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
+#include <QtQml>
 #include "uavobjectsinit.h"
 $(OBJINC)
 

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
@@ -57,6 +57,7 @@ bool UAVObjectGeneratorGCS::generate(UAVObjectParser* parser,QString templatepat
         process_object(info);
 
         gcsObjInit.append("    objMngr->registerObject( new " + info->name + "() );\n");
+        gcsObjInit.append("    qmlRegisterType<" + info->name + ">(\"com.dronin.uavo\", 1, 0, \"" + info->name + "Class\");\n");
         objInc.append("#include \"" + info->namelc + ".h\"\n");
     }
 

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
@@ -32,6 +32,10 @@ bool UAVObjectGeneratorGCS::generate(UAVObjectParser* parser,QString templatepat
     fieldTypeStrCPP << "qint8" << "qint16" << "qint32" <<
         "quint8" << "quint16" << "quint32" << "float" << "quint8";
 
+    // work around Qt bug 37241 by not exporting 8-bit ints to QML
+    fieldTypeStrQML << "qint16" << "qint16" << "qint32" <<
+        "quint16" << "quint16" << "quint32" << "float" << "quint16";
+
     fieldTypeStrCPPClass << "INT8" << "INT16" << "INT32"
         << "UINT8" << "UINT16" << "UINT32" << "FLOAT32" << "ENUM";
 
@@ -163,6 +167,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
 
         // Determine type
         type = fieldTypeStrCPP[field->type];
+        QString qmlType = fieldTypeStrQML[field->type];
         // Append field
         if ( field->numElements > 1 ) {
             //add both field(elementIndex)/setField(elemntIndex,value) and field_element properties
@@ -198,7 +203,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
             for (int elementIndex = 0; elementIndex < field->numElements; elementIndex++) {
                 QString elementName = field->elementNames[elementIndex];
                 properties += QString("    Q_PROPERTY(%1 %2 READ get%2 WRITE set%2 NOTIFY %2Changed);\n")
-                        .arg(type).arg(field->name+"_"+elementName);
+                        .arg(qmlType).arg(field->name+"_"+elementName);
                 propertyGetters +=
                         QString("    Q_INVOKABLE %1 get%2_%3() const;\n")
                         .arg(type).arg(field->name).arg(elementName);
@@ -232,7 +237,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
             }
         } else {
             properties += QString("    Q_PROPERTY(%1 %2 READ get%2 WRITE set%2 NOTIFY %2Changed);\n")
-                    .arg(type).arg(field->name);
+                    .arg(qmlType).arg(field->name);
             propertyGetters +=
                     QString("    Q_INVOKABLE %1 get%2() const;\n")
                     .arg(type).arg(field->name);

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.h
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.h
@@ -42,7 +42,7 @@ private:
             const QString& fieldName, const QString& option);
 
     QString gcsCodeTemplate,gcsIncludeTemplate;
-    QStringList fieldTypeStrCPP,fieldTypeStrCPPClass;
+    QStringList fieldTypeStrCPP, fieldTypeStrQML,fieldTypeStrCPPClass;
     QDir gcsCodePath;
     QDir gcsOutputPath;
 };


### PR DESCRIPTION
- Export int16 rather than int8 to QML to avoid QT bug 37241, previously we used some javascript code but this becomes a real pain as we develop more QML code that uses enums and int8 fields.
- Export the UAVO class defs to QML, added a "Class" suffix to avoid clashing with all the existing QML code. This allows enum options to be accessed from QML among other things.

From https://github.com/d-ronin/dRonin/pull/498.
