### PR TITLE
GCS: don't load EmptyGadgets when restoring config

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/splitterorview.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/splitterorview.cpp
@@ -39,11 +39,11 @@
 using namespace Core;
 using namespace Core::Internal;
 
-SplitterOrView::SplitterOrView(Core::UAVGadgetManager *uavGadgetManager, Core::IUAVGadget *uavGadget) :
+SplitterOrView::SplitterOrView(Core::UAVGadgetManager *uavGadgetManager, Core::IUAVGadget *uavGadget, bool restoring) :
         m_uavGadgetManager(uavGadgetManager),
         m_splitter(0)
 {
-    m_view = new UAVGadgetView(m_uavGadgetManager, uavGadget, this);
+    m_view = new UAVGadgetView(m_uavGadgetManager, uavGadget, this, restoring);
     m_layout = new QStackedLayout(this);
     m_layout->addWidget(m_view);
 }
@@ -231,7 +231,7 @@ QList<IUAVGadget*> SplitterOrView::gadgets()
     return g;
 }
 
-void SplitterOrView::split(Qt::Orientation orientation)
+void SplitterOrView::split(Qt::Orientation orientation, bool restoring)
 {
     Q_ASSERT(m_view);
     Q_ASSERT(!m_splitter);
@@ -245,10 +245,10 @@ void SplitterOrView::split(Qt::Orientation orientation)
         // Give our gadget to the new left or top SplitterOrView.
         m_view->removeGadget();
         m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager, ourGadget));
-        m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager));
+        m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager, 0, restoring));
     } else {
-        m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager));
-        m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager));
+        m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager, 0, restoring));
+        m_splitter->addWidget(new SplitterOrView(m_uavGadgetManager, 0, restoring));
     }
 
     m_layout->setCurrentWidget(m_splitter);
@@ -362,7 +362,7 @@ void SplitterOrView::restoreState(QSettings* qSettings)
         foreach (QVariant value, sizesQVariant) {
             m_sizes.append(value.toInt());
         }
-        split((Qt::Orientation)orientation);
+        split((Qt::Orientation)orientation, true);
         m_splitter->setSizes(m_sizes);
         qSettings->beginGroup("side0");
         static_cast<SplitterOrView*>(m_splitter->widget(0))->restoreState(qSettings);

--- a/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/splitterorview.h
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/splitterorview.h
@@ -42,10 +42,10 @@ class SplitterOrView  : public QWidget
 {
     Q_OBJECT
 public:
-    SplitterOrView(UAVGadgetManager *uavGadgetManager, Core::IUAVGadget *uavGadget = 0);
+    SplitterOrView(UAVGadgetManager *uavGadgetManager, Core::IUAVGadget *uavGadget = 0, bool restoring = false);
     ~SplitterOrView();
 
-    void split(Qt::Orientation orientation);
+    void split(Qt::Orientation orientation, bool restoring = false);
     void unsplit();
 
     inline bool isView() const { return m_view != 0; }

--- a/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetmanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetmanager.cpp
@@ -99,7 +99,7 @@ UAVGadgetManager::UAVGadgetManager(ICore *core, QString name, QIcon icon, int pr
             this, SLOT(modeChanged(Core::IMode*)));
 
     // other setup
-    m_splitterOrView = new SplitterOrView(this, 0);
+    m_splitterOrView = new SplitterOrView(this, 0, true);
 
     // SplitterOrView with 0 as gadget calls our setCurrentGadget, which relies on currentSplitterOrView(),
     // which needs our m_splitterorView to be set, which isn't set yet at that time.

--- a/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetview.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetview.cpp
@@ -58,7 +58,7 @@ Q_DECLARE_METATYPE(Core::IUAVGadget *)
 using namespace Core;
 using namespace Core::Internal;
 
-UAVGadgetView::UAVGadgetView(Core::UAVGadgetManager *uavGadgetManager, IUAVGadget *uavGadget, QWidget *parent) :
+UAVGadgetView::UAVGadgetView(Core::UAVGadgetManager *uavGadgetManager, IUAVGadget *uavGadget, QWidget *parent, bool restoring) :
         QWidget(parent),
         m_uavGadgetManager(uavGadgetManager),
         m_uavGadget(uavGadget),
@@ -143,7 +143,9 @@ UAVGadgetView::UAVGadgetView(Core::UAVGadgetManager *uavGadgetManager, IUAVGadge
     if (m_uavGadget) {
         setGadget(m_uavGadget);
     } else {
-        selectionActivated(m_defaultIndex, false);
+	if (!restoring) {
+            selectionActivated(m_defaultIndex, false);
+	}
     }
 }
 

--- a/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetview.h
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetview.h
@@ -65,7 +65,7 @@ class UAVGadgetView : public QWidget
     Q_OBJECT
 
 public:
-    UAVGadgetView(UAVGadgetManager *uavGadgetManager, IUAVGadget *uavGadget = 0, QWidget *parent = 0);
+    UAVGadgetView(UAVGadgetManager *uavGadgetManager, IUAVGadget *uavGadget = 0, QWidget *parent = 0, bool restoring = false);
     virtual ~UAVGadgetView();
     void selectionActivated(int index, bool forceLoadConfiguration);
     void removeGadget();


### PR DESCRIPTION
"Previously, when we were instantiating splitter views, we'd briefly instantiate an EmptyGadget until we've gone and recursed and restored that configuration. Now, in that case, skip doing that as the appropriate gadget widget will be selected soon."

Tested, the newer version is indeed faster to load than the older version.

From https://github.com/d-ronin/dRonin/pull/311. Fixes https://github.com/d-ronin/dRonin/pull/297 
