### PR TITLE
OpenSSL: Don't fetch with curl when installer file already present

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -588,7 +588,8 @@ OPENSSL_DIR = $(TOOLS_DIR)/win32openssl
 # order-only prereq on directory existance:
 openssl_install : | $(DL_DIR) $(TOOLS_DIR)
 openssl_install: openssl_clean
-	$(V1) curl -L -k -o "$(DL_DIR)/$(OPENSSL_FILE)" "$(OPENSSL_URL)"
+	# Check if the file is already present. If so, run null command (:). If not, grab it with curl
+	$(V1) ! [ -f ./downloads/$(OPENSSL_FILE) ] && curl -L -k -o "$(DL_DIR)/$(OPENSSL_FILE)" "$(OPENSSL_URL)" || :
 	$(V1) ./downloads/$(OPENSSL_FILE) /DIR=$(OPENSSL_DIR) /silent
 else
 openssl_install:


### PR DESCRIPTION
This prevents Windows from downloading OpenSSL when it's already present in the downloads directory. The primary benefit from this is for creating a build server from scratch on each checkout. While it is arguably better to fetch the most recent OpenSSL each time, in reality this has proven to be troublesome as the OpenSSL guys pull the old versions down as soon as a new version is available. In addition, sometimes the curl freezes stalls the build.

As a way of covering the case where the file is no longer hosted online, we will have the build server periodically check that all tools make scripts work. This seems better than having the actual test build fail, since that returns erroneous information to the engineer.
