### PR TITLE
Qt Creator Project: Create a Firmware project using Qt Creator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # /flight/Project/OpenPilotOSX/
 /flight/Project/OpenPilotOSX/build/
+/flight/Project/Qt\ Creator/flight.pro.user
 
 # /ground/
 /ground/Build

--- a/flight/Project/Qt Creator/flight.pro
+++ b/flight/Project/Qt Creator/flight.pro
@@ -1,0 +1,25 @@
+######################################################################
+# (c) Kenneth Sebesta, 2015.
+# qmake file for Tau Labs and related projects
+######################################################################
+
+# Define some useful shortcuts
+ROOT_FLIGHT_DIR = ../../
+FLIGHT_SYNTHETICS_DIR = ../../../build/uavobject-synthetics/flight/
+SHARED_API_DIR = ../../../shared/api/
+UAVOBJECT_DEFINITION_DIR = ../../../shared/uavobjectdefinition/
+
+# Define a system command which appends a /* (slash-star) to the end of each line.
+APPEND_SLASH_AND_STAR = "awk '{print $0 \"/*\"}'"
+
+# Add all files indiscriminately. Since this .pro file is not intended to
+# firmware blobs, this is okay and desirable
+SOURCES += $$system("find $$ROOT_FLIGHT_DIR -type d | $$APPEND_SLASH_AND_STAR") # All files in firmware directory
+SOURCES += $$system("find $$FLIGHT_SYNTHETICS_DIR -type d | $$APPEND_SLASH_AND_STAR") # All files in firmware synthetics
+SOURCES += $$system("find $$SHARED_API_DIR -type d | $$APPEND_SLASH_AND_STAR") # All shared api files
+
+# If you'd like to see the list of sources, uncomment the below `warning()` line
+#warning($$SOURCES)
+
+# Add the UAVObject definition files
+OTHER_FILES += $$system("find $$UAVOBJECT_DEFINITION_DIR -name *.xml")


### PR DESCRIPTION
This includes all files indiscriminately. This is desirable, since this project file is just a list of all project files. Make must still be called separately.

I've been using this tons because it lets me switch back and forth between ground and firmware projects without having to leave Qt Creator.

Tested and works for debugging and compiling. (Unfortunately, those setups are on a per-user basis, so by default the project files does _not_ work for compiling and debugging.)

![screen shot 2016-02-12 at 3 17 19 pm](https://cloud.githubusercontent.com/assets/1118185/13020308/a89ee572-d1a2-11e5-9e8c-dd7734a7b46c.png)

Tested only on OSX. Should work similarly on Linux and Windows, but would appreciate feedback.
