### PR TITLE
Logging: Change FileSectorNum to uint32

### DIFF
--- a/shared/uavobjectdefinition/loggingstats.xml
+++ b/shared/uavobjectdefinition/loggingstats.xml
@@ -8,7 +8,7 @@
 	<field name="Operation" units="" type="enum" elements="1" options="INITIALIZING, LOGGING, IDLE, DOWNLOAD, COMPLETE, FORMAT, ERROR"/>
 
 	<field name="FileRequest" units="" type="uint16" elements="1"/>
-	<field name="FileSectorNum" units="" type="uint16" elements="1"/>
+	<field name="FileSectorNum" units="" type="uint32" elements="1"/>
 	<field name="FileSector" units="" type="uint8" elements="128"/>
 
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
For too large files sizes (in the case of the MX25L128 more than 8MB), the logging download would fail because FileSectorNum was limited to 16 bits (65535 sectors). This increases the maximum number of sectors, although FileSectorNum is currently copied into an int32, so at most this gives 2^31 sectors. Still, this is far greater than any likely memory requirement in the short term.

Tested and works all the way up to 16MB log files.
