### PR TITLE
Flight firmware: only look for ccache path once, use in submakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ TOOLS_DIR := $(ROOT_DIR)/tools
 BUILD_DIR := $(ROOT_DIR)/build
 DL_DIR := $(ROOT_DIR)/downloads
 
+export RM := rm
+export CCACHE_BIN := $(shell which ccache 2>/dev/null)
+
 # import macros that are OS specific
 include $(ROOT_DIR)/make/$(OSFAMILY).mk
 

--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -5,10 +5,10 @@ CCACHE :=
 
 ifeq ($(FLIGHT_BUILD_CONF), debug)
 export DEBUG:=YES
-CCACHE := $(shell which ccache)
+CCACHE := $(CCACHE_BIN)
 else ifeq ($(FLIGHT_BUILD_CONF), default)
 # In the default case, keep the old "DEBUG"  variable handling
-CCACHE := $(shell which ccache)
+CCACHE := $(CCACHE_BIN)
 else ifeq ($(FLIGHT_BUILD_CONF), release)
 export DEBUG:=NO
 else

--- a/make/linux.mk
+++ b/make/linux.mk
@@ -6,9 +6,6 @@
 #   and the ARM toolchain installed to either the Taulabs/tools directory, their 
 #   respective default installation locations,  or made available on the system path.
 
-# misc tools
-RM=rm
-
 QT_SPEC ?= linux-g++
 
 # Check for and find Python 2

--- a/make/macosx.mk
+++ b/make/macosx.mk
@@ -6,9 +6,6 @@
 #   and the ARM toolchain installed to either the Taulabs/tools directory, their 
 #   respective default installation locations, or made available on the system path.
 
-# misc tools
-RM=rm
-
 # Check for and find Python 2
 
 # Get Python version, separate major/minor/patch, then put into wordlist

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -12,9 +12,6 @@
 #   msysGit
 #   Python
 
-# misc tools
-RM=rm
-
 PYTHON := python
 export PYTHON
 


### PR DESCRIPTION
Previously, building flight firmware on Windows caused repeated messages from the "which ccache" calls.

From https://github.com/d-ronin/dRonin/pull/196. Fixes https://github.com/d-ronin/dRonin/pull/195.

Signed-off-by: James Cotton peabody124@gmail.com
