### PR TITLE
.gitignore: Add "ignore" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Exclude temporary and system files
 .DS_Store
 *.swp
+/ignore
 
 # /flight/
 /flight/*.pnproj

--- a/ignore/README.md
+++ b/ignore/README.md
@@ -1,0 +1,3 @@
+# Ignore
+
+This directory is for files which git will ignore. Use it to hold temporary files in the local repository, files which git will not suggest are to be staged. This helps clean up `git status`, `git gui`, etc...


### PR DESCRIPTION
This directory is for files which git will ignore. You can use it to hold temporary files in the local repository, files which git will not suggest are to be staged. This helps clean up `git status`, `git gui`, etc... when there are developer-generated files hanging around. 

I personally use it to have local scripts hanging around, or logfiles, or whatnot. It's aesthetically pleasing to place all temporary files there, do a `git status`, and see perfect emptiness as a response. :D
