### PR TITLE
Mapcontrol relative path fixes

### DIFF
--- a/ground/gcs/src/libs/tlmapcontrol/core/tlmaps.h
+++ b/ground/gcs/src/libs/tlmapcontrol/core/tlmaps.h
@@ -42,12 +42,12 @@
 #include "urlfactory.h"
 #include "diagnostics.h"
 
-#include "../internals/pureprojection.h"
-#include "../internals/projections/lks94projection.h"
-#include "../internals/projections/mercatorprojection.h"
-#include "../internals/projections/mercatorprojectionyandex.h"
-#include "../internals/projections/platecarreeprojection.h"
-#include "../internals/projections/platecarreeprojectionpergo.h"
+#include "internals/pureprojection.h"
+#include "internals/projections/lks94projection.h"
+#include "internals/projections/mercatorprojection.h"
+#include "internals/projections/mercatorprojectionyandex.h"
+#include "internals/projections/platecarreeprojection.h"
+#include "internals/projections/platecarreeprojectionpergo.h"
 
 namespace core {
     class TLMaps: public MemoryCache,public AllLayersOfType,public UrlFactory

--- a/ground/gcs/src/libs/tlmapcontrol/core/urlfactory.h
+++ b/ground/gcs/src/libs/tlmapcontrol/core/urlfactory.h
@@ -37,7 +37,7 @@
 #include <QCoreApplication>
 #include "providerstrings.h"
 #include "pureimagecache.h"
-#include "../internals/pointlatlng.h"
+#include "internals/pointlatlng.h"
 #include "geodecoderstatus.h"
 #include <QTime>
 #include "cache.h"

--- a/ground/gcs/src/libs/tlmapcontrol/internals/core.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/core.h
@@ -32,10 +32,10 @@
 
 #include "pointlatlng.h"
 #include "mousewheelzoomtype.h"
-#include "../core/size.h"
-#include "../core/point.h"
+#include "core/size.h"
+#include "core/point.h"
 
-#include "../core/maptype.h"
+#include "core/maptype.h"
 #include "rectangle.h"
 #include "QThreadPool"
 #include "tilematrix.h"
@@ -48,16 +48,16 @@
 #include "projections/mercatorprojectionyandex.h"
 #include "projections/platecarreeprojection.h"
 #include "projections/platecarreeprojectionpergo.h"
-#include "../core/geodecoderstatus.h"
-#include "../core/tlmaps.h"
-#include "../core/diagnostics.h"
+#include "core/geodecoderstatus.h"
+#include "core/tlmaps.h"
+#include "core/diagnostics.h"
 
 #include <QSemaphore>
 #include <QThread>
 #include <QDateTime>
 
 #include <QObject>
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/internals/loadtask.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/loadtask.h
@@ -29,7 +29,7 @@
 #define LOADTASK_H
 
 #include <QString>
-#include "../core/point.h"
+#include "core/point.h"
 
 using namespace core;
 namespace internals

--- a/ground/gcs/src/libs/tlmapcontrol/internals/pointlatlng.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/pointlatlng.h
@@ -31,7 +31,7 @@
 #include <QHash>
 #include <QString>
 #include "sizelatlng.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace internals {
 struct TLMAPWIDGET_EXPORT PointLatLng

--- a/ground/gcs/src/libs/tlmapcontrol/internals/projections/lks94projection.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/projections/lks94projection.h
@@ -29,7 +29,7 @@
 #define LKS94PROJECTION_H
 #include <QVector>
 #include "cmath"
-#include "../pureprojection.h"
+#include "internals/pureprojection.h"
 
 
 namespace projections {

--- a/ground/gcs/src/libs/tlmapcontrol/internals/projections/mercatorprojection.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/projections/mercatorprojection.h
@@ -27,7 +27,7 @@
 */
 #ifndef MERCATORPROJECTION_H
 #define MERCATORPROJECTION_H
-#include "../pureprojection.h"
+#include "internals/pureprojection.h"
 
 
 namespace projections {

--- a/ground/gcs/src/libs/tlmapcontrol/internals/projections/mercatorprojectionyandex.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/projections/mercatorprojectionyandex.h
@@ -28,7 +28,7 @@
 #ifndef MERCATORPROJECTIONYANDEX_H
 #define MERCATORPROJECTIONYANDEX_H
 
-#include "../pureprojection.h"
+#include "internals/pureprojection.h"
 
  
 namespace projections {

--- a/ground/gcs/src/libs/tlmapcontrol/internals/projections/platecarreeprojection.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/projections/platecarreeprojection.h
@@ -28,7 +28,7 @@
 #ifndef PLATECARREEPROJECTION_H
 #define PLATECARREEPROJECTION_H
 
-#include "../pureprojection.h"
+#include "internals/pureprojection.h"
 
  
 namespace projections {

--- a/ground/gcs/src/libs/tlmapcontrol/internals/projections/platecarreeprojectionpergo.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/projections/platecarreeprojectionpergo.h
@@ -28,7 +28,7 @@
 #ifndef PLATECARREEPROJECTIONPERGO_H
 #define PLATECARREEPROJECTIONPERGO_H
 
-#include "../pureprojection.h"
+#include "internals/pureprojection.h"
 
  
 namespace projections {

--- a/ground/gcs/src/libs/tlmapcontrol/internals/pureprojection.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/pureprojection.h
@@ -28,9 +28,9 @@
 #ifndef PUREPROJECTION_H
 #define PUREPROJECTION_H
 
-#include "../core/size.h"
-#include "../core/point.h"
-#include "../internals/pointlatlng.h"
+#include "core/size.h"
+#include "core/point.h"
+#include "internals/pointlatlng.h"
 #include "pointlatlng.h"
 #include "cmath"
 #include "rectlatlng.h"

--- a/ground/gcs/src/libs/tlmapcontrol/internals/rectangle.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/rectangle.h
@@ -27,7 +27,7 @@
 */
 #ifndef RECTANGLE_H
 #define RECTANGLE_H
-#include "../core/size.h"
+#include "core/size.h"
 #include "math.h"
 using namespace core;
 namespace internals

--- a/ground/gcs/src/libs/tlmapcontrol/internals/rectlatlng.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/rectlatlng.h
@@ -28,8 +28,7 @@
 #ifndef RECTLATLNG_H
 #define RECTLATLNG_H
 
-//#include "pointlatlng.h"
-#include "../internals/pointlatlng.h"
+#include "internals/pointlatlng.h"
 #include "math.h"
 #include <QString>
 #include "sizelatlng.h"

--- a/ground/gcs/src/libs/tlmapcontrol/internals/tile.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/tile.h
@@ -30,7 +30,7 @@
 
 #include "QList"
 #include <QImage>
-#include "../core/point.h"
+#include "core/point.h"
 #include <QMutex>
 #include <QDebug>
 #include "debugheader.h"

--- a/ground/gcs/src/libs/tlmapcontrol/internals/tilematrix.h
+++ b/ground/gcs/src/libs/tlmapcontrol/internals/tilematrix.h
@@ -31,7 +31,7 @@
 #include <QHash>
 #include "tile.h"
 #include <QList>
-#include "../core/point.h"
+#include "core/point.h"
 #include "debugheader.h"
 #include <QBuffer>
 namespace internals {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/configuration.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/configuration.h
@@ -33,10 +33,10 @@
 #include <QPen>
 #include <QString>
 #include <QFont>
-#include "../core/tlmaps.h"
-#include "../core/accessmode.h"
-#include "../core/cache.h"
-#include "../core/corecommon.h"
+#include "core/tlmaps.h"
+#include "core/accessmode.h"
+#include "core/cache.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/gpsitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/gpsitem.h
@@ -35,7 +35,7 @@
 #include <QtSvg/QSvgRenderer>
 #include "trailitem.h"
 #include "traillineitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/homeitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/homeitem.h
@@ -30,7 +30,7 @@
 
 
 #include "mappointitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapcircle.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapcircle.h
@@ -29,7 +29,7 @@
 #define MAPCIRCLE_H
 
 #include "mappointitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapgraphicitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapgraphicitem.h
@@ -29,8 +29,8 @@
 #define MAPGRAPHICITEM_H
 
 #include <QGraphicsItem>
-#include "../internals/core.h"
-#include "../core/diagnostics.h"
+#include "internals/core.h"
+#include "core/diagnostics.h"
 #include "configuration.h"
 #include <QtGui>
 #include <QTransform>
@@ -38,7 +38,7 @@
 #include <QBrush>
 #include <QFont>
 #include <QObject>
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapline.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapline.h
@@ -30,7 +30,7 @@
 
 #include "mapgraphicitem.h"
 #include "mappointitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mappointitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mappointitem.h
@@ -34,10 +34,10 @@
 #include <QPainter>
 #include <QPoint>
 
-#include "../internals/pointlatlng.h"
+#include "internals/pointlatlng.h"
 #include "mapgraphicitem.h"
 #include "physical_constants.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapripper.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapripper.h
@@ -29,11 +29,11 @@
 #define MAPRIPPER_H
 
 #include <QThread>
-#include "../internals/core.h"
+#include "internals/core.h"
 #include "mapripform.h"
 #include <QObject>
 #include <QMessageBox>
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/tlmapwidget.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/tlmapwidget.h
@@ -28,11 +28,11 @@
 #ifndef TLMAPWIDGET_H
 #define TLMAPWIDGET_H
 
-#include "../mapwidget/mapgraphicitem.h"
-#include "../core/geodecoderstatus.h"
-#include "../core/maptype.h"
-#include "../core/languagetype.h"
-#include "../core/diagnostics.h"
+#include "mapwidget/mapgraphicitem.h"
+#include "core/geodecoderstatus.h"
+#include "core/maptype.h"
+#include "core/languagetype.h"
+#include "core/diagnostics.h"
 #include "configuration.h"
 #include <QObject>
 #include "waypointitem.h"
@@ -45,7 +45,7 @@
 #include "mapcircle.h"
 #include "waypointcurve.h"
 #include "waypointitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 #include <QGraphicsView>
 
 namespace mapcontrol

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/trailitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/trailitem.h
@@ -31,10 +31,10 @@
 #include <QGraphicsItem>
 #include <QPainter>
 #include <QLabel>
-#include "../internals/pointlatlng.h"
+#include "internals/pointlatlng.h"
 #include <QObject>
 #include "mapgraphicitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/traillineitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/traillineitem.h
@@ -31,10 +31,10 @@
 #include <QGraphicsItem>
 #include <QPainter>
 #include <QLabel>
-#include "../internals/pointlatlng.h"
+#include "internals/pointlatlng.h"
 #include <QObject>
 #include "mapgraphicitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/uavitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/uavitem.h
@@ -35,7 +35,7 @@
 #include "uavtrailtype.h"
 #include "trailitem.h"
 #include "traillineitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/uavmapfollowtype.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/uavmapfollowtype.h
@@ -32,7 +32,7 @@
 #include <QMetaObject>
 #include <QMetaEnum>
 #include <QStringList>
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol {
     class TLMAPWIDGET_EXPORT UAVMapFollowType:public QObject

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/uavtrailtype.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/uavtrailtype.h
@@ -32,7 +32,7 @@
 #include <QMetaObject>
 #include <QMetaEnum>
 #include <QStringList>
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol {
     class TLMAPWIDGET_EXPORT UAVTrailType:public QObject

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/waypointcurve.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/waypointcurve.h
@@ -28,7 +28,7 @@
 #define WAYPOINTCURVE_H
 
 #include "waypointitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/waypointitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/waypointitem.h
@@ -29,7 +29,7 @@
 #define WAYPOINTITEM_H
 
 #include "mappointitem.h"
-#include "../core/corecommon.h"
+#include "core/corecommon.h"
 
 namespace mapcontrol
 {

--- a/ground/gcs/src/libs/tlmapcontrol/tlmapcontrol.pri
+++ b/ground/gcs/src/libs/tlmapcontrol/tlmapcontrol.pri
@@ -1,1 +1,2 @@
 LIBS *= -l$$qtLibraryName(tlmapwidget)
+INCLUDEPATH += $$PWD/ \

--- a/ground/gcs/src/libs/tlmapcontrol/tlmapcontrol.pro
+++ b/ground/gcs/src/libs/tlmapcontrol/tlmapcontrol.pro
@@ -53,7 +53,8 @@ SOURCES += mapwidget/mapgraphicitem.cpp \
 # order of linking matters
 include(../utils/utils.pri)
 
-HEADERS += mapwidget/mapgraphicitem.h \
+HEADERS += tlmapcontrol.h \
+    mapwidget/mapgraphicitem.h \
     mapwidget/configuration.h \
     mapwidget/mappointitem.h \
     mapwidget/waypointitem.h \
@@ -107,7 +108,7 @@ HEADERS += mapwidget/mapgraphicitem.h \
     internals/projections/mercatorprojectionyandex.h \
     internals/projections/platecarreeprojection.h \
     internals/projections/platecarreeprojectionpergo.h \
-    core/corecommon.h
+    core/corecommon.h \
 
 QT += network
 QT += sql
@@ -119,4 +120,6 @@ RESOURCES += mapwidget/mapresources.qrc
 
 FORMS += \
     mapwidget/mapripform.ui
+
+OTHER_FILES += README \
 


### PR DESCRIPTION
Using relative directories was linked to problems on a Windows build server. There doesn't seem to be any advantage to using relative directories since the directories themselves are already along the include
path. In any case, using strings of relative paths led to obnoxiously long absolute paths full of things like `plugins/../plugins/../ground/../`, etc...

This change resolves the problem (and hopefully results in nicer code).
