### PR TITLE
GCS:Config: Warn, don't crash, for invalid btn objrelation

### DIFF
--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       configtaskwidget.cpp
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  *
@@ -25,6 +26,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include "configtaskwidget.h"
 #include <QWidget>
@@ -813,13 +818,23 @@ void ConfigTaskWidget::autoLoadWidgets()
                     break;
                 case default_button:
                     button=qobject_cast<QPushButton *>(widget);
-                    if(button)
-                        addDefaultButton(button,uiRelation.buttonGroup.at(0));
+                    if (button) {
+                        if (!uiRelation.buttonGroup.length()) {
+                            qWarning() << "[autoLoadWidgets] No button group specified for default button!";
+                            uiRelation.buttonGroup.append(0);
+                        }
+                        addDefaultButton(button, uiRelation.buttonGroup.at(0));
+                    }
                     break;
                 case reload_button:
                     button=qobject_cast<QPushButton *>(widget);
-                    if(button)
-                        addReloadButton(button,uiRelation.buttonGroup.at(0));
+                    if (button) {
+                        if (!uiRelation.buttonGroup.length()) {
+                            qWarning() << "[autoLoadWidgets] No button group specified for reload button!";
+                            uiRelation.buttonGroup.append(0);
+                        }
+                        addReloadButton(button, uiRelation.buttonGroup.at(0));
+                    }
                     break;
                 case help_button:
                     button=qobject_cast<QPushButton *>(widget);


### PR DESCRIPTION
From https://github.com/d-ronin/dRonin/pull/793. Definitely see the point of avoiding crashing at all costs.
