### PR TITLE
OPMap: Rename saveConfig to saveMapConfig

### DIFF
--- a/ground/gcs/src/plugins/opmap/opmapgadget.cpp
+++ b/ground/gcs/src/plugins/opmap/opmapgadget.cpp
@@ -47,7 +47,7 @@ void OPMapGadget::saveDefaultLocation(double lng,double lat,double zoom)
         m_config->setLatitude(lat);
         m_config->setLongitude(lng);
         m_config->setZoom(zoom);
-        m_config->saveConfig();
+        m_config->saveMapConfig();
     }
 }
 

--- a/ground/gcs/src/plugins/opmap/opmapgadgetconfiguration.cpp
+++ b/ground/gcs/src/plugins/opmap/opmapgadgetconfiguration.cpp
@@ -118,7 +118,7 @@ IUAVGadgetConfiguration * OPMapGadgetConfiguration::clone()
 
     return m;
 }
-void OPMapGadgetConfiguration::saveConfig() const {
+void OPMapGadgetConfiguration::saveMapConfig() const {
     if(!m_settings)
         return;
    m_settings->setValue("mapProvider", m_mapProvider);

--- a/ground/gcs/src/plugins/opmap/opmapgadgetconfiguration.h
+++ b/ground/gcs/src/plugins/opmap/opmapgadgetconfiguration.h
@@ -69,7 +69,7 @@ public:
     QString uavSymbol() const { return m_uavSymbol; }
     int maxUpdateRate() const { return m_maxUpdateRate; }
     qreal opacity() const { return m_opacity; }
-    void saveConfig() const;
+    void saveMapConfig() const;
 
     QString getUserImageLocation(){return m_userImageLocation;}
     float getUserImageHorizontalScale(){return m_userImageHorizontalScale;}


### PR DESCRIPTION
The compiler was complaining that saveConfig() was shadowing saveConfig(QSettings*). This simply makes it explicit and helps reduce namespace clutter.

To be determined why both `saveMapConfig()` and `saveConfig(QSettings *)` do almost identical things.
