### PR TITLE
Bootloader: Allow redefining of DFU wait period

### DIFF
--- a/flight/targets/bl/common/main.c
+++ b/flight/targets/bl/common/main.c
@@ -49,7 +49,13 @@ extern void PIOS_Board_Init(void);
 #define BL_DETECT_BREAK_TO_BL_TIMER MSEC_TO_USEC(500)
 #endif
 
-#define BL_WAIT_FOR_DFU_TIMER SEC_TO_USEC(6)
+// allow altering bootloader delay
+#ifndef DFU_PAUSE_DELAY_MS
+#define DFU_PAUSE_DELAY_MS 6000
+#endif
+
+#define BL_WAIT_FOR_DFU_TIMER MSEC_TO_USEC(DFU_PAUSE_DELAY_MS)
+
 #define BL_RECOVER_FROM_FAULT_TIMER SEC_TO_USEC(10)
 
 enum bl_states {


### PR DESCRIPTION
Previously, it was always 6 seconds. In practice, this doesn't seem always necessary. This allows redefining the delay for individual targets.

We find that a 2 second wait isn't causing us any issues and is a lot more tolerable than 6 seconds when debugging.
