### PR TITLE
Fix maps domain brittleness

### DIFF
--- a/ground/gcs/src/libs/tlmapcontrol/core/providerstrings.cpp
+++ b/ground/gcs/src/libs/tlmapcontrol/core/providerstrings.cpp
@@ -73,7 +73,21 @@ QString ProviderStrings::decrypt(QString str)
 ProviderStrings::ProviderStrings()
 {
     quint64 key = 0;
-    QByteArray array = QCryptographicHash::hash(QApplication::organizationDomain().toLatin1(), QCryptographicHash::Md4);
+
+    // Get the base URL and use that as the organization name registered with
+    // Google. Unfortunately, this is a hack since Qt does not provide a function
+    // to do this directly, so we have to trim it down from the full hostname.
+    QStringList domainName = QUrl(QApplication::organizationDomain()).host().split(".");
+    QString organizationBaseURL;
+    if (domainName.length() >=2) {
+        int len = domainName.length();
+        organizationBaseURL = QString(domainName.at(len-2)).append(".").append(domainName.at(len-1));
+    } else {
+        qDebug() << "Incorrect host name: " << domainName << ". Mapping functionality may not work.";
+        return;
+    }
+
+    QByteArray array = QCryptographicHash::hash(organizationBaseURL.toLatin1(), QCryptographicHash::Md4);
     for(uint x = 0; x < 3; ++x) {
         key += array.at(2 ^ x);
     }

--- a/ground/gcs/src/libs/tlmapcontrol/core/providerstrings.cpp
+++ b/ground/gcs/src/libs/tlmapcontrol/core/providerstrings.cpp
@@ -29,6 +29,7 @@
 #include <QDebug>
 #include <QApplication>
 #include <QCryptographicHash>
+#include <QUrl>
 
 namespace core {
 const QString ProviderStrings::levelsForSigPacSpainMap[] = {"0", "1", "2", "3", "4",
@@ -53,9 +54,9 @@ QString ProviderStrings::encrypt(QString str)
     return QString::fromLatin1(array.toBase64());
 }
 
-QString ProviderStrings::decrypt(QString str)
+QString ProviderStrings::decrypt(QString inputString)
 {
-    QByteArray ba = QByteArray::fromBase64(str.toLatin1());
+    QByteArray ba = QByteArray::fromBase64(inputString.toLatin1());
     int pos(0);
     int cnt(ba.count());
     char lastChar = 0;
@@ -67,7 +68,11 @@ QString ProviderStrings::decrypt(QString str)
         ++pos;
     }
 
-    return QString::fromUtf8(qUncompress(ba));
+    QString decryptedString = QString::fromUtf8(qUncompress(ba));
+    if (decryptedString.isEmpty()) {
+        throw std::domain_error(QString("Decrypted to an empty vector!. Input vector: ").append(inputString).toStdString());
+    }
+    return decryptedString;
 }
 
 ProviderStrings::ProviderStrings()
@@ -100,48 +105,54 @@ ProviderStrings::ProviderStrings()
         cryptKeyVector[i] = static_cast<char>(part);
     }
 
-    VersionGoogleMap = decrypt("hoaGv8cd7uEX4ukZ7RwTmmudkhqWmenlbRwZK3YqyRQQ7JFyMS1uE4kUlnX266hKmYTQo74yHjO5eXl5jPvrog==").split("%@%").at(1);;
-    VersionGoogleSatellite = decrypt("hoaGt88V5ukf6uER5RQbkmOVmhKekeHtZRQRI34iwRwY5Jl6OSVmG4Ecnn3+46BCkYzY1RgVFWJLRTQ=").split("%@%").at(1);
-    VersionGoogleLabels = decrypt("hoaGv8cd7uEX4ukZ7RwTmmudkhqWmenlbRwZK3YqyRQQ7JFyMS1uE4kUlnX266hKmYTQ4/9zX3L4ODg4zY2d2Q==").split("%@%").at(1);
-    VersionGoogleTerrain = decrypt("hoaGucEb6OcR5O8f6xoVnG2blByQn+/jaxofLXAszxIW6pd0NytoFY8SkHPw7a5Mn4LWnYGNAI1/9ellSWRoqC4ucLqrbw==").split("%@%").at(1);
-    SecGoogleWord = "Galileo";
+    try {
+        VersionGoogleMap = decrypt("hoaGv8cd7uEX4ukZ7RwTmmudkhqWmenlbRwZK3YqyRQQ7JFyMS1uE4kUlnX266hKmYTQo74yHjO5eXl5jPvrog==").split("%@%").at(1);;
+        VersionGoogleSatellite = decrypt("hoaGt88V5ukf6uER5RQbkmOVmhKekeHtZRQRI34iwRwY5Jl6OSVmG4Ecnn3+46BCkYzY1RgVFWJLRTQ=").split("%@%").at(1);
+        VersionGoogleLabels = decrypt("hoaGv8cd7uEX4ukZ7RwTmmudkhqWmenlbRwZK3YqyRQQ7JFyMS1uE4kUlnX266hKmYTQ4/9zX3L4ODg4zY2d2Q==").split("%@%").at(1);
+        VersionGoogleTerrain = decrypt("hoaGucEb6OcR5O8f6xoVnG2blByQn+/jaxofLXAszxIW6pd0NytoFY8SkHPw7a5Mn4LWnYGNAI1/9ellSWRoqC4ucLqrbw==").split("%@%").at(1);
+        SecGoogleWord = "Galileo";
 
-    // Google (China) version strings
-    VersionGoogleMapChina = VersionGoogleMap;
-    VersionGoogleSatelliteChina = VersionGoogleSatellite;
-    VersionGoogleLabelsChina = VersionGoogleLabels;
-    VersionGoogleTerrainChina = decrypt("hoaGucEb6OcR5O8f6xoVnG2blByQn+/jaxofLXAszxIW6pd0NytoFY8SkHPw7a5Mn4LWnYGNAI1/9ellSWRoqC4ucLqrbw==").split("%@%").at(1);
+        // Google (China) version strings
+        VersionGoogleMapChina = VersionGoogleMap;
+        VersionGoogleSatelliteChina = VersionGoogleSatellite;
+        VersionGoogleLabelsChina = VersionGoogleLabels;
+        VersionGoogleTerrainChina = decrypt("hoaGucEb6OcR5O8f6xoVnG2blByQn+/jaxofLXAszxIW6pd0NytoFY8SkHPw7a5Mn4LWnYGNAI1/9ellSWRoqC4ucLqrbw==").split("%@%").at(1);
 
-    // Google (Korea) version strings
-    VersionGoogleMapKorea = VersionGoogleMap;
-    VersionGoogleSatelliteKorea = VersionGoogleSatellite;
-    VersionGoogleLabelsKorea = VersionGoogleLabels;
+        // Google (Korea) version strings
+        VersionGoogleMapKorea = VersionGoogleMap;
+        VersionGoogleSatelliteKorea = VersionGoogleSatellite;
+        VersionGoogleLabelsKorea = VersionGoogleLabels;
 
-    // Yahoo version strings
-    VersionYahooMap = "4.3";
-    VersionYahooSatellite = "1.9";
-    VersionYahooLabels = "4.3";
+        // Yahoo version strings
+        VersionYahooMap = "4.3";
+        VersionYahooSatellite = "1.9";
+        VersionYahooLabels = "4.3";
 
-    // BingMaps
-    VersionBingMaps = "563";
+        // BingMaps
+        VersionBingMaps = "563";
 
-    // YandexMap
-    VersionYandexMap = "2.16.0";
-    //VersionYandexSatellite = "1.19.0";
-    ////////////////////
+        // YandexMap
+        VersionYandexMap = "2.16.0";
+        //VersionYandexSatellite = "1.19.0";
+        ////////////////////
 
-    /// <summary>
-    /// Bing Maps Customer Identification, more info here
-    /// http://msdn.microsoft.com/en-us/library/bb924353.aspx
-    /// </summary>
-    BingMapsClientToken = "";
+        /// <summary>
+        /// Bing Maps Customer Identification, more info here
+        /// http://msdn.microsoft.com/en-us/library/bb924353.aspx
+        /// </summary>
+        BingMapsClientToken = "";
 
-    gMapRegex = decrypt("hoaG36d9joF3gol5jXxz+gv98nr2+YmFDXx5SxZKqXRwjPESUU0Oc+l09hVodXaUR1oOPXc9N73We496CULIJcCSZrRHtGcUwDWnVCfSGVO3WygCiQNuHYay0II2AgP2YX2a").split("%@%").at(1);
-    gLabRegex = decrypt("hoaG36d9joF3gol5jXxz+gv98nr2+YmFDXx5SxZKqXRwjPESUU0Oc+l09hWU0GzGw6nvpu+uH6KxD3EfVuea1tqE/oD+hMpguMq0GmQ9dPgDTSh5yKUjoGAspjAWFuT4YrE=").split("%@%").at(1);
-    gSatRegex = decrypt("hoaG06txgo17joV1gXB/9gfx/nb69YWJAXB1RxpGpXh8gP0eXUECf+V4+hmah8Qm9ei8j8WPhQ9kyT3Ie0g6sdq56x/NPs0e67lM3i1e350q3LkPFSQNV0tLy1ZNdQ==").split("%@%").at(1);
-    gTerRegex = decrypt("hoaG559FtrlPurFBtURLwjPFykLOwbG9NURBcy5ykUxItMkqaXU2S9FMzi2us/ASwdyIu/G7sTtQ/Qn8j8ROo0YU4DLBMuGSRrMh0qFUn9Ux3a6ED4XoozkNbz2JvchC5NDQOOT76g==").split("%@%").at(1);
+        gMapRegex = decrypt("hoaG36d9joF3gol5jXxz+gv98nr2+YmFDXx5SxZKqXRwjPESUU0Oc+l09hVodXaUR1oOPXc9N73We496CULIJcCSZrRHtGcUwDWnVCfSGVO3WygCiQNuHYay0II2AgP2YX2a").split("%@%").at(1);
+        gLabRegex = decrypt("hoaG36d9joF3gol5jXxz+gv98nr2+YmFDXx5SxZKqXRwjPESUU0Oc+l09hWU0GzGw6nvpu+uH6KxD3EfVuea1tqE/oD+hMpguMq0GmQ9dPgDTSh5yKUjoGAspjAWFuT4YrE=").split("%@%").at(1);
+        gSatRegex = decrypt("hoaG06txgo17joV1gXB/9gfx/nb69YWJAXB1RxpGpXh8gP0eXUECf+V4+hmah8Qm9ei8j8WPhQ9kyT3Ie0g6sdq56x/NPs0e67lM3i1e350q3LkPFSQNV0tLy1ZNdQ==").split("%@%").at(1);
+        gTerRegex = decrypt("hoaG559FtrlPurFBtURLwjPFykLOwbG9NURBcy5ykUxItMkqaXU2S9FMzi2us/ASwdyIu/G7sTtQ/Qn8j8ROo0YU4DLBMuGSRrMh0qFUn9Ux3a6ED4XoozkNbz2JvchC5NDQOOT76g==").split("%@%").at(1);
 
-    gAPIUrl = decrypt("hoaGGGC6nxXS3B4+Ki9gM8LvlJnIHCpDlxJKFq6M0yHk1cHJKdR5lPwx/R68AYr0ksCdJV10tfOsgnGrAe8uQY0/2BjWdRe1ZLEYgshBOHc5NQQzFRHy4sYLhoh7kVkbeeplv+YSl/nwClU/WFO93dXStWpj8TR4zY9djqhp8t1D5w9YFn4S4pCXNLWCdg==").split("%@%").at(1);
+        gAPIUrl = decrypt("hoaGGGC6nxXS3B4+Ki9gM8LvlJnIHCpDlxJKFq6M0yHk1cHJKdR5lPwx/R68AYr0ksCdJV10tfOsgnGrAe8uQY0/2BjWdRe1ZLEYgshBOHc5NQQzFRHy4sYLhoh7kVkbeeplv+YSl/nwClU/WFO93dXStWpj8TR4zY9djqhp8t1D5w9YFn4S4pCXNLWCdg==").split("%@%").at(1);
+    } catch (const std::domain_error& e) {
+        qDebug() << "Decryption failed: " << e.what();
+        qDebug() << "Maps may not work.";
+    }
+
 }
 }
 


### PR DESCRIPTION
The current Google API approach is very brittle to the crypto key and GCS will crash if the crypto key is wrong. This gets the base domain name from the organization name in a more robust manner, so `www.taulabs.org` returns the same results as `forums.taulabs.org` as `taulabs.org`, etc...

In the event that the key is just plain wrong, then the decrypt function will thrown an error, which is caught in the parent. The parent will send a debug message instead of GCS segfaulting.

It could be arguable, however, that we should do a `qFatal()` instead of `qDebug()`, as not having correct provider strings could lead to system instability elsewhere. Still, in limited testing on OSX 10.10 having the function return early did _not_ lead to crashes, or even any immediate decrease in functionality.

Fixes problem seen in https://github.com/TauLabs/TauLabs/pull/2106#issuecomment-163786632. Once this is in we can merge https://github.com/TauLabs/TauLabs/pull/2106.
