### PR TITLE
GCS: Uploader: Append board name to board ID

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploader.ui
+++ b/ground/gcs/src/plugins/uploader/uploader.ui
@@ -296,7 +296,7 @@ Rescue is possible in USB mode only.</string>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_dev_id">
                       <property name="text">
-                       <string>Device ID:</string>
+                       <string>Device Name (ID):</string>
                       </property>
                       <property name="alignment">
                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -203,7 +203,7 @@ void UploaderGadgetWidget::DeviceInformationUpdate(deviceInfo board)
         return;
     currentBoard = board;
     m_widget->boardName_lbl->setText(board.board->boardDescription());
-    m_widget->devID_lbl->setText(QString::number(board.board->getBoardType(), 16));
+    m_widget->devID_lbl->setText(board.board->getBoardNameFromID(board.board->getBoardType() << 8) + " (ID: 0x" + QString::number(board.board->getBoardType(), 16) + ")");
     m_widget->hwRev_lbl->setText(board.hw_revision);
     m_widget->blVer_lbl->setText(board.bl_version);
     m_widget->maxCode_lbl->setText(board.max_code_size);


### PR DESCRIPTION
Adds the board name to the uploader. This gives normal users an easy-to-read board name.

New look: 
<img width="355" alt="screen shot 2016-02-02 at 6 10 04 pm" src="https://cloud.githubusercontent.com/assets/1118185/12767628/55d02f62-c9d8-11e5-8541-c40354aa16e9.png">

Inspired by https://github.com/d-ronin/dRonin/pull/489.

P.S. Having two "ID" might be unnecessarily redundant.
