### PR TITLE
RFM22b COM assignment

### DIFF
--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -127,9 +127,6 @@ static int32_t RadioComBridgeStart(void)
 		// Check if this is the coordinator modem
 		data->isCoordinator = PIOS_RFM22B_IsCoordinator(PIOS_COM_RFM22B);
 
-		// Parse UAVTalk out of the link
-		data->parseUAVTalk = true;
-
 		// Configure our UAVObjects for updates.
 		UAVObjConnectQueue(UAVObjGetByID(RFM22BSTATUS_OBJID), data->uavtalkEventQueue,
 				   EV_UPDATED | EV_UPDATED_MANUAL | EV_UPDATE_REQ);

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -6,8 +6,8 @@
  * @{ 
  *
  * @file       RadioComBridge.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
  * @brief      Bridges from RFM22b comm channel to another PIOS_COM channel
  *             has the ability to hook and process UAVO packets for the radio
  *             board (e.g. TauLink)

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -152,9 +152,8 @@ static int32_t RadioComBridgeStart(void)
 					   EV_UPDATED | EV_UPDATED_MANUAL | EV_UPDATE_REQ);
 		}
 
-		if (data->isCoordinator) {
-			registerObject(RadioComBridgeStatsHandle());
-		}
+		registerObject(RadioComBridgeStatsHandle());
+
 		// Configure the UAVObject callbacks
 		ObjectPersistenceConnectCallback(&objectPersistenceUpdatedCb);
 

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -146,9 +146,12 @@ static int32_t RadioComBridgeStart(void)
 		PIOS_WDG_RegisterFlag(PIOS_WDG_RADIORX);
 #endif
 
-		// Start the primary tasks for receiving/sending UAVTalk packets from the GCS.
+		// Insert packets from the modem to the telemetry side
 		data->telemetryTxTaskHandle = PIOS_Thread_Create(telemetryTxTask, "telemetryTxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
+		// Pass data from telemetry to the radio link
 		data->telemetryRxTaskHandle = PIOS_Thread_Create(telemetryRxTask, "telemetryRxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
+		// Pass data from the radio link to the telemetry side
+		data->radioRxTaskHandle = PIOS_Thread_Create(radioRxTask, "radioRxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 			    
 		if (PIOS_PPM_RECEIVER != 0) {
 #ifdef PIOS_INCLUDE_WDG
@@ -156,7 +159,6 @@ static int32_t RadioComBridgeStart(void)
 #endif
 			data->PPMInputTaskHandle = PIOS_Thread_Create(PPMInputTask, "PPMInputTask",STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 		}
-		data->radioRxTaskHandle = PIOS_Thread_Create(radioRxTask, "radioRxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 
 		return 0;
 	}

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -326,7 +326,7 @@ static void radioRxTask( __attribute__ ((unused))
 						ProcessRadioStream(data->radioUAVTalkCon, data->telemUAVTalkCon, serial_data[i]);
 					}
 				} else if (select_telemetry_port()) {
-				    PIOS_COM_SendBufferNonBlocking(select_telemetry_port(), serial_data, bytes_to_process);
+				    PIOS_COM_SendBuffer(select_telemetry_port(), serial_data, bytes_to_process);
 				}
 			}
 		} else {
@@ -365,7 +365,7 @@ static void telemetryRxTask( __attribute__ ((unused))
 						ProcessTelemetryStream(data->telemUAVTalkCon, data->radioUAVTalkCon, serial_data[i]);
 					}
 				} else if (PIOS_COM_RFM22B) {
-					PIOS_COM_SendBufferNonBlocking(PIOS_COM_RFM22B, serial_data, bytes_to_process);
+					PIOS_COM_SendBuffer(PIOS_COM_RFM22B, serial_data, bytes_to_process);
 				}
 			}
 		} else {

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -406,7 +406,7 @@ static void PPMInputTask( __attribute__ ((unused))
 static int32_t UAVTalkSendHandler(uint8_t * buf, int32_t length)
 {
 	int32_t ret;
-	uint32_t outputPort = data->parseUAVTalk ? PIOS_COM_TELEMETRY : 0;
+	uint32_t outputPort = PIOS_COM_TELEMETRY;
 
 #if defined(PIOS_INCLUDE_USB)
 	// Determine output port (USB takes priority over telemetry port)
@@ -433,9 +433,6 @@ static int32_t UAVTalkSendHandler(uint8_t * buf, int32_t length)
  */
 static int32_t RadioSendHandler(uint8_t * buf, int32_t length)
 {
-	if (!data->parseUAVTalk) {
-		return length;
-	}
 	uint32_t outputPort = PIOS_COM_RFM22B;
 
 	// Don't send any data unless the radio port is available.

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -280,7 +280,9 @@ static void telemetryTxTask( __attribute__ ((unused))
 			if (ev.obj == RadioComBridgeStatsHandle()) {
 				updateRadioComBridgeStats();
 			}
-			UAVTalkSendObject(data->telemUAVTalkCon, ev.obj, ev.instId, 0, RETRY_TIMEOUT_MS);
+			if (data->parseUAVTalk) {
+				UAVTalkSendObject(data->telemUAVTalkCon, ev.obj, ev.instId, 0, RETRY_TIMEOUT_MS);
+			}
 		}
 	}
 }

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -316,7 +316,7 @@ static void radioRxTask( __attribute__ ((unused))
 		PIOS_WDG_UpdateFlag(PIOS_WDG_RADIORX);
 #endif
 		if (PIOS_COM_RFM22B) {
-			uint8_t serial_data[1];
+			uint8_t serial_data[64];
 			uint16_t bytes_to_process =
 			    PIOS_COM_ReceiveBuffer(PIOS_COM_RFM22B, serial_data, sizeof(serial_data), MAX_PORT_DELAY);
 			if (bytes_to_process > 0) {
@@ -355,7 +355,7 @@ static void telemetryRxTask( __attribute__ ((unused))
 		PIOS_WDG_UpdateFlag(PIOS_WDG_TELEMETRYRX);
 #endif
 		if (inputPort) {
-			uint8_t serial_data[1];
+			uint8_t serial_data[64];
 			uint16_t bytes_to_process =
 			    PIOS_COM_ReceiveBuffer(inputPort, serial_data, sizeof(serial_data), MAX_PORT_DELAY);
 			if (bytes_to_process > 0) {

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -234,25 +234,20 @@ static void PIOS_HAL_SetReceiver(int receiver_type, uintptr_t value) {
 }
 #endif
 
-#if defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
+#if defined(PIOS_INCLUDE_COM)
 /**
- * @brief Configures USART and COM subsystems, allocates buffers.
+ * @brief Configures COM subsystems, allocates buffers.
  *
- * @param[in] usart_port_cfg USART configuration
+ * @param[in] subsys_id handle to subsystem support pios_com
  * @param[in] rx_buf_len receive buffer size
  * @param[in] tx_buf_len transmit buffer size
  * @param[in] com_driver communications driver
  * @param[out] com_id id of the PIOS_Com instance
  */
-void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
+void PIOS_HAL_ConfigureCom(uintptr_t subsys_id,
 		size_t rx_buf_len, size_t tx_buf_len,
 		const struct pios_com_driver *com_driver, uintptr_t *com_id)
 {
-	uintptr_t usart_id;
-	if (PIOS_USART_Init(&usart_id, usart_port_cfg)) {
-		PIOS_Assert(0);
-	}
-
 	uint8_t * rx_buffer;
 	if (rx_buf_len > 0) {
 		rx_buffer = (uint8_t *) PIOS_malloc(rx_buf_len);
@@ -269,11 +264,34 @@ void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
 		tx_buffer = NULL;
 	}
 
-	if (PIOS_COM_Init(com_id, com_driver, usart_id,
+	if (PIOS_COM_Init(com_id, com_driver, subsys_id,
 				rx_buffer, rx_buf_len,
 				tx_buffer, tx_buf_len)) {
 		PIOS_Assert(0);
 	}
+}
+#endif  /*  PIOS_INCLUDE_COM */
+
+#if defined(PIOS_INCLUDE_USART) && defined(PIOS_INCLUDE_COM)
+/**
+ * @brief Configures USART and COM subsystems, allocates buffers.
+ *
+ * @param[in] usart_port_cfg USART configuration
+ * @param[in] rx_buf_len receive buffer size
+ * @param[in] tx_buf_len transmit buffer size
+ * @param[in] com_driver communications driver
+ * @param[out] com_id id of the PIOS_Com instance
+ */
+void PIOS_HAL_ConfigureUsart(const struct pios_usart_cfg *usart_port_cfg,
+		size_t rx_buf_len, size_t tx_buf_len,
+		const struct pios_com_driver *com_driver, uintptr_t *com_id)
+{
+	uintptr_t usart_id;
+	if (PIOS_USART_Init(&usart_id, usart_port_cfg)) {
+		PIOS_Assert(0);
+	}
+
+	PIOS_HAL_ConfigureCom(usart_id, rx_buf_len, tx_buf_len, com_driver, com_id);
 }
 #endif  /* PIOS_INCLUDE_USART && PIOS_INCLUDE_COM */
 
@@ -436,11 +454,11 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 	case HWSHARED_PORTTYPES_DISABLED:
 		break;
 	case HWSHARED_PORTTYPES_TELEMETRY:
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_telem_serial_id;
 		break;
 	case HWSHARED_PORTTYPES_GPS:
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_GPS_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_GPS_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_gps_id;
 		break;
 	case HWSHARED_PORTTYPES_DSM:
@@ -492,66 +510,66 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 		break;
 	case HWSHARED_PORTTYPES_DEBUGCONSOLE:
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, 0, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_debug_id;
 #endif  /* PIOS_INCLUDE_DEBUG_CONSOLE */
 		break;
 	case HWSHARED_PORTTYPES_COMBRIDGE:
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_BRIDGE_RX_BUF_LEN, PIOS_COM_BRIDGE_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_BRIDGE_RX_BUF_LEN, PIOS_COM_BRIDGE_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_bridge_id;
 		break;
 	case HWSHARED_PORTTYPES_MAVLINKTX:
 #if defined(PIOS_INCLUDE_MAVLINK)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_MAVLINK_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, 0, PIOS_COM_MAVLINK_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_mavlink_id;
 #endif          /* PIOS_INCLUDE_MAVLINK */
 		break;
 	case HWSHARED_PORTTYPES_MSP:
 #if defined(PIOS_INCLUDE_MSP_BRIDGE)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_MSP_RX_BUF_LEN, PIOS_COM_MSP_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_MSP_RX_BUF_LEN, PIOS_COM_MSP_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_msp_id;
 #endif
 		break;
 	case HWSHARED_PORTTYPES_MAVLINKTX_GPS_RX:
 #if defined(PIOS_INCLUDE_MAVLINK)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_MAVLINK_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_MAVLINK_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_mavlink_id;
 		target2 = &pios_com_gps_id;
 #endif          /* PIOS_INCLUDE_MAVLINK */
 		break;
 	case HWSHARED_PORTTYPES_HOTTTELEMETRY:
 #if defined(PIOS_INCLUDE_HOTT)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_HOTT_RX_BUF_LEN, PIOS_COM_HOTT_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_HOTT_RX_BUF_LEN, PIOS_COM_HOTT_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_hott_id;
 #endif /* PIOS_INCLUDE_HOTT */
 		break;
 	case HWSHARED_PORTTYPES_FRSKYSENSORHUB:
 #if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB)
-		PIOS_HAL_ConfigureCom(usart_frsky_port_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_frsky_port_cfg, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_frsky_sensor_hub_id;
 #endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
 		break;
 	case HWSHARED_PORTTYPES_FRSKYSPORTTELEMETRY:
 #if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY)
-		PIOS_HAL_ConfigureCom(usart_frsky_port_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_frsky_port_cfg, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_frsky_sport_id;
 #endif /* PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY */
 		break;
 	case HWSHARED_PORTTYPES_LIGHTTELEMETRYTX:
 #if defined(PIOS_INCLUDE_LIGHTTELEMETRY)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_LIGHTTELEMETRY_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, 0, PIOS_COM_LIGHTTELEMETRY_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_lighttelemetry_id;
 #endif
 		break;
 	case HWSHARED_PORTTYPES_PICOC:
 #if defined(PIOS_INCLUDE_PICOC)
-		PIOS_HAL_ConfigureCom(usart_port_cfg, PIOS_COM_PICOC_RX_BUF_LEN, PIOS_COM_PICOC_TX_BUF_LEN, com_driver, &port_driver_id);
+		PIOS_HAL_ConfigureUsart(usart_port_cfg, PIOS_COM_PICOC_RX_BUF_LEN, PIOS_COM_PICOC_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_picoc_id;
 #endif /* PIOS_INCLUDE_PICOC */
 		break;
 	    case HWSHARED_PORTTYPES_OPENLOG:
 #if defined(PIOS_INCLUDE_OPENLOG)
-			PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, com_driver, &port_driver_id);
+			PIOS_HAL_ConfigureUsart(usart_port_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, com_driver, &port_driver_id);
 			target = &pios_com_openlog_logging_id;
 			PIOS_COM_ChangeBaud(port_driver_id, 115200);
 #endif /* PIOS_INCLUDE_OPENLOG */
@@ -591,57 +609,23 @@ void PIOS_HAL_ConfigureCDC(HwSharedUSB_VCPPortOptions port_type,
 	case HWSHARED_USB_VCPPORT_DISABLED:
 		break;
 	case HWSHARED_USB_VCPPORT_USBTELEMETRY:
-	{
-		uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_TELEM_USB_RX_BUF_LEN);
-		uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_TELEM_USB_TX_BUF_LEN);
-		PIOS_Assert(rx_buffer);
-		PIOS_Assert(tx_buffer);
-		if (PIOS_COM_Init(&pios_com_telem_usb_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						rx_buffer, PIOS_COM_TELEM_USB_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_TELEM_USB_TX_BUF_LEN)) {
-			PIOS_Assert(0);
-		}
-	}
+		PIOS_HAL_ConfigureCom(pios_usb_cdc_id, PIOS_COM_TELEM_USB_RX_BUF_LEN, PIOS_COM_TELEM_USB_TX_BUF_LEN,
+		                      &pios_usb_cdc_com_driver, &pios_com_telem_usb_id);
 	break;
 	case HWSHARED_USB_VCPPORT_COMBRIDGE:
-	{
-		uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_BRIDGE_RX_BUF_LEN);
-		uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_BRIDGE_TX_BUF_LEN);
-		PIOS_Assert(rx_buffer);
-		PIOS_Assert(tx_buffer);
-		if (PIOS_COM_Init(&pios_com_vcp_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						rx_buffer, PIOS_COM_BRIDGE_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_BRIDGE_TX_BUF_LEN)) {
-			PIOS_Assert(0);
-		}
-	}
+		PIOS_HAL_ConfigureCom(pios_usb_cdc_id, PIOS_COM_BRIDGE_RX_BUF_LEN, PIOS_COM_BRIDGE_TX_BUF_LEN,
+		                      &pios_usb_cdc_com_driver, &pios_com_vcp_id);
 	break;
 	case HWSHARED_USB_VCPPORT_DEBUGCONSOLE:
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
-		{
-			uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_debug_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						NULL, 0,
-						tx_buffer, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-		}
+		PIOS_HAL_ConfigureCom(pios_usb_cdc_id, 0, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN,
+		                      &pios_usb_cdc_com_driver, &pios_com_debug_id);
 #endif  /* PIOS_INCLUDE_DEBUG_CONSOLE */
 		break;
 	case HWSHARED_USB_VCPPORT_PICOC:
 #if defined(PIOS_INCLUDE_PICOC)
-		{
-			uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_PICOC_RX_BUF_LEN);
-			uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_PICOC_TX_BUF_LEN);
-			PIOS_Assert(rx_buffer);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_picoc_id, &pios_usb_cdc_com_driver, pios_usb_cdc_id,
-						rx_buffer, PIOS_COM_PICOC_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_PICOC_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-		}
+		PIOS_HAL_ConfigureCom(pios_usb_cdc_id, PIOS_COM_PICOC_RX_BUF_LEN, PIOS_COM_PICOC_TX_BUF_LEN,
+		                      &pios_usb_cdc_com_driver, &pios_com_picoc_id);
 #endif  /* PIOS_INCLUDE_PICOC */
 		break;
 	}
@@ -667,17 +651,8 @@ void PIOS_HAL_ConfigureHID(HwSharedUSB_HIDPortOptions port_type,
 	case HWSHARED_USB_HIDPORT_DISABLED:
 		break;
 	case HWSHARED_USB_HIDPORT_USBTELEMETRY:
-	{
-		uint8_t * rx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_TELEM_USB_RX_BUF_LEN);
-		uint8_t * tx_buffer = (uint8_t *) PIOS_malloc(PIOS_COM_TELEM_USB_TX_BUF_LEN);
-		PIOS_Assert(rx_buffer);
-		PIOS_Assert(tx_buffer);
-		if (PIOS_COM_Init(&pios_com_telem_usb_id, &pios_usb_hid_com_driver, pios_usb_hid_id,
-						rx_buffer, PIOS_COM_TELEM_USB_RX_BUF_LEN,
-						tx_buffer, PIOS_COM_TELEM_USB_TX_BUF_LEN)) {
-			PIOS_Assert(0);
-		}
-	}
+		PIOS_HAL_ConfigureCom(pios_usb_hid_id, PIOS_COM_TELEM_USB_RX_BUF_LEN, PIOS_COM_TELEM_USB_TX_BUF_LEN,
+		                      &pios_usb_hid_com_driver, &pios_com_telem_usb_id);
 	break;
 	}
 }
@@ -707,6 +682,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 		const struct pios_openlrs_cfg *openlrs_cfg,
 		const struct pios_rfm22b_cfg *rfm22b_cfg,
 		uint8_t min_chan, uint8_t max_chan, uint32_t coord_id,
+		HwSharedPortTypesOptions port_type,
 		int status_inst)
 {
 	/* Initalize the RFM22B radio COM device. */
@@ -766,18 +742,22 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 		rfm22bstatus.DeviceID = PIOS_RFM22B_DeviceID(pios_rfm22b_id);
 		rfm22bstatus.BoardRevision = PIOS_RFM22B_ModuleVersion(pios_rfm22b_id);
 
-		/* Configure the radio com interface */
-		uint8_t *rx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_RFM22B_RF_RX_BUF_LEN);
-		uint8_t *tx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_RFM22B_RF_TX_BUF_LEN);
-
-		PIOS_Assert(rx_buffer);
-		PIOS_Assert(tx_buffer);
-		if (PIOS_COM_Init(&pios_com_rf_id, &pios_rfm22b_com_driver, pios_rfm22b_id,
-					rx_buffer, PIOS_COM_RFM22B_RF_RX_BUF_LEN,
-					tx_buffer, PIOS_COM_RFM22B_RF_TX_BUF_LEN)) {
-			PIOS_Assert(0);
+		switch(port_type) {
+		case HWSHARED_PORTTYPES_TELEMETRY:
+			PIOS_HAL_ConfigureUsart(pios_rfm22b_id, PIOS_COM_RFM22B_RF_RX_BUF_LEN, PIOS_COM_RFM22B_RF_TX_BUF_LEN, &pios_rfm22b_com_driver, &port_driver_id);
+			target = &pios_com_telem_serial_id;
+			break;
+		case HWSHARED_PORTTYPES_DEBUGCONSOLE:
+		#if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
+			PIOS_HAL_ConfigureUsart(usart_port_cfg, 0, PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN, com_driver, &port_driver_id);
+			target = &pios_com_debug_id;
+		#endif  /* PIOS_INCLUDE_DEBUG_CONSOLE */
+			break;
 		}
 
+		PIOS_HAL_ConfigureCom(pios_rfm22b_id, PIOS_COM_RFM22B_RF_RX_BUF_LEN, PIOS_COM_RFM22B_RF_TX_BUF_LEN,
+		                      &pios_rfm22b_com_driver, &pios_com_rf_id);
+	
 #ifndef PIOS_NO_TELEM_ON_RF
 		/* Set Telemetry to use RFM22b if no other telemetry is configured (USB always overrides anyway) */
 		if (!pios_com_telem_serial_id) {

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -36,7 +36,7 @@ extern uintptr_t pios_rcvr_group_map[];
 
 #endif
 
-void PIOS_HAL_ConfigureCom(const struct pios_usart_cfg *usart_port_cfg,
+void PIOS_HAL_ConfigureUsart(const struct pios_usart_cfg *usart_port_cfg,
 		size_t rx_buf_len, size_t tx_buf_len,
 		const struct pios_com_driver *com_driver, uintptr_t *com_id);
 
@@ -76,6 +76,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 		const struct pios_openlrs_cfg *openlrs_cfg,
 		const struct pios_rfm22b_cfg *rfm22b_cfg,
 		uint8_t min_chan, uint8_t max_chan, uint32_t coord_id,
+		HwSharedPortTypesOptions port_type,
 		int status_inst);
 #endif /* PIOS_INCLUDE_RFM22B */
 

--- a/flight/PiOS/inc/pios_wdg.h
+++ b/flight/PiOS/inc/pios_wdg.h
@@ -40,7 +40,6 @@
 #define PIOS_WDG_SENSORS         0x0010
 #define PIOS_WDG_AUTOTUNE        0x0020
 #define PIOS_WDG_PPMINPUT        0x0040
-#define PIOS_WDG_SERIALRX        0x0080
 #define PIOS_WDG_TELEMETRYTX     0x0100
 #define PIOS_WDG_TELEMETRYRX     0x0200
 

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -365,12 +365,12 @@ void PIOS_Board_Init(void) {
 	switch (hw_mainport) {
 	case HWNAZE_MAINPORT_TELEMETRY:
 #if defined(PIOS_INCLUDE_TELEMETRY)
-		PIOS_HAL_ConfigureCom(&pios_usart_main_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_telem_serial_id);
+		PIOS_HAL_ConfigureUsart(&pios_usart_main_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_telem_serial_id);
 #endif /* PIOS_INCLUDE_TELEMETRY */
 		break;
 	case HWNAZE_MAINPORT_MSP:
 #if defined(PIOS_INCLUDE_MSP_BRIDGE)
-		PIOS_HAL_ConfigureCom(&pios_usart_main_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_msp_id);
+		PIOS_HAL_ConfigureUsart(&pios_usart_main_cfg, PIOS_COM_TELEM_RF_RX_BUF_LEN, PIOS_COM_TELEM_RF_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_msp_id);
 #endif /* PIOS_INCLUDE_MSP_BRIDGE */
 		break;
 	}

--- a/flight/targets/pipxtreme/fw/Makefile
+++ b/flight/targets/pipxtreme/fw/Makefile
@@ -93,6 +93,7 @@ SRC += ${foreach MOD, ${MODULES} ${OPTMODULES}, ${wildcard ${OPMODULEDIR}/${MOD}
 SRC += ${OPMODULEDIR}/PipXtreme/pipxtrememod.c
 SRC += main.c
 SRC += pios_board.c
+SRC += $(FLIGHTLIB)/alarms.c
 SRC += $(OPUAVTALK)/uavtalk.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
 SRC += $(OPUAVOBJ)/eventdispatcher.c
@@ -120,6 +121,7 @@ SRC += $(OPUAVSYNTHDIR)/velocityactual.c
 endif
 
 ## PIOS Hardware (STM32F10x)
+SRC += $(PIOSSTM32F10X)/pios_iap.c
 SRC += $(PIOSSTM32F10X)/pios_sys.c
 SRC += $(PIOSSTM32F10X)/pios_led.c
 SRC += $(PIOSSTM32F10X)/pios_usart.c

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -193,7 +193,7 @@ void PIOS_Board_Init(void) {
 	    bdinfo->board_rev, hwTauLink.MaxRfPower,
 	    hwTauLink.MaxRfSpeed, hwTauLink.RfBand, NULL, rfm22b_cfg,
 	    hwTauLink.MinChannel, hwTauLink.MaxChannel,
-	    hwTauLink.CoordID, 0);
+	    hwTauLink.CoordID, HWSHARED_PORTTYPES_DISABLED, 0);
 
 	if (bdinfo->board_rev == TAULINK_VERSION_MODULE) {
 		// Configure the main serial port function
@@ -202,20 +202,7 @@ void PIOS_Board_Init(void) {
 		{
 			// Note: if the main port is also on telemetry the bluetooth
 			// port will take precedence
-			uintptr_t pios_usart2_id;
-			if (PIOS_USART_Init(&pios_usart2_id, &pios_usart_bluetooth_cfg)) {
-				PIOS_Assert(0);
-			}
-			uint8_t *rx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_RX_BUF_LEN);
-			uint8_t *tx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_TX_BUF_LEN);
-			PIOS_Assert(rx_buffer);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_telem_uart_bluetooth_id, &pios_usart_com_driver, pios_usart2_id,
-			                  rx_buffer, PIOS_COM_TELEM_RX_BUF_LEN,
-			                  tx_buffer, PIOS_COM_TELEM_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
-
+			PIOS_HAL_ConfigureUsart(&pios_usart_bluetooth_cfg, PIOS_COM_TELEM_RX_BUF_LEN, PIOS_COM_TELEM_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_telem_uart_bluetooth_id);
 			PIOS_COM_ChangeBaud(pios_com_telem_uart_bluetooth_id, 9600);
 
 			// Note this doesn't actually send until RTOS is running
@@ -234,19 +221,7 @@ void PIOS_Board_Init(void) {
 		{
 			// Note: if the main port is also on telemetry the bluetooth
 			// port will take precedence
-			uintptr_t pios_usart2_id;
-			if (PIOS_USART_Init(&pios_usart2_id, &pios_usart_bluetooth_cfg)) {
-				PIOS_Assert(0);
-			}
-			uint8_t *rx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_RX_BUF_LEN);
-			uint8_t *tx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_TX_BUF_LEN);
-			PIOS_Assert(rx_buffer);
-			PIOS_Assert(tx_buffer);
-			if (PIOS_COM_Init(&pios_com_telem_uart_bluetooth_id, &pios_usart_com_driver, pios_usart2_id,
-			                  rx_buffer, PIOS_COM_TELEM_RX_BUF_LEN,
-			                  tx_buffer, PIOS_COM_TELEM_TX_BUF_LEN)) {
-				PIOS_Assert(0);
-			}
+			PIOS_HAL_ConfigureUsart(&pios_usart_bluetooth_cfg, PIOS_COM_TELEM_RX_BUF_LEN, PIOS_COM_TELEM_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_telem_uart_bluetooth_id);
 
 			// Since we don't expose the ModuleSettings object from TauLink to the GCS
 			// we just map the baud rate from HwTauLink into this object

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -45,8 +45,6 @@ uintptr_t pios_uavo_settings_fs_id;
 
 #define PIOS_COM_TELEM_RX_BUF_LEN 256
 #define PIOS_COM_TELEM_TX_BUF_LEN 256
-#define PIOS_COM_RFM22B_RF_RX_BUF_LEN 256
-#define PIOS_COM_RFM22B_RF_TX_BUF_LEN 256
 #define PIOS_COM_FRSKYSPORT_TX_BUF_LEN 16
 
 /**

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -304,13 +304,13 @@ void PIOS_Board_Init(void) {
     }
     case HWTAULINK_PPMPORT_SPORT:
 #if defined(PIOS_INCLUDE_TARANIS_SPORT)
-        PIOS_HAL_ConfigureCom(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
+        PIOS_HAL_ConfigureUsart(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_TARANIS_SPORT */
         break;
     case HWTAULINK_PPMPORT_PPMSPORT:
     {
-#if defined(PIOS_INCLUDE_TARANIS_SPORT)
-        PIOS_HAL_ConfigureCom(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
+#if defined(PIOS_HAL_ConfigureUsart)
+        PIOS_HAL_ConfigureUsart(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_TARANIS_SPORT */
 #if defined(PIOS_INCLUDE_PPM)
         /* PPM input is configured on the coordinator modem and sent in the RFM22BReceiver UAVO. */

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -133,6 +133,18 @@ void PIOS_Board_Init(void) {
 	HwTauLinkData hwTauLink;
 	HwTauLinkGet(&hwTauLink);
 
+	/* IAP System Setup */
+	PIOS_IAP_Init();
+	uint16_t boot_count = PIOS_IAP_ReadBootCount();
+	if (boot_count < 3) {
+		PIOS_IAP_WriteBootCount(++boot_count);
+		AlarmsClear(SYSTEMALARMS_ALARM_BOOTFAULT);
+	} else {
+		/* Too many failed boot attempts, force hw config to defaults */
+		HwTauLinkSetDefaults(HwTauLinkHandle(), 0);
+		AlarmsSet(SYSTEMALARMS_ALARM_BOOTFAULT, SYSTEMALARMS_ALARM_CRITICAL);
+	}
+
 	/*Initialize the USB device */
 	uintptr_t pios_usb_id;
 	PIOS_USB_Init(&pios_usb_id, &pios_usb_main_cfg);

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -34,6 +34,7 @@
 #include <modulesettings.h>
 #include <hwtaulink.h>
 #include <pios_hal.h>
+#include <pios_iap.h>
 #include <rfm22bstatus.h>
 
 uintptr_t pios_com_telem_uart_bluetooth_id;
@@ -79,6 +80,10 @@ void PIOS_Board_Init(void) {
 	/* Initialize UAVObject libraries */
 	EventDispatcherInitialize();
 	UAVObjInitialize();
+
+	/* Initialize the alarms library. Reads RCC reset flags */
+	AlarmsInitialize();
+	PIOS_RESET_Clear(); // Clear the RCC reset flags after use.
 
 	/* Set up the SPI interface to the rfm22b */
 	if (PIOS_SPI_Init(&pios_spi_rfm22b_id, &pios_spi_rfm22b_cfg)) {

--- a/flight/targets/pipxtreme/fw/pios_config.h
+++ b/flight/targets/pipxtreme/fw/pios_config.h
@@ -102,7 +102,6 @@
 
 #define PIOS_INCLUDE_DEBUG_CONSOLE
 
-#define PIOS_NO_TELEM_ON_RF
 #define PIOS_NO_ALARMS
 
 /* Turn on debugging signals on the telemetry port */

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -7,7 +7,7 @@
  *
  * @file       pios_board.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2016
  * @brief      The board specific initialization routines
  * @see        The GNU Public License (GPL) Version 3
  * 
@@ -378,7 +378,8 @@ void PIOS_Board_Init(void) {
 			hwRevoMini.MaxRfPower, hwRevoMini.MaxRfSpeed,
 			hwRevoMini.RfBand,
 			openlrs_cfg, rfm22b_cfg, hwRevoMini.MinChannel,
-			hwRevoMini.MaxChannel, hwRevoMini.CoordID, 1);
+			hwRevoMini.MaxChannel, hwRevoMini.CoordID,
+			hwRevoMini.RadioPort, 1);
 #endif /* PIOS_INCLUDE_RFM22B */
 
 	/* Configure the receiver port*/

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -619,7 +619,7 @@ void PIOS_Board_Init(void) {
 			hwSparky2.RfBand,
 			openlrs_cfg, rfm22b_cfg,
 			hwSparky2.MinChannel, hwSparky2.MaxChannel,
-			hwSparky2.CoordID, 1);
+			hwSparky2.CoordID, hwSparky2.RadioPort, 1);
 
 #endif /* PIOS_INCLUDE_RFM22B */
 

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -63,6 +63,15 @@
 		<!--  2. Telem+PPM - telemetry and ppm -->
 		<!--  3. PPM - PPM only (one way connection) -->
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled"/>
+		<!-- what to map the serial port component to -->
+		<field name="RadioPort" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Telemetry">
+			<options>
+				<option>Disabled</option>
+				<option>Telemetry</option>
+				<option>DebugConsole</option>
+				<option>PicoC</option>
+			</options>
+		</field>
 		<!-- ID of the coordinator to allow binding to. 0 indicates allow all connections -->
 		<field name="CoordID" units="hex" type="uint32" elements="1" defaultvalue="0"/>
 

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -65,6 +65,16 @@
 		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled"/>
+		<!-- what to map the serial port component to -->
+		<field name="RadioPort" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Telemetry">
+			<options>
+				<option>Disabled</option>
+				<option>Telemetry</option>
+				<option>DebugConsole</option>
+				<option>PicoC</option>
+				<option>OpenLog</option>
+			</options>
+		</field>
 		<!-- ID of the coordinator to allow binding to. 0 indicates allow all connections -->
 		<field name="CoordID" units="hex" type="uint32" elements="1" defaultvalue="0"/>
 

--- a/shared/uavobjectdefinition/radiocombridgestats.xml
+++ b/shared/uavobjectdefinition/radiocombridgestats.xml
@@ -4,7 +4,6 @@
 
         <field name="TelemetryTxBytes" units="bytes" type="uint32" elements="1"/>
         <field name="TelemetryTxFailures" units="count" type="uint32" elements="1"/>
-        <field name="TelemetryTxRetries" units="count" type="uint32" elements="1"/>
         <field name="TelemetryRxBytes" units="bytes" type="uint32" elements="1"/>
         <field name="TelemetryRxFailures" units="count" type="uint32" elements="1"/>
         <field name="TelemetryRxSyncErrors" units="count" type="uint32" elements="1"/>
@@ -12,7 +11,6 @@
         
         <field name="RadioTxBytes" units="bytes" type="uint32" elements="1"/>
         <field name="RadioTxFailures" units="count" type="uint32" elements="1"/>
-        <field name="RadioTxRetries" units="count" type="uint32" elements="1"/>
         <field name="RadioRxBytes" units="bytes" type="uint32" elements="1"/>
         <field name="RadioRxFailures" units="count" type="uint32" elements="1"/>
         <field name="RadioRxSyncErrors" units="count" type="uint32" elements="1"/>


### PR DESCRIPTION
This makes the PIOS_COM assignment for the RFM22B module on
flight controllers programmable. This allows sending debug information
or other through it to a serial port. You can still use the PPM channels
for control.

Fixes #2201 
