### PR TITLE
Uploader Upgrades

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -267,6 +267,7 @@ void UploaderGadgetWidget::FirmwareLoadedUpdate(QByteArray firmwareArray)
         m_widget->userDefined_LD_lbl->setVisible(false);
         return;
     }
+    setStatusInfo(tr("File loaded successfully"), uploader::STATUSICON_INFO);
     m_widget->builtForLD_lbl->setText(Core::IBoardType::getBoardNameFromID(firmware.boardID()));
     bool ok;
     currentBoard.max_code_size.toLong(&ok);

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1099,7 +1099,9 @@ QString UploaderGadgetWidget::LoadFirmwareFileDialog(QString boardName)
     QString fileName = QFileDialog::getOpenFileName(this,
                                                     tr("Select firmware file"),
                                                     fwDirectoryStr,
-                                                    tr("Firmware Files (*.opfw *.tlfw *.bin)"),
+                                                    tr("Firmware (fw_*.tlfw);;"
+                                                       "Bootloader Update (bu_*.tlfw);;"
+                                                       "All (*.tlfw *.opfw *.bin)"),
                                                     &selectedFilter,
                                                     options);
     return fileName;


### PR DESCRIPTION
Some upgrades that came through in dRonin. We had done several of them internally, but these accomplish the same things so no point in having divergence.
- Previously we told them if a file was loaded unsuccessfully but then never overwrote that message when they sucessfully loaded on a subsequent attempt. This tells the user if a file was loaded successfully. https://github.com/d-ronin/dRonin/pull/525
- Only show firmware images by default in file dialog. https://github.com/d-ronin/dRonin/pull/551

Other things that are worth considering for this (or a subsequent) PR
- [ ] https://github.com/d-ronin/dRonin/pull/524
- [ ] https://github.com/d-ronin/dRonin/pull/551
- [ ] https://github.com/d-ronin/dRonin/pull/677
- [ ] https://github.com/d-ronin/dRonin/pull/753
- [ ] https://github.com/d-ronin/dRonin/pull/755
- [ ] https://github.com/d-ronin/dRonin/pull/769
- [ ] https://github.com/d-ronin/dRonin/pull/776
