### PR TITLE
GCS:QmlView: Make more friendly/usable for development

### DIFF
--- a/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.cpp
@@ -45,24 +45,13 @@ QmlViewGadgetWidget::QmlViewGadgetWidget(QWindow *parent) :
 {
     setResizeMode(SizeRootObjectToView);
 
-    QStringList objectsToExport;
-    objectsToExport << "VelocityActual" <<
-                       "PositionActual" <<
-                       "AttitudeActual" <<
-                       "GPSPosition" <<
-                       "GCSTelemetryStats" <<
-                       "FlightBatteryState";
-
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
 
-    foreach (const QString &objectName, objectsToExport) {
-        UAVObject* object = objManager->getObject(objectName);
-        if (object)
-            engine()->rootContext()->setContextProperty(objectName, object);
-        else
-            qWarning() << "Failed to load object" << objectName;
-    }
+    QVector<QVector<UAVObject*>> objects = objManager->getObjectsVector();
+
+    foreach (const QVector<UAVObject*> &objInst, objects)
+        engine()->rootContext()->setContextProperty(objInst.at(0)->getName(), objInst.at(0));
 
     engine()->rootContext()->setContextProperty("qmlWidget", this);
 }

--- a/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.cpp
@@ -68,6 +68,8 @@ void QmlViewGadgetWidget::setQmlFile(QString fn)
     SvgImageProvider *svgProvider = new SvgImageProvider(fn);
     engine()->addImageProvider("svg", svgProvider);
 
+    engine()->clearComponentCache();
+
     //it's necessary to allow qml side to query svg element position
     engine()->rootContext()->setContextProperty("svgRenderer", svgProvider);
     engine()->setBaseUrl(QUrl::fromLocalFile(fn));
@@ -78,5 +80,15 @@ void QmlViewGadgetWidget::setQmlFile(QString fn)
     foreach(const QQmlError &error, errors()) {
         qDebug() << error.description();
     }
+}
+
+void QmlViewGadgetWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    // Reload the schene on the middle mouse button click.
+    if (event->button() == Qt::MiddleButton) {
+        setQmlFile(m_fn);
+    }
+
+    QQuickView::mouseReleaseEvent(event);
 }
 

--- a/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.h
+++ b/ground/gcs/src/plugins/qmlview/qmlviewgadgetwidget.h
@@ -51,6 +51,9 @@ public:
 
    void enableSmoothUpdates(bool flag) { beSmooth = flag; }
 
+protected:
+    void mouseReleaseEvent(QMouseEvent *event);
+
 private:
    bool beSmooth;
    QString m_fn;


### PR DESCRIPTION
- Export all UAVOs rather than a small selection (only first instance for muli-instance objs)
- Add QML reload functionality (middle mouse button click on the QML view reloads)

From https://github.com/d-ronin/dRonin/pull/497
