### PR TITLE
Battery: Don't trigger voltage alarms when the thresholds are 0

### DIFF
--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -155,13 +155,16 @@ static void batteryTask(void * parameters)
 
 			flightBatteryData.Voltage = scaled_voltage;
 
-			// generate alarms and warnings
-			if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM])
+			// Set alarm if insufficient voltage, but only if the threshold is positive
+			if ((batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM]) > 0
+			        && (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_ALARM])) {
 				AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_CRITICAL);
-			else if (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING])
+			} else if ((batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING] > 0)
+			           && (flightBatteryData.Voltage < batterySettings.VoltageThresholds[FLIGHTBATTERYSETTINGS_VOLTAGETHRESHOLDS_WARNING])) {
 				AlarmsSet(SYSTEMALARMS_ALARM_BATTERY, SYSTEMALARMS_ALARM_WARNING);
-			else
+			} else {
 				AlarmsClear(SYSTEMALARMS_ALARM_BATTERY);
+			}
 		} else {
 			flightBatteryData.Voltage = 0;
 		}
@@ -205,15 +208,16 @@ static void batteryTask(void * parameters)
 			else
 				flightBatteryData.EstimatedFlightTime = 9999;
 
-			// generate alarms and warnings
+			// Set alarm if insufficient time remaining, but only if the threshold is positive
 			if ((batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_ALARM] > 0)
-				&& (flightBatteryData.EstimatedFlightTime < batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_ALARM]))
+			        && (flightBatteryData.EstimatedFlightTime < batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_ALARM])) {
 				AlarmsSet(SYSTEMALARMS_ALARM_FLIGHTTIME, SYSTEMALARMS_ALARM_CRITICAL);
-			else if ((batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_WARNING] > 0)
-					 && (flightBatteryData.EstimatedFlightTime < batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_WARNING]))
+			} else if ((batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_WARNING] > 0)
+			           && (flightBatteryData.EstimatedFlightTime < batterySettings.FlightTimeThresholds[FLIGHTBATTERYSETTINGS_FLIGHTTIMETHRESHOLDS_WARNING])) {
 				AlarmsSet(SYSTEMALARMS_ALARM_FLIGHTTIME, SYSTEMALARMS_ALARM_WARNING);
-			else
+			} else {
 				AlarmsClear(SYSTEMALARMS_ALARM_FLIGHTTIME);
+			}
 		} else {
 			flightBatteryData.Current = 0;
 		}


### PR DESCRIPTION
This allows the user to turn off all battery alarms, without having to disable the battery module. This is useful in bench testing because it allows arming the system without having to have the battery plugged in.

Also slightly changes the battery threshold testing to match code style standards.
