### PR TITLE
MSP Lib: create a general library for parsing MSP

### DIFF
--- a/flight/Libraries/inc/msplib.h
+++ b/flight/Libraries/inc/msplib.h
@@ -1,0 +1,220 @@
+/**
+ ******************************************************************************
+ * @addtogroup TauLabsLibraries Tau Labs Libraries
+ * @{
+ *
+ * @file       msplib.h
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015-2016
+ * @brief      Library for handling MSP protocol communications
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef MSPLIB_H
+#define MSPLIB_H
+
+#include "openpilot.h"
+#include "pios.h"
+#include "flightstatus.h"
+
+#define MSP_MAX_PACKET_SIZE 16
+
+/* MSP constants */
+
+#define MSP_SENSOR_ACC 1
+#define MSP_SENSOR_BARO 2
+#define MSP_SENSOR_MAG 4
+#define MSP_SENSOR_GPS 8
+
+// Magic numbers copied from mwosd
+#define  MSP_IDENT      100 // multitype + multiwii version + protocol version + capability variable
+#define  MSP_STATUS     101 // cycletime & errors_count & sensor present & box activation & current setting number
+#define  MSP_RAW_IMU    102 // 9 DOF
+#define  MSP_SERVO      103 // 8 servos
+#define  MSP_MOTOR      104 // 8 motors
+#define  MSP_RC         105 // 8 rc chan and more
+#define  MSP_RAW_GPS    106 // fix, numsat, lat, lon, alt, speed, ground course
+#define  MSP_COMP_GPS   107 // distance home, direction home
+#define  MSP_ATTITUDE   108 // 2 angles 1 heading
+#define  MSP_ALTITUDE   109 // altitude, variometer
+#define  MSP_ANALOG     110 // vbat, powermetersum, rssi if available on RX
+#define  MSP_RC_TUNING  111 // rc rate, rc expo, rollpitch rate, yaw rate, dyn throttle PID
+#define  MSP_PID        112 // P I D coeff (9 are used currently)
+#define  MSP_BOX        113 // BOX setup (number is dependant of your setup)
+#define  MSP_MISC       114 // powermeter trig
+#define  MSP_MOTOR_PINS 115 // which pins are in use for motors & servos, for GUI
+#define  MSP_BOXNAMES   116 // the aux switch names
+#define  MSP_PIDNAMES   117 // the PID names
+#define  MSP_BOXIDS     119 // get the permanent IDs associated to BOXes
+#define  MSP_NAV_STATUS 121 // Returns navigation status
+#define  MSP_CELLS      130 // FrSky SPort Telemtry
+#define  MSP_ALARMS     242 // Alarm request
+
+/* Data formats for sending and receiving */
+
+//! MSP flight modes
+typedef enum {
+	MSP_BOX_ARM,
+	MSP_BOX_ANGLE,
+	MSP_BOX_HORIZON,
+	MSP_BOX_BARO,
+	MSP_BOX_VARIO,
+	MSP_BOX_MAG,
+	MSP_BOX_GPSHOME,
+	MSP_BOX_GPSHOLD,
+	MSP_BOX_LAST,
+} msp_box_t;
+
+struct msp_packet_status {
+	uint16_t cycleTime;
+	uint16_t i2cErrors;
+	uint16_t sensors;
+	uint32_t flags;
+	uint8_t setting;
+} __attribute__((packed));
+
+struct msp_packet_attitude {
+	int16_t x;
+	int16_t y;
+	int16_t h;
+} __attribute__((packed));
+
+struct msp_packet_analog {
+	uint8_t vbat;
+	uint16_t powerMeterSum;
+	uint16_t rssi;
+	uint16_t current;
+} __attribute__((packed));
+
+struct msp_packet_altitude {
+	int32_t alt; // cm
+	uint16_t vario; // cm/s
+} __attribute__((packed));
+
+struct msp_packet_command {
+	uint16_t channels[8];
+} __attribute__((packed));
+
+struct msp_packet_boxids {
+	uint8_t boxes[MSP_BOX_LAST];
+} __attribute__((packed));
+
+struct msp_packet_rawgps {
+	uint8_t  fix;                 // 0 or 1
+	uint8_t  num_sat;
+	int32_t lat;                  // 1 / 10 000 000 deg
+	int32_t lon;                  // 1 / 10 000 000 deg
+	uint16_t alt;                 // meter
+	uint16_t speed;               // cm/s
+	int16_t ground_course;        // degree * 10
+} __attribute__((packed));
+
+struct msp_packet_compgps {
+	uint16_t distance_to_home;     // meter
+	int16_t  direction_to_home;    // degree [-180:180]
+	uint8_t  home_position_valid;  // 0 = Invalid
+} __attribute__((packed));
+
+union msp_data {
+	uint8_t data[MSP_MAX_PACKET_SIZE];
+	struct msp_packet_status status;
+	struct msp_packet_attitude attitude;
+	struct msp_packet_analog analog;
+	struct msp_packet_altitude altitude;
+	struct msp_packet_command command;
+	struct msp_packet_boxids boxids;
+	struct msp_packet_rawgps rawgps;
+	struct msp_packet_compgps compgps;
+};
+
+//! Map between our flight modes
+const static struct {
+	msp_box_t mode;
+	uint8_t mwboxid;
+	FlightStatusFlightModeOptions tlmode;
+} msp_boxes[] = {
+	{ MSP_BOX_ARM, 0, 0 },
+	{ MSP_BOX_ANGLE, 1, FLIGHTSTATUS_FLIGHTMODE_LEVELING},
+	{ MSP_BOX_HORIZON, 2, FLIGHTSTATUS_FLIGHTMODE_HORIZON},
+	{ MSP_BOX_BARO, 3, FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD},
+	{ MSP_BOX_VARIO, 4, 0},
+	{ MSP_BOX_MAG, 5, 0},
+	{ MSP_BOX_GPSHOME, 10, FLIGHTSTATUS_FLIGHTMODE_RETURNTOHOME},
+	{ MSP_BOX_GPSHOLD, 11, FLIGHTSTATUS_FLIGHTMODE_POSITIONHOLD},
+	{ MSP_BOX_LAST, 0xff, 0},
+};
+
+//! MSP parser states
+typedef enum {
+	MSP_IDLE,
+	MSP_HEADER_START,
+	MSP_HEADER_M,
+	/* These states mean we are in a request or command packet */
+	MSP_HEADER_C_SIZE,
+	MSP_HEADER_C_CMD,
+	MSP_C_FILLBUF,
+	MSP_C_CHECKSUM,
+	/* These states mean we are in a response packet */
+	MSP_HEADER_R_SIZE,
+	MSP_HEADER_R_CMD,
+	MSP_R_FILLBUF,
+	MSP_R_CHECKSUM,
+	/* Throw away any bytes we can't consume */
+	MSP_DISCARD,
+} msp_state;
+
+typedef bool (*msp_cb)(uint8_t cmd, const uint8_t *data, size_t len);
+
+//! Track all the state information for the parser
+struct msp_bridge {
+	uintptr_t com;
+
+	msp_state state;
+
+	uint8_t cmd_size;
+	uint8_t cmd_id;
+	uint8_t cmd_i;
+	uint8_t checksum;
+
+	msp_cb response_cb;
+	msp_cb request_cb;
+
+	union msp_data cmd_data;
+};
+
+//! Allocate memory for an MSP bridge
+struct msp_bridge * msp_init(uintptr_t com);
+
+//! Send response to a data request
+void msp_send_reponse(struct msp_bridge *m, uint8_t cmd, const uint8_t *data, size_t len);
+
+//! Send a request for a data update
+void msp_send_request(struct msp_bridge *m, uint8_t type);
+
+//! Consume and process bytes received by the parser
+bool msp_receive_byte(struct msp_bridge *m, uint8_t b);
+
+void msp_set_response_cb(struct msp_bridge *m, msp_cb response_cb);
+void msp_set_request_cb(struct msp_bridge *m, msp_cb request_cb);
+
+#endif /* MSPLIB_H */
+
+/**
+ * @}
+ */

--- a/flight/Libraries/inc/msplib.h
+++ b/flight/Libraries/inc/msplib.h
@@ -179,7 +179,7 @@ typedef enum {
 	MSP_DISCARD,
 } msp_state;
 
-typedef bool (*msp_cb)(uint8_t cmd, const uint8_t *data, size_t len);
+typedef bool (*msp_cb_store)(void *msp, uint8_t cmd, const uint8_t *data, size_t len);
 
 //! Track all the state information for the parser
 struct msp_bridge {
@@ -192,17 +192,22 @@ struct msp_bridge {
 	uint8_t cmd_i;
 	uint8_t checksum;
 
-	msp_cb response_cb;
-	msp_cb request_cb;
+	msp_cb_store response_cb;
+	msp_cb_store request_cb;
 
 	union msp_data cmd_data;
 };
+
+// We do a little dance here to have a nice clean function prototype for the outside
+// API but internally we have to have the first parameter as void* in order to avoid
+// a circular definition
+typedef bool (*msp_cb)(struct msp_bridge *msp, uint8_t cmd, const uint8_t *data, size_t len);
 
 //! Allocate memory for an MSP bridge
 struct msp_bridge * msp_init(uintptr_t com);
 
 //! Send response to a data request
-void msp_send_reponse(struct msp_bridge *m, uint8_t cmd, const uint8_t *data, size_t len);
+void msp_send_response(struct msp_bridge *m, uint8_t cmd, const uint8_t *data, size_t len);
 
 //! Send a request for a data update
 void msp_send_request(struct msp_bridge *m, uint8_t type);

--- a/flight/Libraries/msplib.c
+++ b/flight/Libraries/msplib.c
@@ -1,0 +1,205 @@
+/**
+ ******************************************************************************
+ * @addtogroup TauLabsLibraries Tau Labs Libraries
+ * @{
+ *
+ * @file       msplib.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015-2016
+ * @brief      Library for handling MSP protocol communications
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "msplib.h"
+
+//! Initialize an MSP parser
+struct msp_bridge * msp_init(uintptr_t com)
+{
+	struct msp_bridge * msp = PIOS_malloc(sizeof(*msp));
+	if (msp != NULL) {
+		memset(msp, 0x00, sizeof(*msp));
+		msp->com = com;
+	}
+
+	return msp;
+}
+
+ //! Send response to a query packet
+void msp_send_reponse(struct msp_bridge *m, uint8_t cmd, const uint8_t *data, size_t len)
+{
+	uint8_t buf[5];
+	uint8_t cs = (uint8_t)(len) ^ cmd;
+
+	buf[0] = '$';
+	buf[1] = 'M';
+	buf[2] = '>';
+	buf[3] = (uint8_t)(len);
+	buf[4] = cmd;
+
+	PIOS_COM_SendBuffer(m->com, buf, sizeof(buf));
+	PIOS_COM_SendBuffer(m->com, data, len);
+
+	for (int i = 0; i < len; i++) {
+		cs ^= data[i];
+	}
+	cs ^= 0;
+
+	buf[0] = cs;
+	PIOS_COM_SendBuffer(m->com, buf, 1);
+}
+
+//! Query an update
+void msp_send_request(struct msp_bridge *m, uint8_t type)
+{
+	const uint32_t REQUEST_PACKET_SIZE = 6;
+
+	uint8_t buf[REQUEST_PACKET_SIZE];
+	buf[0] = '$';
+	buf[1] = 'M';
+	buf[2] = '<';
+	buf[3] = 0;
+	buf[4] = type;
+	buf[5] = 0 ^ type; // calculate checksum
+
+	PIOS_COM_SendBuffer(m->com, buf, REQUEST_PACKET_SIZE);
+}
+
+void msp_set_response_cb(struct msp_bridge *m, msp_cb response_cb)
+{
+	m->response_cb = response_cb;
+}
+
+void msp_set_request_cb(struct msp_bridge *m, msp_cb request_cb)
+{
+	m->request_cb = request_cb;
+}
+
+//! Receive the size of the next packet
+static msp_state msp_state_size(struct msp_bridge *m, uint8_t b)
+{
+	m->cmd_size = b;
+	m->checksum = b;
+
+	// Advance to next state but track if we are in a command or response
+	return (m->state == MSP_HEADER_C_SIZE) ? MSP_HEADER_C_CMD : MSP_HEADER_R_CMD;
+}
+
+//! Receive the command of the next packet
+static msp_state msp_state_cmd(struct msp_bridge *m, uint8_t b)
+{
+	m->cmd_i = 0;
+	m->cmd_id = b;
+	m->checksum ^= m->cmd_id;
+
+	if (m->cmd_size > sizeof(m->cmd_data)) {
+		// Too large a body.  Let's ignore it.
+		return MSP_DISCARD;
+	}
+
+	// Advance to next state but track if we are in a command or response
+	return m->cmd_size == 0 ? (m->state == MSP_HEADER_C_CMD ? MSP_C_CHECKSUM : MSP_R_CHECKSUM) : 
+	                          (m->state == MSP_HEADER_C_CMD ? MSP_C_FILLBUF : MSP_R_FILLBUF);
+}
+
+//! Receive the data packet for commands or responses
+static msp_state msp_state_fill_buf(struct msp_bridge *m, uint8_t b)
+{
+	m->cmd_data.data[m->cmd_i++] = b;
+	m->checksum ^= b;
+
+	// Advance to next state but track if we are in a command or response
+	return m->cmd_i == m->cmd_size ? (m->state == MSP_HEADER_C_CMD ? MSP_C_CHECKSUM : MSP_R_CHECKSUM) : m->state;
+}
+
+//! Receive the checksum of the current packet
+static msp_state msp_state_checksum(struct msp_bridge *m, uint8_t b)
+{
+	if ((m->checksum ^ b) != 0) {
+		return MSP_IDLE;
+	}
+
+	if (m->state == MSP_C_CHECKSUM) {
+		// Respond to requests/commands we support
+		if(m->request_cb) {
+			m->request_cb(m->cmd_id, m->cmd_data.data, m->cmd_size);
+		}
+	} else if (m->state == MSP_R_CHECKSUM) {
+		// Respond to requests/commands we support
+		if(m->response_cb) {
+			m->response_cb(m->cmd_id, m->cmd_data.data, m->cmd_size);
+		}
+	}
+
+	return MSP_IDLE;
+}
+
+//! Throw out bytes when we can't receive a large packet
+static msp_state msp_state_discard(struct msp_bridge *m, uint8_t b)
+{
+	return m->cmd_i++ == m->cmd_size ? MSP_IDLE : MSP_DISCARD;
+}
+
+/**
+ * Process incoming bytes from an MSP packet
+ * for the OSD this should mostly be responses to queries
+ * we made
+ * @param[in] b received byte
+ * @return true if we should continue processing bytes
+ */
+bool msp_receive_byte(struct msp_bridge *m, uint8_t b)
+{
+	switch (m->state) {
+	case MSP_IDLE:
+		m->state = b == '$' ? MSP_HEADER_START : MSP_IDLE;
+		break;
+	case MSP_HEADER_START:
+		m->state = b == 'M' ? MSP_HEADER_M : MSP_IDLE;
+		break;
+	case MSP_HEADER_M:
+		m->state = b == '<' ? MSP_HEADER_C_SIZE : // command/request packet
+		           b == '>' ? MSP_HEADER_R_SIZE : // response packet
+		           MSP_IDLE;
+		break;
+	case MSP_HEADER_C_SIZE:
+	case MSP_HEADER_R_SIZE:
+		m->state = msp_state_size(m, b);
+		break;
+	case MSP_HEADER_C_CMD:
+	case MSP_HEADER_R_CMD:
+		m->state = msp_state_cmd(m, b);
+		break;
+	case MSP_C_FILLBUF:
+	case MSP_R_FILLBUF:
+		m->state = msp_state_fill_buf(m, b);
+		break;
+	case MSP_C_CHECKSUM:
+	case MSP_R_CHECKSUM:
+		m->state = msp_state_checksum(m, b);
+		break;
+	case MSP_DISCARD:
+		m->state = msp_state_discard(m, b);
+		break;
+	}
+
+	return true;
+}
+
+/**
+ * @}
+ */

--- a/flight/Libraries/msplib.c
+++ b/flight/Libraries/msplib.c
@@ -41,7 +41,7 @@ struct msp_bridge * msp_init(uintptr_t com)
 }
 
  //! Send response to a query packet
-void msp_send_reponse(struct msp_bridge *m, uint8_t cmd, const uint8_t *data, size_t len)
+void msp_send_response(struct msp_bridge *m, uint8_t cmd, const uint8_t *data, size_t len)
 {
 	uint8_t buf[5];
 	uint8_t cs = (uint8_t)(len) ^ cmd;
@@ -82,12 +82,12 @@ void msp_send_request(struct msp_bridge *m, uint8_t type)
 
 void msp_set_response_cb(struct msp_bridge *m, msp_cb response_cb)
 {
-	m->response_cb = response_cb;
+	m->response_cb = (msp_cb_store) response_cb;
 }
 
 void msp_set_request_cb(struct msp_bridge *m, msp_cb request_cb)
 {
-	m->request_cb = request_cb;
+	m->request_cb = (msp_cb_store) request_cb;
 }
 
 //! Receive the size of the next packet
@@ -137,12 +137,12 @@ static msp_state msp_state_checksum(struct msp_bridge *m, uint8_t b)
 	if (m->state == MSP_C_CHECKSUM) {
 		// Respond to requests/commands we support
 		if(m->request_cb) {
-			m->request_cb(m->cmd_id, m->cmd_data.data, m->cmd_size);
+			m->request_cb((void *)m, m->cmd_id, m->cmd_data.data, m->cmd_size);
 		}
 	} else if (m->state == MSP_R_CHECKSUM) {
 		// Respond to requests/commands we support
 		if(m->response_cb) {
-			m->response_cb(m->cmd_id, m->cmd_data.data, m->cmd_size);
+			m->response_cb((void *)m, m->cmd_id, m->cmd_data.data, m->cmd_size);
 		}
 	}
 

--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -6,7 +6,8 @@
  * @{
  *
  * @file       uavomspbridge.c
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015-2016
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Bridges selected UAVObjects to MSP for MWOSD and the like.
  *
  * @see        The GNU Public License (GPL) Version 3

--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -149,7 +149,7 @@ struct msp_bridge {
 #if defined(PIOS_MSP_STACK_SIZE)
 #define STACK_SIZE_BYTES PIOS_MSP_STACK_SIZE
 #else
-#define STACK_SIZE_BYTES 672
+#define STACK_SIZE_BYTES 768
 #endif
 #define TASK_PRIORITY               PIOS_THREAD_PRIO_LOW
 

--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -193,8 +193,8 @@ static void msp_send_raw_gps(struct msp_bridge *m)
 	union {
 		uint8_t buf[0];
 		struct {
-			uint8_t  fix;                 // 0 or 1
-			uint8_t  num_sat;
+			uint8_t fix;                 // 0 or 1
+			uint8_t num_sat;
 			int32_t lat;                  // 1 / 10 000 000 deg
 			int32_t lon;                  // 1 / 10 000 000 deg
 			uint16_t alt;                 // meter
@@ -205,8 +205,7 @@ static void msp_send_raw_gps(struct msp_bridge *m)
 	
 	GPSPositionData gps_data = {};
 	
-	if (GPSPositionHandle() != NULL)
-	{
+	if (GPSPositionHandle() != NULL) {
 		GPSPositionGet(&gps_data);
 		data.raw_gps.fix           = (gps_data.Status >= GPSPOSITION_STATUS_FIX2D ? 1 : 0);  // Data will display on OSD if 2D fix or better
 		data.raw_gps.num_sat       = gps_data.Satellites;
@@ -215,9 +214,7 @@ static void msp_send_raw_gps(struct msp_bridge *m)
 		data.raw_gps.alt           = gps_data.Altitude;
 		data.raw_gps.speed         = gps_data.Groundspeed;
 		data.raw_gps.ground_course = gps_data.Heading * 10;
-	}
-	else
-	{
+	} else {
 		data.raw_gps.fix           = 0;  // Data won't display on OSD
 		data.raw_gps.num_sat       = 0;
 		data.raw_gps.lat           = 0;
@@ -252,21 +249,18 @@ static void msp_send_comp_gps(struct msp_bridge *m)
 		GPSPositionGet(&gps_data);
 		HomeLocationGet(&home_data);
 		
-		if((gps_data.Status < GPSPOSITION_STATUS_FIX2D) || (home_data.Set == HOMELOCATION_SET_FALSE))
-		{
+		if((gps_data.Status < GPSPOSITION_STATUS_FIX2D) || (home_data.Set == HOMELOCATION_SET_FALSE)) {
 			data.comp_gps.distance_to_home    = 0;
 			data.comp_gps.direction_to_home   = 0;
 			data.comp_gps.home_position_valid = 0;  // Home distance and direction will not display on OSD
-		}
-		else
-		{
+		} else {
 			data.comp_gps.home_position_valid = 1;  // Home distance and direction will display on OSD
 			
 			int32_t delta_lon = (home_data.Longitude - gps_data.Longitude);  // degrees * 1e7
 			int32_t delta_lat = (home_data.Latitude  - gps_data.Latitude );  // degrees * 1e7
 	
-			float delta_y = (float)delta_lon * WGS84_RADIUS_EARTH_KM * DEG2RAD;  // KM * 1e7
-			float delta_x = (float)delta_lat * WGS84_RADIUS_EARTH_KM * DEG2RAD;  // KM * 1e7
+			float delta_y = delta_lon * WGS84_RADIUS_EARTH_KM * DEG2RAD;  // KM * 1e7
+			float delta_x = delta_lat * WGS84_RADIUS_EARTH_KM * DEG2RAD;  // KM * 1e7
 	
 			delta_y *= cosf(home_data.Latitude * 1e-7f * (float)DEG2RAD);  // Latitude compression correction
 	

--- a/flight/targets/aq32/fw/Makefile
+++ b/flight/targets/aq32/fw/Makefile
@@ -124,6 +124,7 @@ SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
 SRC += $(FLIGHTLIB)/timeutils.c
 SRC += $(FLIGHTLIB)/frsky_packing.c
+SRC += $(FLIGHTLIB)/msplib.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/misc_math.c
 SRC += $(MATHLIB)/atmospheric_math.c

--- a/flight/targets/coptercontrol/fw/Makefile
+++ b/flight/targets/coptercontrol/fw/Makefile
@@ -162,6 +162,8 @@ SRC += $(FLIGHTLIB)/alarms.c
 SRC += $(OPUAVTALK)/uavtalk.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
 SRC += $(OPUAVOBJ)/eventdispatcher.c
+SRC += $(FLIGHTLIB)/msplib.c
+
 else
 ## TESTCODE
 SRC += $(OPTESTS)/test_common.c

--- a/flight/targets/naze32/fw/Makefile
+++ b/flight/targets/naze32/fw/Makefile
@@ -215,6 +215,7 @@ SRC += $(PIOSCOMMON)/pios_board_info.c
 SRC += $(FLIGHTLIB)/fifo_buffer.c
 SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
+SRC += $(FLIGHTLIB)/msplib.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/misc_math.c
 SRC += $(MATHLIB)/pid.c

--- a/flight/targets/quanton/fw/Makefile
+++ b/flight/targets/quanton/fw/Makefile
@@ -123,6 +123,7 @@ SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
 SRC += $(FLIGHTLIB)/timeutils.c
 SRC += $(FLIGHTLIB)/frsky_packing.c
+SRC += $(FLIGHTLIB)/msplib.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/misc_math.c
 SRC += $(MATHLIB)/atmospheric_math.c

--- a/flight/targets/sparky/fw/Makefile
+++ b/flight/targets/sparky/fw/Makefile
@@ -113,6 +113,7 @@ SRC += $(FLIGHTLIB)/insgps14state.c
 SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
 SRC += $(FLIGHTLIB)/frsky_packing.c
+SRC += $(FLIGHTLIB)/msplib.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/misc_math.c
 SRC += $(MATHLIB)/pid.c

--- a/flight/targets/sparky2/fw/Makefile
+++ b/flight/targets/sparky2/fw/Makefile
@@ -128,6 +128,7 @@ SRC += $(FLIGHTLIB)/taskmonitor.c
 SRC += $(FLIGHTLIB)/sanitycheck.c
 SRC += $(FLIGHTLIB)/timeutils.c
 SRC += $(FLIGHTLIB)/frsky_packing.c
+SRC += $(FLIGHTLIB)/msplib.c
 SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/misc_math.c
 SRC += $(MATHLIB)/atmospheric_math.c


### PR DESCRIPTION
The MSP protocol is fairly popular and well documented

http://www.stefanocottafavi.com/msp-the-multiwii-serial-protocol/

This abstracts the code for the parser into a library and refactors the
UAVOMSPBridge to use it. Also back ports a few improvements from
https://github.com/d-ronin/dRonin/pull/571

This code is also used for querying the FC for updates in TauOSD
and this has been tested and works on both ends.
