### PR TITLE
PiOS Watchdog: Validate that a flag has been registered

### DIFF
--- a/flight/PiOS/STM32F10x/pios_wdg.c
+++ b/flight/PiOS/STM32F10x/pios_wdg.c
@@ -121,6 +121,11 @@ bool PIOS_WDG_RegisterFlag(uint16_t flag_requested)
  */
 bool PIOS_WDG_UpdateFlag(uint16_t flag) 
 {	
+	// Validate that the flag has been registered. If not, halt the program.
+	if ((wdg_configuration.used_flags & flag) == 0) {
+		PIOS_Assert(0);
+	}
+
 	// we can probably avoid using a semaphore here which will be good for
 	// efficiency and not blocking critical tasks.  race condition could 
 	// overwrite their flag update, but unlikely to block _all_ of them 

--- a/flight/PiOS/STM32F10x/pios_wdg.c
+++ b/flight/PiOS/STM32F10x/pios_wdg.c
@@ -7,6 +7,7 @@
  * @{
  *
  * @file       pios_spi.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * 	        Parts by Thorsten Klose (tk@midibox.org) (tk@midibox.org)
  * @brief      Hardware Abstraction Layer for SPI ports of STM32

--- a/flight/PiOS/STM32F30x/pios_wdg.c
+++ b/flight/PiOS/STM32F30x/pios_wdg.c
@@ -128,6 +128,11 @@ bool PIOS_WDG_RegisterFlag(uint16_t flag_requested)
  */
 bool PIOS_WDG_UpdateFlag(uint16_t flag) 
 {	
+	// Validate that the flag has been registered. If not, halt the program.
+	if ((wdg_configuration.used_flags & flag) == 0) {
+		PIOS_Assert(0);
+	}
+
 	// we can probably avoid using a semaphore here which will be good for
 	// efficiency and not blocking critical tasks.  race condition could 
 	// overwrite their flag update, but unlikely to block _all_ of them 

--- a/flight/PiOS/STM32F30x/pios_wdg.c
+++ b/flight/PiOS/STM32F30x/pios_wdg.c
@@ -7,8 +7,8 @@
  * @{
  *
  * @file       pios_spi.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2013
  * 	           Parts by Thorsten Klose (tk@midibox.org) (tk@midibox.org)
  * @brief      Hardware Abstraction Layer for SPI ports of STM32
  * @see        The GNU Public License (GPL) Version 3

--- a/flight/PiOS/STM32F4xx/pios_wdg.c
+++ b/flight/PiOS/STM32F4xx/pios_wdg.c
@@ -127,6 +127,11 @@ bool PIOS_WDG_RegisterFlag(uint16_t flag_requested)
  */
 bool PIOS_WDG_UpdateFlag(uint16_t flag) 
 {	
+	// Validate that the flag has been registered. If not, halt the program.
+	if ((wdg_configuration.used_flags & flag) == 0) {
+		PIOS_Assert(0);
+	}
+
 	// we can probably avoid using a semaphore here which will be good for
 	// efficiency and not blocking critical tasks.  race condition could 
 	// overwrite their flag update, but unlikely to block _all_ of them 

--- a/flight/PiOS/STM32F4xx/pios_wdg.c
+++ b/flight/PiOS/STM32F4xx/pios_wdg.c
@@ -7,6 +7,7 @@
  * @{
  *
  * @file       pios_spi.c
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
  * 	        Parts by Thorsten Klose (tk@midibox.org) (tk@midibox.org)
  * @brief      Hardware Abstraction Layer for SPI ports of STM32


### PR DESCRIPTION
It's subtle, but an unregistered flag being updated would ultimately cause the watchdog to timeout and the board to reset. This prevents that by first checking that the watchdog flag is indeed registered before processing it.

Untested on F1 and F3 targets, works fine on F4. 
