### PR TITLE
WIP: Fix DEBUG=YES compiling (also -O0 compiling)

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -718,10 +718,11 @@ static MixerSettingsMixer1TypeOptions get_mixer_type(int idx)
 	case 9:
 		return mixerSettings.Mixer10Type;
 		break;
-	default:
-		// We can never get here unless there are mixer channels not handled in the above. Fail out.
-		PIOS_Assert(0);
 	}
+
+	// We can never get here unless there are mixer channels not handled in the above. Fail out.
+	PIOS_Assert(0);
+	return MIXERSETTINGS_MIXER1TYPE_DISABLED;
 }
 
 static typeof(mixerSettings.Mixer1Vector) *get_mixer_vec(int idx)
@@ -757,10 +758,11 @@ static typeof(mixerSettings.Mixer1Vector) *get_mixer_vec(int idx)
 	case 9:
 		return &mixerSettings.Mixer10Vector;
 		break;
-	default:
-		// We can never get here unless there are mixer channels not handled in the above. Fail out.
-		PIOS_Assert(0);
 	}
+
+	// We can never get here unless there are mixer channels not handled in the above. Fail out.
+	PIOS_Assert(0);
+	return (typeof(mixerSettings.Mixer1Vector) *) NULL;
 }
 
 #define OUTPUT_MODE_ASSUMPTIONS ( ( (int) PWM_MODE_1MHZ == ACTUATORSETTINGS_TIMERPWMRESOLUTION_1MHZ ) && \


### PR DESCRIPTION
As noticed in #2206, the compiler does no optimizations and thus cannot determine many things. For instance, even when a function will never get to the end, without optimizations the compiler does not know this and the result is compile failure due to reaching the end of a non-void function.

The current failure I am trying to understand is why `cm3_fault_handlers.c` fails, with

```
CC          flight/PiOS/Common/Libraries/Debug/cm3_fault_handlers.c
/Users/kenz/Documents/TauLabs/tools/gcc-arm-none-eabi-4_9-2015q1/bin/arm-none-eabi-gcc -c -mthumb -O0 -DGENERAL_COV -finstrument-functions -ffixed-r10 -mcpu=cortex-m4 -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DDIAGNOSTICS -DDIAG_TASKS -DMEM_SIZE=1024000000 -gdwarf-2 -ffast-math -mcpu=cortex-m4 -DUSE_STDPERIPH_DRIVER -DARM_MATH_CM4 -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1 -DUNALIGNED_SUPPORT_DISABLE -DSTM32F40_41xxx -DHSE_VALUE=8000000 -DSYSCLK_FREQ=168000000 -DUSE_STDPERIPH_DRIVER -DUSE_STM32F4xx_RM -DCORTEX_VTOR_INIT='(0x08020000   - 0x08000000  )'  -DMODULE_Sensors_BUILTIN   -DMODULE_Attitude_BUILTIN   -DMODULE_ManualControl_BUILTIN   -DMODULE_Stabilization_BUILTIN   -DMODULE_Actuator_BUILTIN   -DMODULE_FirmwareIAP_BUILTIN   -DMODULE_Telemetry_BUILTIN   -DMODULE_DacBeepCodes_BUILTIN  -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32F4xx -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/GPIOv2 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/I2Cv1 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/OTGv1 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/RTCv2 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/SPIv1 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/TIMv1 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32/USARTv1 -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/hal/include -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/ports/common/ARMCMx/CMSIS/include -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/ports/common/ARMCMx -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/ARMCMx -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/ARMCMx/STM32F4xx -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/ChibiOS/os/kernel/include -I/Users/kenz/Documents/TauLabs/flight/Libraries/CMSIS3/DSP_Lib/Include -I/Users/kenz/Documents/TauLabs/flight/PiOS/STM32F4xx//inc -I/Users/kenz/Documents/TauLabs/flight/PiOS/STM32F4xx//Libraries/STM32F4xx_StdPeriph_Driver/inc -I/Users/kenz/Documents/TauLabs/flight/PiOS/STM32F4xx//Libraries/STM32_USB_OTG_Driver/inc -I/Users/kenz/Documents/TauLabs/flight/PiOS/STM32F4xx//Libraries/STM32_USB_Device_Library/Core/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Sensors/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Attitude/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/ManualControl/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Stabilization/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Actuator/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/FirmwareIAP/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Telemetry/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/DacBeepCodes/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/GPS/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/AltitudeHold/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/PathPlanner/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/VtolPathFollower/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/FixedWingPathFollower/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/GroundPathFollower/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/CameraStab/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Autotune/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/TxPID/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Battery/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/ComUsbBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/VibrationAnalysis/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVOMavlinkBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVOMSPBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVOLighttelemetryBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVORelay/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Airspeed/revolution/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVOHoTTBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVOFrSKYSensorHubBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/UAVOFrSKYSPortBridge/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/PicoC/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/Logging/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/FlightStats/inc -I/Users/kenz/Documents/TauLabs/flight/Modules/System/inc -I/Users/kenz/Documents/TauLabs/shared/api -I/Users/kenz/Documents/TauLabs/flight/PiOS -I/Users/kenz/Documents/TauLabs/flight/PiOS/inc -I/Users/kenz/Documents/TauLabs/flight/UAVTalk -I/Users/kenz/Documents/TauLabs/flight/UAVTalk/inc -I/Users/kenz/Documents/TauLabs/flight/UAVObjects -I/Users/kenz/Documents/TauLabs/flight/UAVObjects/inc -I/Users/kenz/Documents/TauLabs/flight/Libraries/inc -I/Users/kenz/Documents/TauLabs/flight/Libraries/math -I/Users/kenz/Documents/TauLabs/flight/Libraries/rscode -I/Users/kenz/Documents/TauLabs/flight/PiOS/STM32F4xx -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common -I/Users/kenz/Documents/TauLabs/flight/targets/sparky2/board-info -I/Users/kenz/Documents/TauLabs/flight/PiOS/STM32F4xx/Libraries/STM32F4xx_StdPeriph_Driver/inc -I/Users/kenz/Documents/TauLabs/build/uavobject-synthetics/flight -I/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/Debug/inc -I/Users/kenz/Documents/TauLabs/flight/Libraries/mavlink/v1.0/common -I. -mapcs-frame -fomit-frame-pointer -ffunction-sections -fdata-sections -Wdouble-promotion -Wall -Werror -Wa,-adhlns=/Users/kenz/Documents/TauLabs/build/fw_sparky2/cm3_fault_handlers.lst -MD -MP -MF /Users/kenz/Documents/TauLabs/build/fw_sparky2/dep/cm3_fault_handlers.o.d -DUAVOBJ_INIT_acceldesired  -DUAVOBJ_INIT_flightstats  -DUAVOBJ_INIT_flightstatssettings  -DUAVOBJ_INIT_geofencesettings  -DUAVOBJ_INIT_groundpathfollowersettings  -DUAVOBJ_INIT_loggingsettings  -DUAVOBJ_INIT_loggingstats  -DUAVOBJ_INIT_rfm22breceiver  -DUAVOBJ_INIT_rfm22bstatus  -DUAVOBJ_INIT_openlrs  -DUAVOBJ_INIT_openlrsstatus  -DUAVOBJ_INIT_hwsparky2  -DUAVOBJ_INIT_altitudeholdstate  -DUAVOBJ_INIT_hottsettings  -DUAVOBJ_INIT_picocsettings  -DUAVOBJ_INIT_picocstatus  -DUAVOBJ_INIT_accels  -DUAVOBJ_INIT_firmwareiapobj  -DUAVOBJ_INIT_flightstatus  -DUAVOBJ_INIT_flighttelemetrystats  -DUAVOBJ_INIT_gcsreceiver  -DUAVOBJ_INIT_gcstelemetrystats  -DUAVOBJ_INIT_modulesettings  -DUAVOBJ_INIT_objectpersistence  -DUAVOBJ_INIT_receiveractivity  -DUAVOBJ_INIT_sessionmanaging  -DUAVOBJ_INIT_systemalarms  -DUAVOBJ_INIT_systemsettings  -DUAVOBJ_INIT_systemstats  -DUAVOBJ_INIT_taskinfo  -DUAVOBJ_INIT_watchdogstatus  -DUAVOBJ_INIT_accessorydesired  -DUAVOBJ_INIT_actuatorcommand  -DUAVOBJ_INIT_actuatordesired  -DUAVOBJ_INIT_actuatorsettings  -DUAVOBJ_INIT_airspeedactual  -DUAVOBJ_INIT_attitudeactual  -DUAVOBJ_INIT_attitudesettings  -DUAVOBJ_INIT_baroaltitude  -DUAVOBJ_INIT_cameradesired  -DUAVOBJ_INIT_camerastabsettings  -DUAVOBJ_INIT_fixedwingairspeeds  -DUAVOBJ_INIT_fixedwingpathfollowerstatus  -DUAVOBJ_INIT_flightbatterysettings  -DUAVOBJ_INIT_flightbatterystate  -DUAVOBJ_INIT_gpsposition  -DUAVOBJ_INIT_gpsvelocity  -DUAVOBJ_INIT_gyros  -DUAVOBJ_INIT_homelocation  -DUAVOBJ_INIT_manualcontrolcommand  -DUAVOBJ_INIT_manualcontrolsettings  -DUAVOBJ_INIT_mixersettings  -DUAVOBJ_INIT_mixerstatus  -DUAVOBJ_INIT_mwratesettings  -DUAVOBJ_INIT_pathdesired  -DUAVOBJ_INIT_pathstatus  -DUAVOBJ_INIT_poilocation  -DUAVOBJ_INIT_positionactual  -DUAVOBJ_INIT_ratedesired  -DUAVOBJ_INIT_sensorsettings  -DUAVOBJ_INIT_stabilizationdesired  -DUAVOBJ_INIT_stabilizationsettings  -DUAVOBJ_INIT_systemident  -DUAVOBJ_INIT_tabletinfo  -DUAVOBJ_INIT_trimangles  -DUAVOBJ_INIT_trimanglessettings  -DUAVOBJ_INIT_txpidsettings  -DUAVOBJ_INIT_ubloxinfo  -DUAVOBJ_INIT_velocityactual  -DUAVOBJ_INIT_airspeedsettings  -DUAVOBJ_INIT_altitudeholddesired  -DUAVOBJ_INIT_altitudeholdsettings  -DUAVOBJ_INIT_baroairspeed  -DUAVOBJ_INIT_fixedwingpathfollowersettings  -DUAVOBJ_INIT_gpssatellites  -DUAVOBJ_INIT_gpstime  -DUAVOBJ_INIT_gyrosbias  -DUAVOBJ_INIT_inssettings  -DUAVOBJ_INIT_insstate  -DUAVOBJ_INIT_loitercommand  -DUAVOBJ_INIT_magbias  -DUAVOBJ_INIT_magnetometer  -DUAVOBJ_INIT_nedaccel  -DUAVOBJ_INIT_nedposition  -DUAVOBJ_INIT_pathplannersettings  -DUAVOBJ_INIT_rangefinderdistance  -DUAVOBJ_INIT_stateestimation  -DUAVOBJ_INIT_velocitydesired  -DUAVOBJ_INIT_vibrationanalysisoutput  -DUAVOBJ_INIT_vibrationanalysissettings  -DUAVOBJ_INIT_vtolpathfollowersettings  -DUAVOBJ_INIT_vtolpathfollowerstatus  -DUAVOBJ_INIT_waypoint  -DUAVOBJ_INIT_waypointactive  -std=gnu99  /Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/Debug/cm3_fault_handlers.c -o /Users/kenz/Documents/TauLabs/build/fw_sparky2/cm3_fault_handlers.o
/Users/kenz/Documents/TauLabs/flight/PiOS/Common/Libraries/Debug/cm3_fault_handlers.c:19:2: error: #error Unsupported CPU
 #error Unsupported CPU
```

The relevant block is 

```
#if defined(STM32F10X)
# include "stm32f10x.h"
#elif defined(STM32F2XX)
# include "stm32f2xx.h"
#elif defined(STM32F30X)
# include "stm32f30x.h"
#elif defined(STM32F4XX)
# include "stm32f4xx.h"
#else
#error Unsupported CPU
#endif
```

Since compiling Spark2 (`make DEBUG=YES spark2`) means that we should definitely have `STM32F4XX` defined, if anyone sees the immediate reason why this is failing I'd happily include that fix as well.
