### PR TITLE
Teach GCS ADC combobox names

### DIFF
--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
@@ -136,3 +136,20 @@ int AQ32::queryMaxGyroRate()
         return 500;
     }
 }
+
+QStringList AQ32::getAdcNames()
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwAQ32 *hwAQ32 = HwAQ32::GetInstance(uavoManager);
+    Q_ASSERT(hwAQ32);
+    if (!hwAQ32)
+        return QStringList();
+
+    HwAQ32::DataFields settings = hwAQ32->getData();
+    if (settings.ADCInputs == HwAQ32::ADCINPUTS_ENABLED) {
+        return QStringList() << "BM" << "Analog AI2" << "Analog AI4";
+    }
+
+    return QStringList() << "Disabled" << "Disabled" << "Disabled";
+}

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  * @file       aq32.cpp
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  *
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.h
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.h
@@ -45,6 +45,7 @@ public:
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();
     virtual int queryMaxGyroRate();
+    virtual QStringList getAdcNames();
 
 };
 

--- a/ground/gcs/src/plugins/boards_naze/naze.cpp
+++ b/ground/gcs/src/plugins/boards_naze/naze.cpp
@@ -3,6 +3,7 @@
  *
  * @file       open_naze.cpp
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  *
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/boards_naze/naze.cpp
+++ b/ground/gcs/src/plugins/boards_naze/naze.cpp
@@ -215,3 +215,22 @@ enum Core::IBoardType::InputType Naze::getInputOnPort(int port_num)
         return INPUT_TYPE_UNKNOWN;
     }
 }
+
+QStringList Naze::getAdcNames()
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
+    Q_ASSERT(hwNaze);
+    if (!hwNaze)
+        return QStringList();
+
+    QStringList names = QStringList() << "Batt" << "ADC/ADC5 Pad";
+    HwNaze::DataFields settings = hwNaze->getData();
+    if (settings.RcvrPort == HwNaze::RCVRPORT_PPM || settings.RcvrPort == HwNaze::RCVRPORT_PPMSERIAL || settings.RcvrPort == HwNaze::RCVRPORT_SERIAL)
+        names << "RC In 2" << "RC In 8";
+    else
+        names << "Disabled" << "Disabled";
+
+    return names;
+}

--- a/ground/gcs/src/plugins/boards_naze/naze.h
+++ b/ground/gcs/src/plugins/boards_naze/naze.h
@@ -49,6 +49,7 @@ public:
     virtual bool setInputOnPort(enum InputType type, int port_num);
     virtual enum Core::IBoardType::InputType getInputOnPort(int port_num);
     virtual bool isUSBSupported() { return false; }
+    virtual QStringList getAdcNames();
 };
 
 

--- a/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
@@ -359,3 +359,8 @@ bool RevoMini::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
 
     return true;
 }
+
+QStringList RevoMini::getAdcNames()
+{
+    return QStringList() << "Pwr Sen Pin 3" << "Pwr Sen Pin 4";
+}

--- a/ground/gcs/src/plugins/boards_openpilot/revomini.h
+++ b/ground/gcs/src/plugins/boards_openpilot/revomini.h
@@ -87,6 +87,8 @@ public:
     virtual bool bindRadio(quint32 id, quint32 baud_rate, float rf_power,
                            Core::IBoardType::LinkMode linkMode, quint8 min, quint8 max);
 
+    virtual QStringList getAdcNames();
+
 private:
     UAVObjectUtilManager* uavoUtilManager;
 };

--- a/ground/gcs/src/plugins/boards_quantec/quanton.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.cpp
@@ -136,3 +136,24 @@ int Quanton::queryMaxGyroRate()
         return 500;
     }
 }
+
+QStringList Quanton::getAdcNames()
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwQuanton *hwQuanton = HwQuanton::GetInstance(uavoManager);
+    Q_ASSERT(hwQuanton);
+    if (!hwQuanton)
+        return QStringList();
+
+    HwQuanton::DataFields settings = hwQuanton->getData();
+    if (settings.RcvrPort == HwQuanton::RCVRPORT_OUTPUTSADC ||
+            settings.RcvrPort == HwQuanton::RCVRPORT_PPMADC ||
+            settings.RcvrPort == HwQuanton::RCVRPORT_PPMOUTPUTSADC ||
+            settings.RcvrPort == HwQuanton::RCVRPORT_PPMPWMADC ||
+            settings.RcvrPort == HwQuanton::RCVRPORT_PWMADC) {
+        return QStringList() << "IN 7" << "IN 8";
+    }
+
+    return QStringList() << "Disabled" << "Disabled";
+}

--- a/ground/gcs/src/plugins/boards_quantec/quanton.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.cpp
@@ -3,6 +3,7 @@
  *
  * @file       quanton.cpp
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  *
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/boards_quantec/quanton.h
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.h
@@ -45,6 +45,7 @@ public:
     virtual QPixmap getBoardPicture();
     virtual QString getHwUAVO();
     virtual int queryMaxGyroRate();
+    virtual QStringList getAdcNames();
 };
 
 

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
@@ -220,3 +220,24 @@ int Sparky::queryMaxGyroRate()
         return 500;
     }
 }
+
+QStringList Sparky::getAdcNames()
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwSparky *hwSparky = HwSparky::GetInstance(uavoManager);
+    Q_ASSERT(hwSparky);
+    if (!hwSparky)
+        return QStringList();
+
+    QStringList names;
+    HwSparky::DataFields settings = hwSparky->getData();
+    if (settings.OutPort == HwSparky::OUTPORT_PWM82ADC || settings.OutPort == HwSparky::OUTPORT_PWM7PWM_IN2ADC)
+        names << "PWM10" << "PWM9" << "Disabled";
+    else if (settings.OutPort == HwSparky::OUTPORT_PWM73ADC)
+        names << "PWM10" << "PWM9" << "PWM8";
+    else
+        names << "Disabled" << "Disabled" << "Disabled";
+
+    return names;
+}

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  * @file       sparky.cpp
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  *
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.h
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.h
@@ -68,6 +68,7 @@ public:
     virtual QString getConnectionDiagram() { return ":/taulabs/images/sparky-connection-diagram.svg"; }
 
     virtual int queryMaxGyroRate();
+    virtual QStringList getAdcNames();
 
 };
 

--- a/ground/gcs/src/plugins/boards_taulabs/sparky2.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky2.cpp
@@ -344,3 +344,8 @@ bool Sparky2::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
 
     return true;
 }
+
+QStringList Sparky2::getAdcNames()
+{
+    return QStringList() << "Analog CUR" << "Analog VOLT";
+}

--- a/ground/gcs/src/plugins/boards_taulabs/sparky2.h
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky2.h
@@ -86,6 +86,8 @@ public:
     virtual bool bindRadio(quint32 id, quint32 baud_rate, float rf_power,
                            Core::IBoardType::LinkMode linkMode, quint8 min, quint8 max);
 
+    virtual QStringList getAdcNames();
+
 private:
     UAVObjectUtilManager* uavoUtilManager;
 };

--- a/ground/gcs/src/plugins/boards_taulabs/sparkybgc.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparkybgc.cpp
@@ -228,4 +228,12 @@ QWidget * SparkyBGC::getBoardConfiguration(QWidget *parent, bool connected)
 {
     Q_UNUSED(connected);
     return new SparkyBgcConfiguration(parent);
+
+}
+
+
+QStringList SparkyBGC::getAdcNames()
+{
+    // TODO: Confirm with @peabody124 if this is correct
+    return QStringList() << "VBAT" << "Current" << "RSSI";
 }

--- a/ground/gcs/src/plugins/boards_taulabs/sparkybgc.h
+++ b/ground/gcs/src/plugins/boards_taulabs/sparkybgc.h
@@ -70,6 +70,7 @@ public:
     virtual int queryMaxGyroRate();
 
     QWidget *getBoardConfiguration(QWidget *parent, bool connected);
+    virtual QStringList getAdcNames();
 };
 
 

--- a/ground/gcs/src/plugins/boards_tbs/colibri.cpp
+++ b/ground/gcs/src/plugins/boards_tbs/colibri.cpp
@@ -238,3 +238,24 @@ enum Core::IBoardType::InputType Colibri::getInputOnPort(int port_num)
     }
 
 }
+
+QStringList Colibri::getAdcNames()
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    HwColibri *hwColibri = HwColibri::GetInstance(uavoManager);
+    Q_ASSERT(hwColibri);
+    if (!hwColibri)
+        return QStringList();
+
+    HwColibri::DataFields settings = hwColibri->getData();
+    if (settings.RcvrPort == HwColibri::RCVRPORT_OUTPUTSADC ||
+            settings.RcvrPort == HwColibri::RCVRPORT_PPMADC ||
+            settings.RcvrPort == HwColibri::RCVRPORT_PPMOUTPUTSADC ||
+            settings.RcvrPort == HwColibri::RCVRPORT_PPMPWMADC ||
+            settings.RcvrPort == HwColibri::RCVRPORT_PWMADC) {
+        return QStringList() << "IN 7" << "IN 8";
+    }
+
+    return QStringList() << "Disabled" << "Disabled";
+}

--- a/ground/gcs/src/plugins/boards_tbs/colibri.cpp
+++ b/ground/gcs/src/plugins/boards_tbs/colibri.cpp
@@ -3,6 +3,7 @@
  *
  * @file       colibri.cpp
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  *
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/boards_tbs/colibri.h
+++ b/ground/gcs/src/plugins/boards_tbs/colibri.h
@@ -63,6 +63,7 @@ public:
      * @return the currently selected input type
      */
     virtual enum InputType getInputOnPort(int port_num = 0);
+    virtual QStringList getAdcNames();
 };
 
 

--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -99,7 +99,7 @@ ConfigInputWidget::ConfigInputWidget(QWidget *parent) : ConfigTaskWidget(parent)
     }
 
     // RSSI
-    inputChannelForm * inpForm=new inputChannelForm(this,false,false);
+    inputChannelForm * inpForm = new inputChannelForm(this, false, false, inputChannelForm::CHANNELFUNC_RSSI);
     m_config->channelSettings->layout()->addWidget(inpForm);
     QString name = "RSSI";
     inpForm->setName(name);

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -3,6 +3,7 @@
  * @file       configmodulewidget.cpp
  * @brief      Configure the optional modules
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup ConfigPlugin Config Plugin

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -28,6 +28,7 @@
 
 #include <extensionsystem/pluginmanager.h>
 #include <coreplugin/generalsettings.h>
+#include <coreplugin/iboardtype.h>
 
 
 #include "airspeedsettings.h"
@@ -472,18 +473,25 @@ void ConfigModuleWidget::objectUpdated(UAVObject * obj, bool success)
         return;
 
     QString objName = obj->getName();
-    if (objName.compare(AirspeedSettings::NAME) == 0)
+    if (objName.compare(AirspeedSettings::NAME) == 0) {
         enableAirspeedTab(success);
-    else if (objName.compare(FlightBatterySettings::NAME) == 0)
+    }
+    else if (objName.compare(FlightBatterySettings::NAME) == 0) {
         enableBatteryTab(success);
-    else if (objName.compare(VibrationAnalysisSettings::NAME) == 0)
+        refreshAdcNames();
+    }
+    else if (objName.compare(VibrationAnalysisSettings::NAME) == 0) {
         enableVibrationTab(success);
-    else if (objName.compare(HoTTSettings::NAME) == 0)
+    }
+    else if (objName.compare(HoTTSettings::NAME) == 0) {
         enableHoTTTelemetryTab(success);
-    else if (objName.compare(GeoFenceSettings::NAME) == 0)
+    }
+    else if (objName.compare(GeoFenceSettings::NAME) == 0) {
         enableGeofenceTab(success);
-    else if (objName.compare(PicoCSettings::NAME) == 0)
+    }
+    else if (objName.compare(PicoCSettings::NAME) == 0) {
         enablePicoCTab(success);
+    }
 }
 
 /**
@@ -710,6 +718,30 @@ void ConfigModuleWidget::enablePicoCTab(bool enabled)
 {
     int idx = ui->moduleTab->indexOf(ui->tabPicoC);
     ui->moduleTab->setTabEnabled(idx,enabled);
+}
+
+//! Replace ADC combobox names on battery tab with board specific ones
+void ConfigModuleWidget::refreshAdcNames(void)
+{
+    QStringList names;
+    Core::IBoardType *board = utilMngr->getBoardType();
+    if (board)
+        names = board->getAdcNames();
+    if (names.isEmpty())
+        return;
+
+    for (int i = 0; i <= 8; i++) {
+        QString name;
+        if (i < names.length())
+            name = names[i] + QString(" (ADC%1)").arg(i);
+        else
+            name = QString("N/A (ADC%1)").arg(i);
+
+        if (i < ui->cbVoltagePin->count())
+            ui->cbVoltagePin->setItemText(i, name);
+        if (i < ui->cbCurrentPin->count())
+            ui->cbCurrentPin->setItemText(i, name);
+    }
 }
 
 /**

--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -68,6 +68,8 @@ private:
     void enableGeofenceTab(bool enabled);
     void enablePicoCTab(bool enabled);
 
+    void refreshAdcNames(void);
+
     static QString trueString;
     static QString falseString;
 

--- a/ground/gcs/src/plugins/config/inputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/inputchannelform.cpp
@@ -4,9 +4,12 @@
 #include "manualcontrolsettings.h"
 #include "gcsreceiver.h"
 
-inputChannelForm::inputChannelForm(QWidget *parent,bool showlegend,bool showSlider):
+#include <coreplugin/iboardtype.h>
+
+inputChannelForm::inputChannelForm(QWidget *parent, bool showlegend, bool showSlider, ChannelFunc chanType):
     ConfigTaskWidget(parent),
-    ui(new Ui::inputChannelForm)
+    ui(new Ui::inputChannelForm),
+    m_chanType(chanType)
 {
     ui->setupUi(this);
     
@@ -121,41 +124,103 @@ void inputChannelForm::groupUpdated()
 
     quint8 count = 0;
 
-    switch(ui->channelGroup->currentIndex()) {
-    case -1: // Nothing selected
-        count = 0;
+    switch (m_chanType) {
+
+    case inputChannelForm::CHANNELFUNC_RC:
+        {
+            switch (ui->channelGroup->currentIndex()) {
+            case -1: // Nothing selected
+                count = 0;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_PWM:
+                count = 8; // Need to make this 6 for CC
+                break;
+            case ManualControlSettings::CHANNELGROUPS_PPM:
+            case ManualControlSettings::CHANNELGROUPS_DSM:
+                count = 12;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_SBUS:
+                count = 18;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_RFM22B:
+                count = 9;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_OPENLRS:
+                count = 8;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_GCS:
+                count = GCSReceiver::CHANNEL_NUMELEM;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_HOTTSUM:
+                count = 32;
+                break;
+            case ManualControlSettings::CHANNELGROUPS_NONE:
+                count = 0;
+                break;
+            default:
+                Q_ASSERT(0);
+            }
+        }
         break;
-    case ManualControlSettings::CHANNELGROUPS_PWM:
-        count = 8; // Need to make this 6 for CC
+
+
+    case inputChannelForm::CHANNELFUNC_RSSI:
+        {
+            switch (ui->channelGroup->currentIndex()) {
+            case -1: // Nothing selected
+                count = 0;
+                break;
+            case ManualControlSettings::RSSITYPE_PWM:
+                count = 8;
+                break;
+            case ManualControlSettings::RSSITYPE_PPM:
+                count = 12;
+                break;
+            case ManualControlSettings::RSSITYPE_SBUS:
+                count = 18;
+                break;
+            case ManualControlSettings::RSSITYPE_ADC:
+                count = 9;
+                break;
+            case ManualControlSettings::RSSITYPE_OPENLRS:
+                count = 8;
+                break;
+            case ManualControlSettings::RSSITYPE_FRSKYPWM:
+                count = 1;
+                break;
+            case ManualControlSettings::RSSITYPE_NONE:
+                count = 0;
+                break;
+            default:
+                Q_ASSERT(0);
+            }
+        }
         break;
-    case ManualControlSettings::CHANNELGROUPS_PPM:
-    case ManualControlSettings::CHANNELGROUPS_DSM:
-        count = 12;
-        break;
-    case ManualControlSettings::CHANNELGROUPS_SBUS:
-        count = 18;
-        break;
-    case ManualControlSettings::CHANNELGROUPS_RFM22B:
-        count = 8;
-        break;
-    case ManualControlSettings::CHANNELGROUPS_OPENLRS:
-        count = 8;
-        break;
-    case ManualControlSettings::CHANNELGROUPS_GCS:
-        count = GCSReceiver::CHANNEL_NUMELEM;
-        break;
-    case ManualControlSettings::CHANNELGROUPS_HOTTSUM:
-        count = 32;
-        break;
-    case ManualControlSettings::CHANNELGROUPS_NONE:
-        count = 0;
-        break;
-    default:
-        Q_ASSERT(0);
+
     }
 
-    for (int i = 0; i < count; i++)
-        ui->channelNumberDropdown->addItem(QString(tr("Chan %1").arg(i+1)));
+    if (m_chanType == inputChannelForm::CHANNELFUNC_RSSI &&
+            ui->channelGroup->currentIndex() == ManualControlSettings::RSSITYPE_ADC) {
+        QStringList names;
+        Core::IBoardType *board = utilMngr->getBoardType();
+        if (board)
+            names = board->getAdcNames();
+
+        for (int i = 0; i < count; i++) {
+            QString name;
+            if (i < names.length())
+                name = names[i] + QString(" (ADC%1)").arg(i);
+            else if (names.isEmpty())
+                name = QString("ADC%1").arg(i);
+            else
+                name = QString("N/A (ADC%1)").arg(i);
+
+            ui->channelNumberDropdown->addItem(name);
+        }
+    } else {
+        for (int i = 0; i < count; i++)
+            ui->channelNumberDropdown->addItem(QString(tr("Chan %1").arg(i+1)));
+    }
 
     ui->channelNumber->setMaximum(count);
     ui->channelNumber->setMinimum(0);

--- a/ground/gcs/src/plugins/config/inputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/inputchannelform.cpp
@@ -1,3 +1,29 @@
+/**
+ ******************************************************************************
+ *
+ * @file       inputchannelform.c
+ * @author     OpenPilot, http://openpilot.org, Copyright (C) 2012
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
 #include "inputchannelform.h"
 #include "ui_inputchannelform.h"
 

--- a/ground/gcs/src/plugins/config/inputchannelform.h
+++ b/ground/gcs/src/plugins/config/inputchannelform.h
@@ -12,7 +12,9 @@ class inputChannelForm : public ConfigTaskWidget
     Q_OBJECT
 
 public:
-    explicit inputChannelForm(QWidget *parent = 0,bool showlegend=false,bool showSlider=true);
+    typedef enum { CHANNELFUNC_RC, CHANNELFUNC_RSSI } ChannelFunc;
+
+    explicit inputChannelForm(QWidget *parent = 0, bool showlegend=false, bool showSlider=true, ChannelFunc chanType = CHANNELFUNC_RC);
     ~inputChannelForm();
     friend class ConfigInputWidget;
     void setName(QString &name);
@@ -24,6 +26,7 @@ private slots:
 
 private:
     Ui::inputChannelForm *ui;
+    ChannelFunc m_chanType;
 };
 
 #endif // INPUTCHANNELFORM_H

--- a/ground/gcs/src/plugins/coreplugin/iboardtype.h
+++ b/ground/gcs/src/plugins/coreplugin/iboardtype.h
@@ -218,6 +218,8 @@ public:
 
     static QString getBoardNameFromID(int id);
 
+    virtual QStringList getAdcNames() { return QStringList(); }
+
 signals:
 
 protected:

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -4,6 +4,7 @@
  * @file       configtaskwidget.cpp
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  *
  * @addtogroup GCSPlugins GCS Plugins
  * @{

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -1138,7 +1138,7 @@ QVariant ConfigTaskWidget::getVariantFromWidget(QWidget * widget,double scale)
 {
     if(QComboBox * comboBox=qobject_cast<QComboBox *>(widget))
     {
-        return (QString)comboBox->currentText();
+        return comboBox->currentData();
     }
     else if(QDoubleSpinBox * dblSpinBox=qobject_cast<QDoubleSpinBox *>(widget))
     {
@@ -1178,7 +1178,7 @@ bool ConfigTaskWidget::setWidgetFromVariant(QWidget *widget, QVariant value, dou
 {
     if(QComboBox * comboBox=qobject_cast<QComboBox *>(widget))
     {
-        comboBox->setCurrentIndex(comboBox->findText(value.toString()));
+        comboBox->setCurrentIndex(comboBox->findData(value.toString()));
         return true;
     }
     else if(QLabel * label=qobject_cast<QLabel *>(widget))
@@ -1268,8 +1268,8 @@ void ConfigTaskWidget::checkWidgetsLimits(QWidget * widget,UAVObjectField * fiel
         widget->setProperty("wasOverLimits",(bool)true);
         if(QComboBox * cb=qobject_cast<QComboBox *>(widget))
         {
-            if(cb->findText(value.toString())==-1)
-                cb->addItem(value.toString());
+            if(cb->findData(value.toString())==-1)
+                cb->addItem(value.toString(), value);
         }
         else if(QDoubleSpinBox * cb=qobject_cast<QDoubleSpinBox *>(widget))
         {
@@ -1330,16 +1330,11 @@ void ConfigTaskWidget::loadWidgetLimits(QWidget * widget,UAVObjectField * field,
     {
         cb->clear();
         QStringList option=field->getOptions();
-        if(hasLimits)
+        foreach(QString str,option)
         {
-            foreach(QString str,option)
-            {
-                if(field->isWithinLimits(str,index,currentBoard))
-                    cb->addItem(str);
-            }
+            if(!hasLimits || field->isWithinLimits(str,index,currentBoard))
+                cb->addItem(str, str);
         }
-        else
-            cb->addItems(option);
     }
     if(!hasLimits)
         return;

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
@@ -185,7 +185,6 @@ private:
     QList <objectToWidget*> objOfInterest;
     ExtensionSystem::PluginManager *pm;
     UAVObjectManager *objManager;
-    UAVObjectUtilManager* utilMngr;
     smartSaveButton *smartsave;
     QMap<UAVObject *,bool> objectUpdates;
     QMap<int,QList<objectToWidget*> *> defaultReloadGroups;
@@ -214,6 +213,7 @@ protected:
     void checkWidgetsLimits(QWidget *widget, UAVObjectField *field, int index, bool hasLimits, QVariant value, double scale);
     virtual QVariant getVariantFromWidget(QWidget *widget, double scale);
     virtual bool setWidgetFromVariant(QWidget *widget,QVariant value,double scale);
+    UAVObjectUtilManager* utilMngr;
 };
 
 #endif // CONFIGTASKWIDGET_H


### PR DESCRIPTION
"Board plugins can now provide names for the ADC pins."

Agreed that this is pretty big win for usability!

From https://github.com/d-ronin/dRonin/pull/449.

We should explore having this information, as well as the timer channels, exist in the firmware's target directory instead of the GCS plugin.
