### PR TITLE
GCS Modules Tab: UI tweaks

### DIFF
--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -81,7 +81,6 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbComBridge, ModuleSettings::ADMINSTATE_COMUSBBRIDGE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbGPS, ModuleSettings::ADMINSTATE_GPS);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbUavoMavlink, ModuleSettings::ADMINSTATE_UAVOMAVLINKBRIDGE);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbOveroSync, ModuleSettings::ADMINSTATE_OVEROSYNC);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbVibrationAnalysis, ModuleSettings::ADMINSTATE_VIBRATIONANALYSIS);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbVtolFollower, ModuleSettings::ADMINSTATE_VTOLPATHFOLLOWER);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbPathPlanner, ModuleSettings::ADMINSTATE_PATHPLANNER);
@@ -94,6 +93,7 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAutotune, ModuleSettings::ADMINSTATE_AUTOTUNE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbUAVOMSPBridge, ModuleSettings::ADMINSTATE_UAVOMSPBRIDGE);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbTxPid, ModuleSettings::ADMINSTATE_TXPID);
+    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbLogging, ModuleSettings::ADMINSTATE_LOGGING);
 
     // Don't allow these to be changed here, only in the respective tabs.
     ui->cbAutotune->setDisabled(true);
@@ -345,9 +345,6 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     ui->cbUavoMavlink->setProperty(trueString.toLatin1(), "Enabled");
     ui->cbUavoMavlink->setProperty(falseString.toLatin1(), "Disabled");
 
-    ui->cbOveroSync->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbOveroSync->setProperty(falseString.toLatin1(), "Disabled");
-
     ui->cbVibrationAnalysis->setProperty(trueString.toLatin1(), "Enabled");
     ui->cbVibrationAnalysis->setProperty(falseString.toLatin1(), "Disabled");
 
@@ -377,6 +374,9 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
 
     ui->cbAutotune->setProperty(trueString.toLatin1(), "Enabled");
     ui->cbAutotune->setProperty(falseString.toLatin1(), "Disabled");
+
+    ui->cbLogging->setProperty(trueString.toLatin1(), "Enabled");
+    ui->cbLogging->setProperty(falseString.toLatin1(), "Disabled");
 
     ui->gb_measureVoltage->setProperty(trueString.toLatin1(), "Enabled");
     ui->gb_measureVoltage->setProperty(falseString.toLatin1(), "Disabled");

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -105,16 +105,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="cbOveroSync">
-         <property name="toolTip">
-          <string>Select to enable synchronization to an Overo module</string>
-         </property>
-         <property name="text">
-          <string>Overo Sync (only for boards with Gumstix)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="cbVibrationAnalysis">
          <property name="text">
           <string>Vibration Analysis</string>
@@ -205,6 +195,16 @@
         <widget class="QCheckBox" name="cbUAVOFrSkySPortBridge">
          <property name="text">
           <string>FrSky S.PORT Telemetry</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbLogging">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select to enable logging to on-board flash memory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Logging</string>
          </property>
         </widget>
        </item>
@@ -565,7 +565,11 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="cbVoltagePin"/>
+           <widget class="QComboBox" name="cbVoltagePin">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select an ADC pin to measure the voltage. Pins not available with the current board configuration are labeled &amp;quot;Disabled&amp;quot;. These pins may be enabled by settings on the &amp;quot;Hardware&amp;quot; tab. Pins labeled &amp;quot;N/A&amp;quot; are not available due to the board hardware design.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -656,7 +660,11 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QComboBox" name="cbCurrentPin"/>
+           <widget class="QComboBox" name="cbCurrentPin">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select an ADC pin to measure the current. Pins not available with the current board configuration are labeled &amp;quot;Disabled&amp;quot;. These pins may be enabled by settings on the &amp;quot;Hardware&amp;quot; tab. Pins labeled &amp;quot;N/A&amp;quot; are not available due to the board hardware design.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
           </item>
           <item row="7" column="0">
            <widget class="QLabel" name="label_33">


### PR DESCRIPTION
1. Remove OveroSync. It's not likely to be used by any non developers.
2. Add logging checkbox.
3. Add tooltip for logging checkbox.
4. Add tooltips for voltage and current combo-boxes.

Having a logging checkbox is very nice for my colleagues. One less reason to peer into the UAVObject browser.

Code inspired by several dRonin commits. Tooltip text copied in order to maintain compatibility.
