### PR TITLE
OutputWidget: disable live output test under bad circumstances

### DIFF
--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -232,6 +232,8 @@ void ConfigGadgetWidget::tabAboutToChange(int i, bool * proceed)
         return;
     }
 
+    wid->tabSwitchingAway();
+
     // Check if widget is dirty (i.e. has unsaved changes)
     if(wid->isDirty() && wid->isAutopilotConnected())
     {

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -49,7 +49,7 @@
 #include <extensionsystem/pluginmanager.h>
 #include <coreplugin/generalsettings.h>
 
-ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(parent),wasItMe(false)
+ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(parent)
 {
     m_config = new Ui_OutputWidget();
     m_config->setupUi(this);
@@ -107,7 +107,6 @@ ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(paren
     resList << m_config->cb_outputResolution1 << m_config->cb_outputResolution2 << m_config->cb_outputResolution3
                << m_config->cb_outputResolution4 << m_config->cb_outputResolution5 << m_config->cb_outputResolution6;
 
-
     // Get the list of output resolutions and assign to the resolution dropdowns
     ActuatorSettings *actuatorSettings = ActuatorSettings::GetInstance(getObjectManager());
     Q_ASSERT(actuatorSettings);
@@ -136,12 +135,12 @@ ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(paren
     UAVObject* obj = objManager->getObject(QString("ActuatorCommand"));
     if(UAVObject::GetGcsTelemetryUpdateMode(obj->getMetadata()) == UAVObject::UPDATEMODE_ONCHANGE)
         this->setEnabled(false);
-    connect(obj,SIGNAL(objectUpdated(UAVObject*)),this,SLOT(disableIfNotMe(UAVObject*)));
     connect(SystemSettings::GetInstance(objManager), SIGNAL(objectUpdated(UAVObject*)),this,SLOT(assignOutputChannels(UAVObject*)));
 
 
     refreshWidgetsValues();
 }
+
 void ConfigOutputWidget::enableControls(bool enable)
 {
     ConfigTaskWidget::enableControls(enable);
@@ -155,7 +154,6 @@ ConfigOutputWidget::~ConfigOutputWidget()
 {
    // Do nothing
 }
-
 
 // ************************************
 
@@ -189,7 +187,6 @@ void ConfigOutputWidget::runChannelTests(bool state)
         int retval = mbox.exec();
         if(retval != QMessageBox::Yes) {
             state = false;
-            qDebug() << "Cancelled";
             m_config->channelOutTest->setChecked(false);
             return;
         }
@@ -199,7 +196,6 @@ void ConfigOutputWidget::runChannelTests(bool state)
     UAVObject::Metadata mdata = obj->getMetadata();
     if (state)
     {
-        wasItMe=true;
         accInitialData = mdata;
         UAVObject::SetFlightAccess(mdata, UAVObject::ACCESS_READONLY);
         UAVObject::SetFlightTelemetryUpdateMode(mdata, UAVObject::UPDATEMODE_ONCHANGE);
@@ -209,7 +205,6 @@ void ConfigOutputWidget::runChannelTests(bool state)
     }
     else
     {
-        wasItMe=false;
         mdata = accInitialData; // Restore metadata
     }
     obj->setMetadata(mdata);

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -622,6 +622,11 @@ void ConfigOutputWidget::openHelp()
     QDesktopServices::openUrl( QUrl("https://github.com/TauLabs/TauLabs/wiki/OnlineHelp:-Output-Configuration", QUrl::StrictMode) );
 }
 
+void ConfigOutputWidget::tabSwitchingAway()
+{
+    stopTests();
+}
+
 void ConfigOutputWidget::stopTests()
 {
     if (m_config->channelOutTest->isChecked()) {

--- a/ground/gcs/src/plugins/config/configoutputwidget.h
+++ b/ground/gcs/src/plugins/config/configoutputwidget.h
@@ -72,11 +72,8 @@ private:
 
     UAVObject::Metadata accInitialData;
 
-    bool wasItMe;
-
 private slots:
     void stopTests();
-    void disableIfNotMe(UAVObject *obj);
     virtual void refreshWidgetsValues(UAVObject * obj=NULL);
     void updateObjectsFromWidgets();
     void runChannelTests(bool state);

--- a/ground/gcs/src/plugins/config/configoutputwidget.h
+++ b/ground/gcs/src/plugins/config/configoutputwidget.h
@@ -72,6 +72,8 @@ private:
 
     UAVObject::Metadata accInitialData;
 
+    virtual void tabSwitchingAway();
+
 private slots:
     void stopTests();
     virtual void refreshWidgetsValues(UAVObject * obj=NULL);

--- a/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
+++ b/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
@@ -79,6 +79,8 @@ void SetupWizardPlugin::shutdown()
 void SetupWizardPlugin::showSetupWizard()
 {
     if (!wizardRunning) {
+        Core::ModeManager::instance()->activateModeByWorkspaceName(Core::Constants::MODE_WELCOME);
+
         wizardRunning = true;
         SetupWizard *m_wiz = new SetupWizard();
         connect(m_wiz, SIGNAL(finished(int)), this, SLOT(wizardTerminated()));

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
@@ -148,6 +148,9 @@ public:
     void forceConnectedState();
 
     void setNotMandatory(QString object);
+
+    virtual void tabSwitchingAway() {}
+
 public slots:
     void onAutopilotDisconnect();
     void onAutopilotConnect();


### PR DESCRIPTION
The live testing in the output widget could be left active under certain circumstances-- like if the tab is changed or the "Disconnect" button is pushed--, which is certainly dangerous.

This also removes some legacy logic to disable widgets in the config output widget when underlying changes happen.

Finally, tells the setup wizard to toggle the UI away from config.

From https://github.com/d-ronin/dRonin/pull/453. Fixes https://github.com/d-ronin/dRonin/issues/452.
