### PR TITLE
Matlab parser enhancements

### DIFF
--- a/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.m
+++ b/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.m
@@ -186,7 +186,6 @@ while bufferIdx < (length(buffer) - 20)
 		datasizeBufferIdx = bufferIdx; %Just grab the index. We'll do a typecast later, if necessary
 		msgType = buffer(bufferIdx+1); % get msg type (quint8 1 byte ) should be 0x20, ignore the rest?
 		objID = typecast(buffer(bufferIdx+4:bufferIdx + 4+4-1), 'uint32'); % get obj id (quint32 4 bytes)
-		timestamp = 0; %double(typecast(buffer(bufferIdx:bufferIdx+4-1),'uint32'));
 		
 		% Advance buffer past header to where data is (or instance ID)
 		bufferIdx=bufferIdx + 8;
@@ -213,11 +212,13 @@ while bufferIdx < (length(buffer) - 20)
 		bufferIdx=bufferIdx + 20;
 	end
 
-	if timestamp < lastTimestamp
-		timestampAccumulator = timestampAccumulator + timestampWraparound;
+	if ~onboardLogger
+		if timestamp < lastTimestamp
+			timestampAccumulator = timestampAccumulator + timestampWraparound;
+		end
+		lastTimestamp = timestamp;
+		timestamp = timestamp + timestampAccumulator;
 	end
-	lastTimestamp = timestamp;    
-	timestamp = timestamp + timestampAccumulator;
 
 	%Check that message type is correct
 	if bitand(msgType, 127) ~= correctMsgByte

--- a/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.m
+++ b/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.m
@@ -123,7 +123,9 @@ end
 timestampAccumulator = 0;
 lastTimestamp = 0;
 
-while bufferIdx < (length(buffer) - 20)
+buffer_len = length(buffer);
+
+while bufferIdx < (buffer_len - 20)
 	%% Read message header
 	% get sync field (0x3C, 1 byte)
 	if onboardLogger
@@ -276,10 +278,10 @@ $(SWITCHCODE)
 		str2=sprintf('wrongSyncByte instances:    % 10d\n', wrongSyncByte );
 		str3=sprintf('wrongMessageByte instances: % 10d\n\n', wrongMessageByte );
 		
-		str4=sprintf('Completed bytes: % 9d of % 9d\n', bufferIdx, length(buffer));
+		str4=sprintf('Completed bytes: % 9d of % 9d\n', bufferIdx, buffer_len);
 		
 		% Arbitrary times two so that it is at least as long	
-		estTimeRemaining=(length(buffer)-bufferIdx)/(bufferIdx/etime(clock,startTime)) * 2;
+		estTimeRemaining=(buffer_len-bufferIdx)/(bufferIdx/etime(clock,startTime)) * 2;
 		h=floor(estTimeRemaining/3600);
 		m=floor((estTimeRemaining-h*3600)/60);
 		s=ceil(estTimeRemaining-h*3600-m*60);
@@ -292,7 +294,7 @@ $(SWITCHCODE)
 	end
 
 	%Check if at end of file. If not, load next prebuffer
-	if bufferIdx+12-1 > length(buffer)
+	if bufferIdx+12-1 > buffer_len
 		break;
 	end
 %	bufferIdx=bufferIdx+12;
@@ -323,7 +325,7 @@ else
 $(EXPORTCSVCODE)
 end
 
-fprintf('%d records in %0.2f seconds.\n', length(buffer), etime(clock,startTime));
+fprintf('%d records in %0.2f seconds.\n', buffer_len, etime(clock,startTime));
 
 
 

--- a/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.m
+++ b/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.m
@@ -388,3 +388,16 @@ function out=mcolon(inStart, inFinish)
 		out(idx:idx+diffIn(i))=inStart(i):inFinish(i);
 		idx=idx+diffIn(i)+1;
 	end
+
+function unwrapped_time = time_unwrap(x, T)
+%% Unwraps the time when a subsequent sample is earlier in time than the
+% prior sample. Note that this can only capture one wrapping period. If
+% there are multiple wrapping periods hidden inside the data, this will not
+% return an appropriately unwrapped timestamp.
+	unwrapped_time = x;
+	time_diff = diff(x) < 0;
+	for i=1:length(time_diff)
+		if time_diff(i) == true
+			unwrapped_time(i+1:end) = unwrapped_time(i+1:end) + T;
+		end
+	end

--- a/ground/uavobjgenerator/generators/matlab/uavobjectgeneratormatlab.cpp
+++ b/ground/uavobjgenerator/generators/matlab/uavobjectgeneratormatlab.cpp
@@ -158,9 +158,9 @@ bool UAVObjectGeneratorMatlab::process_object(ObjectInfo* info, int numBytes)
         currentIdx+=2;
     }
     allocationFields.append("\tif onboardLogger\n");
-    allocationFields.append("\t" + objectName + ".timestamp = " +
-                      "double(typecast(buffer(mcolon(" + objectName + "FidIdx" +
-                      ", 1+" + objectName + "FidIdx)), 'uint16'))';\n");
+    allocationFields.append("\t\t" + objectName + ".timestamp = " +
+                      "time_unwrap(double(typecast(buffer(mcolon(" + objectName + "FidIdx" +
+                      ", 1+" + objectName + "FidIdx)), 'uint16'))', 2^16);\n");
     allocationFields.append("\tend\n");
 
     for (int n = 0; n < info->fields.length(); ++n) {

--- a/ground/uavobjgenerator/generators/matlab/uavobjectgeneratormatlab.cpp
+++ b/ground/uavobjgenerator/generators/matlab/uavobjectgeneratormatlab.cpp
@@ -124,7 +124,9 @@ bool UAVObjectGeneratorMatlab::process_object(ObjectInfo* info, int numBytes)
     matlabSwitchCode.append("\t\tcase " + objectTableName.toUpper() + "_OBJID\n");
     matlabSwitchCode.append("\t\t\t" + tableIdxName + " = " + tableIdxName +" + 1;\n");
     matlabSwitchCode.append("\t\t\t" + objectTableName + "FidIdx(" + tableIdxName + ") = bufferIdx; %#ok<*AGROW>\n");
-    matlabSwitchCode.append("\t\t\t" + objectTableName + ".timestamp(" + tableIdxName + ") = timestamp; %#ok<*AGROW>\n");
+    matlabSwitchCode.append("\t\t\tif ~onboardLogger\n");
+    matlabSwitchCode.append("\t\t\t\t" + objectTableName + ".timestamp(" + tableIdxName + ") = timestamp; %#ok<*AGROW>\n");
+    matlabSwitchCode.append("\t\t\tend\n");
     matlabSwitchCode.append("\t\t\tbufferIdx=bufferIdx + " +  objectTableName.toUpper() + "_NUMBYTES + timestampedMsgOffset + 1; %+1 is for CRC\n");
     if(!info->isSingleInst){
         matlabSwitchCode.append("\t\t\tbufferIdx = bufferIdx + 2; %An extra two bytes for the instance ID\n");
@@ -155,9 +157,11 @@ bool UAVObjectGeneratorMatlab::process_object(ObjectInfo* info, int numBytes)
                           ", " + objectName + "FidIdx  + instanceIdOffset + 2-1)), 'uint16'))';\n");
         currentIdx+=2;
     }
+    allocationFields.append("\tif onboardLogger\n");
     allocationFields.append("\t" + objectName + ".timestamp = " +
                       "double(typecast(buffer(mcolon(" + objectName + "FidIdx" +
                       ", 1+" + objectName + "FidIdx)), 'uint16'))';\n");
+    allocationFields.append("\tend\n");
 
     for (int n = 0; n < info->fields.length(); ++n) {
         // Determine variable type

--- a/ground/uavobjgenerator/generators/matlab/uavobjectgeneratormatlab.cpp
+++ b/ground/uavobjgenerator/generators/matlab/uavobjectgeneratormatlab.cpp
@@ -122,17 +122,19 @@ bool UAVObjectGeneratorMatlab::process_object(ObjectInfo* info, int numBytes)
     // Generate 'Switch:' code (will replace the $(SWITCHCODE) tag) //
     //==============================================================//
     matlabSwitchCode.append("\t\tcase " + objectTableName.toUpper() + "_OBJID\n");
-    matlabSwitchCode.append("\t\t\t" + tableIdxName + " = " + tableIdxName +" + 1;\n");
-    matlabSwitchCode.append("\t\t\t" + objectTableName + "FidIdx(" + tableIdxName + ") = bufferIdx; %#ok<*AGROW>\n");
-    matlabSwitchCode.append("\t\t\tif ~onboardLogger\n");
-    matlabSwitchCode.append("\t\t\t\t" + objectTableName + ".timestamp(" + tableIdxName + ") = timestamp; %#ok<*AGROW>\n");
-    matlabSwitchCode.append("\t\t\tend\n");
-    matlabSwitchCode.append("\t\t\tbufferIdx=bufferIdx + " +  objectTableName.toUpper() + "_NUMBYTES + timestampedMsgOffset + 1; %+1 is for CRC\n");
+    matlabSwitchCode.append("\t\t\tif buffer_len >= bufferIdx + " +  objectTableName.toUpper() + "_NUMBYTES+1;\n");
+    matlabSwitchCode.append("\t\t\t\t" + tableIdxName + " = " + tableIdxName +" + 1;\n");
+    matlabSwitchCode.append("\t\t\t\t" + objectTableName + "FidIdx(" + tableIdxName + ") = bufferIdx; %#ok<*AGROW>\n");
+    matlabSwitchCode.append("\t\t\t\tif ~onboardLogger\n");
+    matlabSwitchCode.append("\t\t\t\t\t" + objectTableName + ".timestamp(" + tableIdxName + ") = timestamp; %#ok<*AGROW>\n");
+    matlabSwitchCode.append("\t\t\t\tend\n");
+    matlabSwitchCode.append("\t\t\t\tbufferIdx=bufferIdx + " +  objectTableName.toUpper() + "_NUMBYTES + timestampedMsgOffset + 1; %+1 is for CRC\n");
     if(!info->isSingleInst){
-        matlabSwitchCode.append("\t\t\tbufferIdx = bufferIdx + 2; %An extra two bytes for the instance ID\n");
+        matlabSwitchCode.append("\t\t\t\tbufferIdx = bufferIdx + 2; %An extra two bytes for the instance ID\n");
     }
-    matlabSwitchCode.append("\t\t\tif " + tableIdxName + " >= length(" + objectTableName +"FidIdx) %Check to see if pre-allocated memory is exhausted\n");
-    matlabSwitchCode.append("\t\t\t\t" + objectTableName + "FidIdx(" + tableIdxName + "*2) = 0;\n");
+    matlabSwitchCode.append("\t\t\t\tif " + tableIdxName + " >= length(" + objectTableName +"FidIdx) %Check to see if pre-allocated memory is exhausted\n");
+    matlabSwitchCode.append("\t\t\t\t\t" + objectTableName + "FidIdx(" + tableIdxName + "*2) = 0;\n");
+    matlabSwitchCode.append("\t\t\t\tend\n");
     matlabSwitchCode.append("\t\t\tend\n");
 
 	


### PR DESCRIPTION
1. The parser would fail when the UAVO had an optional timestamp.
2. The parser would fail when parsing logfiles created on the onboard flash. This is because the logfile format changed some time ago.
3. Fixes out-of-range access, as inspired by https://github.com/d-ronin/dRonin/pull/651.

NOTE: Currently, the logic to choose between logfile formats is placed at the top of the Matlab file. This can lead to a race condition if both `overo` and `onboardLogger` are set to `true`. This will be resolved in a future commit once the flash logfile identifies itself.

P.S. I realize this isn't a particularly atomic PR, but in theory it should "just work" for parsing Matlab and so that's the best litmus test for this kind of script.
