### PR TITLE
Sparky2: enable DAC as ADC port

### DIFF
--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -1814,19 +1814,6 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
 		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \
 	},
-	.adc_pin_count = 4
-};
-
-struct stm32_gpio pios_current_sonar_pin ={
-    .gpio = GPIOA,
-			.init = {
-				.GPIO_Pin = GPIO_Pin_8,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_IN,
-				.GPIO_OType = GPIO_OType_OD,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource8,
 };
 
 static void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       pios_board.c 
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2016
  * @brief      Board specific hardware configuration file
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -1809,8 +1809,8 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
 	.adc_pins = {                                                                               \
-		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Current sensor */            \
-		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Voltage sensor */            \
+		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Voltage sensor */            \
+		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Current sensor */            \
 		{GPIOA, GPIO_Pin_4,     ADC_Channel_4},                 /* DAC pin        */            \
 		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
 		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \

--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -1811,9 +1811,11 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	.adc_pins = {                                                                               \
 		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Current sensor */            \
 		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Voltage sensor */            \
+		{GPIOA, GPIO_Pin_4,     ADC_Channel_4},                 /* DAC pin        */            \
 		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
 		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \
 	},
+	.adc_pin_count = 5
 };
 
 static void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -687,9 +687,6 @@ void PIOS_Board_Init(void) {
 	uint32_t internal_adc_id;
 	PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);
 	PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
- 
-        // configure the pullup for PA8 (inhibit pullups from current/sonar shared pin)
-        GPIO_Init(pios_current_sonar_pin.gpio, &pios_current_sonar_pin.init);
 #endif
 
 #if defined(PIOS_INCLUDE_MS5611)


### PR DESCRIPTION
This adds the DAC pin on Sparky2 as an ADC pin, which can be used
for things like RSSI monitoring. Also cleans up some comments.

Parts back ported from https://github.com/d-ronin/dRonin/pull/543
