### PR TITLE
GCS: Only send one failure to connect message

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/connectionmanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/connectionmanager.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       connectionmanager.cpp
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  *             Parts by Nokia Corporation (qt-info@nokia.com) Copyright (C) 2009.
  * @addtogroup GCSPlugins GCS Plugins
@@ -39,7 +40,6 @@
 #include <QHBoxLayout>
 #include <QComboBox>
 #include <QEventLoop>
-#include <QMessageBox>
 #include <alarmsmonitorwidget.h>
 
 namespace Core {
@@ -110,8 +110,6 @@ void ConnectionManager::init()
  */
 void ConnectionManager::onConnectDeviceFailed(DevListItem *device)
 {
-    QMessageBox msgBox;
-
     QString msg("<span style='color:red'>Failed</span> to connect device: ");
     if(device && device->device)
         msg.append(device->device->getDisplayName());
@@ -123,8 +121,8 @@ void ConnectionManager::onConnectDeviceFailed(DevListItem *device)
         msg.append("<br />Have you set udev rules?");
 #endif
 
-    msgBox.setText(msg);
-    msgBox.exec();
+    msgFailedToConnect.setText(msg);
+    msgFailedToConnect.open();
 }
 
 /**

--- a/ground/gcs/src/plugins/coreplugin/connectionmanager.h
+++ b/ground/gcs/src/plugins/coreplugin/connectionmanager.h
@@ -40,6 +40,7 @@
 #include <QPushButton>
 #include <QComboBox>
 #include <QPointer>
+#include <QMessageBox>
 
 #include "core_global.h"
 #include <QTimer>
@@ -149,6 +150,8 @@ protected:
 
     //currently connected QIODevice
     QIODevice *m_ioDev;
+
+    QMessageBox msgFailedToConnect;
 
 private:
 	bool connectDevice();


### PR DESCRIPTION
Note the subtle shift from `exec()` to `open()`.

Ported from https://github.com/d-ronin/dRonin/pull/791.
