### PR TITLE
Attitude: Move minimum PDOP and minimum number of satellites to UAVObject

### DIFF
--- a/shared/uavobjectdefinition/inssettings.xml
+++ b/shared/uavobjectdefinition/inssettings.xml
@@ -15,6 +15,9 @@
 		<!-- These settings are related to how the sensors are post processed -->
 		<field name="MagBiasNullingRate" units="" type="float" elements="1" defaultvalue="0"/>
 
+		<field name="MinRNAVSatellites" units="" type="uint8" elements="1" defaultvalue="6"/>
+		<field name="MinRNAVPDOP" units="" type="float" elements="1" defaultvalue="4"/>
+
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
This should be a configurable settings because each GPS and vehicle will have different minimum RNAV requirements. While we don't expect users to set this themselves, it should still be accessible for development and tuning purposes.

Tested and works very nicely for not having to sit around waiting for enough satellites in order to take off, gain some altitude, and get some more satellites. :D
