### PR TITLE
RevoMini: extend functionality of Flex-IO port

### DIFF
--- a/flight/targets/revomini/board-info/board_hw_defs.c
+++ b/flight/targets/revomini/board-info/board_hw_defs.c
@@ -7,6 +7,7 @@
  *
  * @file       board_hw_defs.c 
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
  * @brief      Defines board specific static initializers for hardware for the
  *             RevoMini board.
@@ -27,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along 
  * with this program; if not, write to the Free Software Foundation, Inc., 
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include <pios_config.h>
 #include <pios_board_info.h>
@@ -634,10 +639,11 @@ const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32
 
 #endif	/* PIOS_INCLUDE_FLASH */
 
+
+
+#ifdef PIOS_INCLUDE_USART
+
 #include <pios_usart_priv.h>
-
-#ifdef PIOS_INCLUDE_COM_TELEM
-
 /*
  * MAIN USART
  */
@@ -669,6 +675,7 @@ static const struct pios_usart_cfg pios_usart_main_cfg = {
 			.GPIO_OType = GPIO_OType_PP,
 			.GPIO_PuPd  = GPIO_PuPd_UP
 		},
+		.pin_source = GPIO_PinSource10,
 	},
 	.tx = {
 		.gpio = GPIOA,
@@ -679,9 +686,9 @@ static const struct pios_usart_cfg pios_usart_main_cfg = {
 			.GPIO_OType = GPIO_OType_PP,
 			.GPIO_PuPd  = GPIO_PuPd_UP
 		},
+		.pin_source = GPIO_PinSource9,
 	},
 };
-#endif /* PIOS_INCLUDE_COM_TELEM */
 
 #include <pios_sbus_priv.h>
 #if defined(PIOS_INCLUDE_SBUS)
@@ -741,7 +748,6 @@ static const struct pios_sbus_cfg pios_sbus_cfg = {
 	.gpio_clk_periph  = RCC_AHB1Periph_GPIOC,
 };
 
-
 #ifdef PIOS_INCLUDE_COM_FLEXI
 /*
  * FLEXI PORT
@@ -775,6 +781,7 @@ static const struct pios_usart_cfg pios_usart_flexi_cfg = {
 			.GPIO_OType = GPIO_OType_PP,
 			.GPIO_PuPd  = GPIO_PuPd_UP
 		},
+		.pin_source = GPIO_PinSource11,
 	},
 	.tx = {
 		.gpio = GPIOB,
@@ -785,12 +792,52 @@ static const struct pios_usart_cfg pios_usart_flexi_cfg = {
 			.GPIO_OType = GPIO_OType_PP,
 			.GPIO_PuPd  = GPIO_PuPd_UP
 		},
+		.pin_source = GPIO_PinSource10,
 	},
 };
 
 #endif /* PIOS_INCLUDE_COM_FLEXI */
 
+/*
+ * FLEXI-IO PORT
+ */
+static const struct pios_usart_cfg pios_rxportusart_cfg = {
+	.regs = USART6,
+	.remap = GPIO_AF_USART6,
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel = USART6_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
+			.NVIC_IRQChannelSubPriority = 0,
+			.NVIC_IRQChannelCmd = ENABLE,
+		},
+	},
+	.rx = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_7,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource7,
+	},
+	.tx = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_6,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource6,
+	},
+};
+
 #if defined(PIOS_INCLUDE_DSM)
+
 /*
  * Spektrum/JR DSM USART
  */
@@ -817,6 +864,19 @@ static const struct pios_dsm_cfg pios_dsm_flexi_cfg = {
 		.gpio = GPIOB,
 		.init = {
 			.GPIO_Pin   = GPIO_Pin_11,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_OUT,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_NOPULL
+		},
+	},
+};
+
+static const struct pios_dsm_cfg pios_rxportusart_dsm_aux_cfg = {
+	.bind = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_7,
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_OUT,
 			.GPIO_OType = GPIO_OType_PP,
@@ -922,6 +982,9 @@ static const struct pios_usart_cfg pios_usart_dsm_hsum_flexi_cfg = {
 	},
 };
 #endif	/* PIOS_INCLUDE_DSM || PIOS_INCLUDE_HSUM */
+
+#endif /* PIOS_INCLUDE_USART */
+
 
 #if defined(PIOS_INCLUDE_COM)
 
@@ -1268,11 +1331,19 @@ static const struct pios_tim_clock_cfg tim_12_cfg = {
 };
 
 
-/**
+/*
  * Pios servo configuration structures
- * Using TIM3, TIM9, TIM2, TIM5
+ * Outputs
+ * 1: TIM3_CH3 (PB0)
+ * 2: TIM3_CH4 (PB1)
+ * 3: TIM9_CH2 (PA3)
+ * 4: TIM2_CH3 (PA2)
+ * 5: TIM5_CH2 (PA1)
+ * 6: TIM5_CH1 (PA0)
  */
+
 #include <pios_servo_priv.h>
+
 static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 	{
 		.timer = TIM3,
@@ -1369,8 +1440,224 @@ static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 			.pin_source = GPIO_PinSource0,
 		},
 		.remap = GPIO_AF_TIM5,
+	}
+};
+
+/*
+ * 	OUTPUTS with extra outputs on recieverport
+	1: TIM3_CH3 (PB0)
+	2: TIM3_CH4 (PB1)
+	3: TIM9_CH2 (PA3)
+	4: TIM2_CH3 (PA2)
+	5: TIM5_CH2 (PA1)
+	6: TIM5_CH1 (PA0)
+	7: TIM12_CH2 (PB15)
+	8: TIM8_CH1 (PC6) UART
+	9: TIM8_CH2 (PC7) UART
+	10: TIM8_CH3 (PC8)
+	11: TIM8_CH4 (PC9)
+	12: TIM12_CH1 (PB14) PPM
+ */
+
+static const struct pios_tim_channel pios_tim_servoport_rcvrport_pins[] = {
+	{ // output 1
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_3,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_0,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource0,
+		},
+		.remap = GPIO_AF_TIM3,
+	},
+	{ // output 2
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_4,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_1,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource1,
+		},
+		.remap = GPIO_AF_TIM3,
+	},
+	{ // output 3
+		.timer = TIM9,
+		.timer_chan = TIM_Channel_2,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_3,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource3,
+		},
+		.remap = GPIO_AF_TIM9,
+	},
+	{ // output 4
+		.timer = TIM2,
+		.timer_chan = TIM_Channel_3,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_2,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource2,
+		},
+		.remap = GPIO_AF_TIM2,
+	},
+	{ // output 5
+		.timer = TIM5,
+		.timer_chan = TIM_Channel_2,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_1,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource1,
+		},
+		.remap = GPIO_AF_TIM5,
+	},
+	{ // output 6
+		.timer = TIM5,
+		.timer_chan = TIM_Channel_1,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_0,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource0,
+		},
+		.remap = GPIO_AF_TIM5,
+	},
+	{ // output 7
+		.timer = TIM12,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM12,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_15,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource15,
+		},
+	},
+	{ // output 8
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_6,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource6,
+		},
+	},
+	{ // output 9
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_7,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource7,
+		},
+	},
+	{ // output 10
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_3,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_8,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource8,
+		},
+	},
+	{ // output 11
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_4,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_9,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource9,
+		},
+	},
+	{ // output 12
+		.timer = TIM12,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM12,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_14,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource14,
+		},
 	},
 };
+
+#if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
+/*
+ * Servo outputs
+ */
 
 const struct pios_servo_cfg pios_servo_cfg = {
 	.tim_oc_init = {
@@ -1387,10 +1674,47 @@ const struct pios_servo_cfg pios_servo_cfg = {
 	.num_channels = NELEMENTS(pios_tim_servoport_all_pins),
 };
 
+const struct pios_servo_cfg pios_servo_rcvr_ppm_cfg = {
+	.tim_oc_init = {
+		.TIM_OCMode = TIM_OCMode_PWM1,
+		.TIM_OutputState = TIM_OutputState_Enable,
+		.TIM_OutputNState = TIM_OutputNState_Disable,
+		.TIM_Pulse = PIOS_SERVOS_INITIAL_POSITION,
+		.TIM_OCPolarity = TIM_OCPolarity_High,
+		.TIM_OCNPolarity = TIM_OCPolarity_High,
+		.TIM_OCIdleState = TIM_OCIdleState_Reset,
+		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
+	},
+	.channels = pios_tim_servoport_rcvrport_pins,
+	.num_channels = NELEMENTS(pios_tim_servoport_rcvrport_pins) - 1,
+};
+
+const struct pios_servo_cfg pios_servo_rcvr_all_cfg = {
+	.tim_oc_init = {
+		.TIM_OCMode = TIM_OCMode_PWM1,
+		.TIM_OutputState = TIM_OutputState_Enable,
+		.TIM_OutputNState = TIM_OutputNState_Disable,
+		.TIM_Pulse = PIOS_SERVOS_INITIAL_POSITION,
+		.TIM_OCPolarity = TIM_OCPolarity_High,
+		.TIM_OCNPolarity = TIM_OCPolarity_High,
+		.TIM_OCIdleState = TIM_OCIdleState_Reset,
+		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
+	},
+	.channels = pios_tim_servoport_rcvrport_pins,
+	.num_channels = NELEMENTS(pios_tim_servoport_rcvrport_pins),
+};
+
+#endif	/* PIOS_INCLUDE_SERVO && PIOS_INCLUDE_TIM */
+
 
 /*
- * PWM Inputs
- * TIM1, TIM8, TIM12
+ * 	INPUTS
+	1: TIM12_CH1 (PB14)
+	2: TIM12_CH2 (PB15)
+	3: TIM8_CH1 (PC6)
+	4: TIM8_CH2 (PC7)
+	5: TIM8_CH3 (PC8)
+	6: TIM8_CH4 (PC9)
  */
 #if defined(PIOS_INCLUDE_PWM) || defined(PIOS_INCLUDE_PPM)
 #include <pios_pwm_priv.h>
@@ -1529,7 +1853,7 @@ static const struct pios_ppm_cfg pios_ppm_cfg = {
 		.TIM_ICSelection = TIM_ICSelection_DirectTI,
 		.TIM_ICPrescaler = TIM_ICPSC_DIV1,
 		.TIM_ICFilter = 0x0,
-		.TIM_Channel = TIM_Channel_2,
+		.TIM_Channel = TIM_Channel_2, //FIXME Why is this Channel 2 and Brain 3 ?
 	},
 	/* Use only the first channel for ppm */
 	.channels = &pios_tim_rcvrport_all_channels[0],
@@ -1704,6 +2028,72 @@ static void PIOS_ADC_DMA_irq_handler(void)
 }
 
 #endif /* PIOS_INCLUDE_ADC */
+
+#if defined(PIOS_INCLUDE_FRSKY_RSSI)
+#include "pios_frsky_rssi_priv.h"
+const TIM_TimeBaseInitTypeDef pios_frsky_rssi_time_base ={
+	.TIM_Prescaler = 6,
+	.TIM_ClockDivision = TIM_CKD_DIV1,
+	.TIM_CounterMode = TIM_CounterMode_Up,
+	.TIM_Period = 0xFFFF,
+	.TIM_RepetitionCounter = 0x0000,
+};
+
+
+const struct pios_frsky_rssi_cfg pios_frsky_rssi_cfg = {
+	.clock_cfg = {
+		.timer = TIM8,
+		.time_base_init = &pios_frsky_rssi_time_base,
+	},
+	.channels = {
+		{
+			.timer = TIM8,
+			.timer_chan = TIM_Channel_2,
+			.pin   = {
+				.gpio = GPIOC,
+				.init = {
+					.GPIO_Pin   = GPIO_Pin_7,
+					.GPIO_Speed = GPIO_Speed_100MHz,
+					.GPIO_Mode  = GPIO_Mode_AF,
+					.GPIO_OType = GPIO_OType_PP,
+					.GPIO_PuPd  = GPIO_PuPd_UP
+				},
+				.pin_source = GPIO_PinSource7,
+			},
+			.remap = GPIO_AF_TIM8,
+		},
+		{
+			.timer = TIM8,
+			.timer_chan = TIM_Channel_1,
+			.pin   = {
+				.gpio = GPIOC,
+				.init = {
+					.GPIO_Pin   = GPIO_Pin_7,
+					.GPIO_Speed = GPIO_Speed_100MHz,
+					.GPIO_Mode  = GPIO_Mode_AF,
+					.GPIO_OType = GPIO_OType_PP,
+					.GPIO_PuPd  = GPIO_PuPd_UP
+				},
+				.pin_source = GPIO_PinSource7,
+			},
+			.remap = GPIO_AF_TIM8,
+		},
+	},
+	.ic2 = {
+		.TIM_ICPolarity = TIM_ICPolarity_Falling,
+		.TIM_ICSelection = TIM_ICSelection_IndirectTI,
+		.TIM_ICPrescaler = TIM_ICPSC_DIV1,
+		.TIM_ICFilter = 0x0,
+	},
+	.ic1 = {
+		.TIM_ICPolarity = TIM_ICPolarity_Rising,
+		.TIM_ICSelection = TIM_ICSelection_DirectTI,
+		.TIM_ICPrescaler = TIM_ICPSC_DIV1,
+		.TIM_ICFilter = 0x0,
+	}
+};
+
+#endif /* PIOS_INCLUDE_FRSKY_RSSI */
 
 /**
  * @}

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -26,6 +26,10 @@
  * You should have received a copy of the GNU General Public License along 
  * with this program; if not, write to the Free Software Foundation, Inc., 
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 /* Pull in the board-specific static HW definitions.
@@ -174,6 +178,7 @@ uintptr_t pios_waypoints_settings_fs_id;
 #include <pios_board_info.h>
 
 void PIOS_Board_Init(void) {
+	bool use_rxport_usart = false;
 
 	/* Delay system */
 	PIOS_DELAY_Init();
@@ -366,6 +371,163 @@ void PIOS_Board_Init(void) {
 			NULL,                                // sbus_cfg    
 			false);                              // sbus_toggle
 
+	/* Configure the receiver port*/
+	uint8_t hw_rcvrport;
+	HwRevoMiniRcvrPortGet(&hw_rcvrport);
+
+	switch (hw_rcvrport) {
+	case HWREVOMINI_RCVRPORT_DISABLED:
+		break;
+
+	case HWREVOMINI_RCVRPORT_PWM:
+		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
+				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
+				NULL,                                   // com_driver
+				NULL,                                   // i2c_id
+				NULL,                                   // i2c_cfg
+				NULL,                                   // ppm_cfg
+				&pios_pwm_cfg,                          // pwm_cfg
+				PIOS_LED_ALARM,                         // led_id
+				NULL,                                   // usart_dsm_hsum_cfg
+				NULL,                                   // dsm_cfg
+				0,                                      // dsm_mode
+				NULL,                                   // sbus_rcvr_cfg
+				NULL,                                   // sbus_cfg
+				false);                                 // sbus_toggle
+		break;
+
+	case HWREVOMINI_RCVRPORT_PPMFRSKY:
+		// special mode that enables PPM, FrSky RSSI, and Sensor Hub
+		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_FRSKYSENSORHUB,  // port type protocol
+				NULL,                                              // usart_port_cfg
+				&pios_rxportusart_cfg,                             // frsky usart_port_cfg
+				&pios_usart_com_driver,                            // com_driver
+				NULL,                                              // i2c_id
+				NULL,                                              // i2c_cfg
+				NULL,                                              // ppm_cfg
+				NULL,                                              // pwm_cfg
+				PIOS_LED_ALARM,                                    // led_id
+				NULL,                                              // usart_dsm_hsum_cfg
+				NULL,                                              // dsm_cfg
+				0,                                                 // dsm_mode
+				NULL,                                              // sbus_rcvr_cfg
+				NULL,                                              // sbus_cfg
+				false);                                            // sbus_toggle
+
+	case HWREVOMINI_RCVRPORT_PPM:
+	case HWREVOMINI_RCVRPORT_PPMOUTPUTS:
+		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
+				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
+				NULL,                                   // com_driver
+				NULL,                                   // i2c_id
+				NULL,                                   // i2c_cfg
+				&pios_ppm_cfg,                          // ppm_cfg
+				NULL,                                   // pwm_cfg
+				PIOS_LED_ALARM,                         // led_id
+				NULL,                                   // usart_dsm_hsum_cfg
+				NULL,                                   // dsm_cfg
+				0,                                      // dsm_mode
+				NULL,                                   // sbus_rcvr_cfg
+				NULL,                                   // sbus_cfg
+				false);                                 // sbus_toggle
+		break;
+
+	case HWREVOMINI_RCVRPORT_UART:
+		use_rxport_usart = true;
+		break;
+
+	case HWREVOMINI_RCVRPORT_PPMUART:
+		use_rxport_usart = true;
+
+		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
+				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
+				NULL,                                   // com_driver
+				NULL,                                   // i2c_id
+				NULL,                                   // i2c_cfg
+				&pios_ppm_cfg,                          // ppm_cfg
+				NULL,                                   // pwm_cfg
+				PIOS_LED_ALARM,                         // led_id
+				NULL,                                   // usart_dsm_hsum_cfg
+				NULL,                                   // dsm_cfg
+				0,                                      // dsm_mode
+				NULL,                                   // sbus_rcvr_cfg
+				NULL,                                   // sbus_cfg
+				false);                                 // sbus_toggle
+		break;
+	}
+
+	/* Configure the RxPort USART */
+	if (use_rxport_usart) {
+		uint8_t hw_rcvrportusart;
+		HwRevoMiniRcvrPortUsartGet(&hw_rcvrportusart);
+
+		PIOS_HAL_ConfigurePort(hw_rcvrportusart,     // port type protocol
+				&pios_rxportusart_cfg,               // usart_port_cfg
+				&pios_rxportusart_cfg,               // frsky usart_port_cfg
+				&pios_usart_com_driver,              // com_driver
+				NULL,                                // i2c_id
+				NULL,                                // i2c_cfg
+				NULL,                                // ppm_cfg
+				NULL,                                // pwm_cfg
+				PIOS_LED_ALARM,                      // led_id
+				NULL,                                // usart_dsm_hsum_cfg
+				NULL,                                // dsm_cfg
+				hw_DSMxMode,                         // dsm_mode
+				NULL,                                // sbus_rcvr_cfg
+				NULL,                                // sbus_cfg
+				false);                              // sbus_toggle
+	}
+
+#if defined(PIOS_INCLUDE_GCSRCVR)
+	GCSReceiverInitialize();
+	uintptr_t pios_gcsrcvr_id;
+	PIOS_GCSRCVR_Init(&pios_gcsrcvr_id);
+	uintptr_t pios_gcsrcvr_rcvr_id;
+	if (PIOS_RCVR_Init(&pios_gcsrcvr_rcvr_id, &pios_gcsrcvr_rcvr_driver, pios_gcsrcvr_id)) {
+		PIOS_Assert(0);
+	}
+	pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_GCS] = pios_gcsrcvr_rcvr_id;
+#endif	/* PIOS_INCLUDE_GCSRCVR */
+
+#ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
+	switch (hw_rcvrport) {
+	case HWREVOMINI_RCVRPORT_DISABLED:
+	case HWREVOMINI_RCVRPORT_PWM:
+	case HWREVOMINI_RCVRPORT_PPM:
+	case HWREVOMINI_RCVRPORT_UART:
+	case HWREVOMINI_RCVRPORT_PPMUART:
+	/* Set up the servo outputs */
+#ifdef PIOS_INCLUDE_SERVO
+		PIOS_Servo_Init(&pios_servo_cfg);
+#endif
+		break;
+	case HWREVOMINI_RCVRPORT_PPMOUTPUTS:
+#ifdef PIOS_INCLUDE_SERVO
+		PIOS_Servo_Init(&pios_servo_rcvr_ppm_cfg);
+#endif
+		break;
+	case HWREVOMINI_RCVRPORT_PPMFRSKY:
+#ifdef PIOS_INCLUDE_SERVO
+		PIOS_Servo_Init(&pios_servo_cfg);
+#endif
+#if defined(PIOS_INCLUDE_FRSKY_RSSI)
+		PIOS_FrSkyRssi_Init(&pios_frsky_rssi_cfg);
+#endif /* PIOS_INCLUDE_FRSKY_RSSI */
+		break;
+	case HWREVOMINI_RCVRPORT_OUTPUTS:
+#ifdef PIOS_INCLUDE_SERVO
+		PIOS_Servo_Init(&pios_servo_rcvr_all_cfg);
+#endif
+		break;
+	}
+#else
+	PIOS_DEBUG_Init(&pios_tim_servo_all_channels, NELEMENTS(pios_tim_servo_all_channels));
+#endif
+
+
 	HwRevoMiniData hwRevoMini;
 	HwRevoMiniGet(&hwRevoMini);
 
@@ -381,105 +543,7 @@ void PIOS_Board_Init(void) {
 			hwRevoMini.MaxChannel, hwRevoMini.CoordID, 1);
 #endif /* PIOS_INCLUDE_RFM22B */
 
-	/* Configure the receiver port*/
-	uint8_t hw_rcvrport;
-	HwRevoMiniRcvrPortGet(&hw_rcvrport);
-	//   
-	switch (hw_rcvrport){
-		case HWREVOMINI_RCVRPORT_DISABLED:
-			break;
-		case HWREVOMINI_RCVRPORT_PWM:
-#if defined(PIOS_INCLUDE_PWM)
-		{
-			/* Set up the receiver port.  Later this should be optional */
-			uintptr_t pios_pwm_id;
-			PIOS_PWM_Init(&pios_pwm_id, &pios_pwm_cfg);
-			
-			uintptr_t pios_pwm_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_pwm_rcvr_id, &pios_pwm_rcvr_driver, pios_pwm_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PWM] = pios_pwm_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_PWM */
-			break;
-		case HWREVOMINI_RCVRPORT_PPMPWM:
-		/* This is a combination of PPM and PWM inputs */
-#if defined(PIOS_INCLUDE_PPM)
-		{
-			uintptr_t pios_ppm_id;
-			PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
 
-			uintptr_t pios_ppm_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PPM] = pios_ppm_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_PPM */
-#if defined(PIOS_INCLUDE_PWM)
-		{
-			uintptr_t pios_pwm_id;
-			PIOS_PWM_Init(&pios_pwm_id, &pios_pwm_with_ppm_cfg);
-
-			uintptr_t pios_pwm_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_pwm_rcvr_id, &pios_pwm_rcvr_driver, pios_pwm_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PWM] = pios_pwm_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_PWM */
-			break;
-		case HWREVOMINI_RCVRPORT_PPM:
-		case HWREVOMINI_RCVRPORT_PPMOUTPUTS:
-#if defined(PIOS_INCLUDE_PPM)
-		{
-			uintptr_t pios_ppm_id;
-			PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
-			
-			uintptr_t pios_ppm_rcvr_id;
-			if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
-				PIOS_Assert(0);
-			}
-			pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_PPM] = pios_ppm_rcvr_id;
-		}
-#endif	/* PIOS_INCLUDE_PPM */
-		case HWREVOMINI_RCVRPORT_OUTPUTS:
-		
-			break;
-	}
-
-
-#if defined(PIOS_INCLUDE_GCSRCVR)
-	GCSReceiverInitialize();
-	uintptr_t pios_gcsrcvr_id;
-	PIOS_GCSRCVR_Init(&pios_gcsrcvr_id);
-	uintptr_t pios_gcsrcvr_rcvr_id;
-	if (PIOS_RCVR_Init(&pios_gcsrcvr_rcvr_id, &pios_gcsrcvr_rcvr_driver, pios_gcsrcvr_id)) {
-		PIOS_Assert(0);
-	}
-	pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_GCS] = pios_gcsrcvr_rcvr_id;
-#endif	/* PIOS_INCLUDE_GCSRCVR */
-
-#ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
-	switch (hw_rcvrport) {
-		case HWREVOMINI_RCVRPORT_DISABLED:
-		case HWREVOMINI_RCVRPORT_PWM:
-		case HWREVOMINI_RCVRPORT_PPM:
-			/* Set up the servo outputs */
-			PIOS_Servo_Init(&pios_servo_cfg);
-			break;
-		case HWREVOMINI_RCVRPORT_PPMOUTPUTS:
-		case HWREVOMINI_RCVRPORT_OUTPUTS:
-			//PIOS_Servo_Init(&pios_servo_rcvr_cfg);
-			//TODO: Prepare the configurations on board_hw_defs and handle here:
-			PIOS_Servo_Init(&pios_servo_cfg);
-			break;
-	}
-#else
-	PIOS_DEBUG_Init(&pios_tim_servo_all_channels, NELEMENTS(pios_tim_servo_all_channels));
-#endif
-	
 	if (PIOS_I2C_Init(&pios_i2c_mag_pressure_adapter_id, &pios_i2c_mag_pressure_adapter_cfg)) {
 		PIOS_DEBUG_Assert(0);
 	}

--- a/flight/targets/revomini/fw/pios_config.h
+++ b/flight/targets/revomini/fw/pios_config.h
@@ -6,6 +6,8 @@
  * @{
  *
  * @file       pios_config.h 
+ *
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @brief      Board specific options that modify PiOS capabilities
@@ -43,6 +45,7 @@
 #define PIOS_INCLUDE_IRQ
 #define PIOS_INCLUDE_LED
 #define PIOS_INCLUDE_IAP
+#define PIOS_INCLUDE_TIM
 #define PIOS_INCLUDE_SERVO
 #define PIOS_INCLUDE_SPI
 #define PIOS_INCLUDE_SYS
@@ -56,6 +59,7 @@
 #define PIOS_INCLUDE_WDG
 #define PIOS_INCLUDE_FASTHEAP
 #define PIOS_INCLUDE_HPWM
+#define PIOS_INCLUDE_FRSKY_RSSI
 
 /* Variables related to the RFM22B functionality */
 #define PIOS_INCLUDE_RFM22B
@@ -75,11 +79,8 @@
 /* Com systems to include */
 #define PIOS_INCLUDE_COM
 #define PIOS_INCLUDE_COM_TELEM
+#define PIOS_INCLUDE_TELEMETRY_RF
 #define PIOS_INCLUDE_COM_FLEXI
-
-#define PIOS_INCLUDE_GPS
-#define PIOS_INCLUDE_GPS_NMEA_PARSER
-#define PIOS_INCLUDE_GPS_UBX_PARSER
 #define PIOS_INCLUDE_MAVLINK
 #define PIOS_INCLUDE_HOTT
 #define PIOS_INCLUDE_FRSKY_SENSOR_HUB
@@ -87,6 +88,11 @@
 #define PIOS_INCLUDE_LIGHTTELEMETRY
 #define PIOS_INCLUDE_PICOC
 #define PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY
+
+#define PIOS_INCLUDE_GPS
+#define PIOS_INCLUDE_GPS_NMEA_PARSER
+#define PIOS_INCLUDE_GPS_UBX_PARSER
+#define PIOS_GPS_SETS_HOMELOCATION
 
 /* Supported receiver interfaces */
 #define PIOS_INCLUDE_RCVR

--- a/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
@@ -162,18 +162,11 @@ bool RevoMini::setInputOnPort(enum InputType type, int port_num)
     settings.MainPort = HwRevoMini::MAINPORT_TELEMETRY;
 
     switch(type) {
-    case INPUT_TYPE_PWM:
-<<<<<<< HEAD:ground/gcs/src/plugins/boards_openpilot/revomini.cpp
-        settings.RcvrPort = HwRevoMini::RCVRPORT_PWM;
-        break;
     case INPUT_TYPE_PPM:
         settings.RcvrPort = HwRevoMini::RCVRPORT_PPM;
-=======
-        settings.RxPort = HwRevolution::RXPORT_PWM;
         break;
-    case INPUT_TYPE_PPM:
-        settings.RxPort = HwRevolution::RXPORT_PPM;
->>>>>>> 85d329d... Revo: Flexi-Io Support:ground/gcs/src/plugins/boards_openpilot/revolution.cpp
+    case INPUT_TYPE_PWM:
+        settings.RcvrPort = HwRevoMini::RCVRPORT_PWM;
         break;
     case INPUT_TYPE_SBUS:
         settings.FlexiPort = HwRevoMini::FLEXIPORT_TELEMETRY;
@@ -186,7 +179,7 @@ bool RevoMini::setInputOnPort(enum InputType type, int port_num)
         settings.FlexiPort = HwRevoMini::FLEXIPORT_HOTTSUMD;
         break;
     case INPUT_TYPE_HOTTSUMH:
-        settings.MainPort = HwRevolution::MAINPORT_HOTTSUMH;
+        settings.MainPort = HwRevoMini::MAINPORT_HOTTSUMH;
         break;
     default:
         return false;
@@ -222,7 +215,7 @@ enum Core::IBoardType::InputType RevoMini::getInputOnPort(int port_num)
         return INPUT_TYPE_DSM;
     case HwRevoMini::FLEXIPORT_HOTTSUMD:
         return INPUT_TYPE_HOTTSUMD;
-    case HwRevolution::FLEXIPORT_HOTTSUMH:
+    case HwRevoMini::FLEXIPORT_HOTTSUMH:
         return INPUT_TYPE_HOTTSUMH;
     default:
         break;
@@ -231,33 +224,22 @@ enum Core::IBoardType::InputType RevoMini::getInputOnPort(int port_num)
     switch(settings.MainPort) {
     case HwRevoMini::MAINPORT_SBUS:
         return INPUT_TYPE_SBUS;
-    case HwRevolution::MAINPORT_DSM:
-        return INPUT_TYPE_DSM;
-    case HwRevolution::MAINPORT_HOTTSUMD:
+    case HwRevoMini::MAINPORT_HOTTSUMD:
         return INPUT_TYPE_HOTTSUMD;
-    case HwRevolution::MAINPORT_HOTTSUMH:
+    case HwRevoMini::MAINPORT_HOTTSUMH:
         return INPUT_TYPE_HOTTSUMH;
     default:
         break;
     }
 
-<<<<<<< HEAD:ground/gcs/src/plugins/boards_openpilot/revomini.cpp
     switch(settings.RcvrPort) {
-    case HwRevoMini::RCVRPORT_PPM:
-        return INPUT_TYPE_PPM;
     case HwRevoMini::RCVRPORT_PWM:
-=======
-    switch(settings.RxPort) {
-    case HwRevolution::RXPORT_PPM:
-    case HwRevolution::RXPORT_PPMPWM:
-    case HwRevolution::RXPORT_PPMOUTPUTS:
-    case HwRevolution::RXPORT_PPMUART:
-    case HwRevolution::RXPORT_PPMUARTOUTPUTS:
-    case HwRevolution::RXPORT_PPMFRSKY:
-        return INPUT_TYPE_PPM;
-    case HwRevolution::RXPORT_PWM:
->>>>>>> 85d329d... Revo: Flexi-Io Support:ground/gcs/src/plugins/boards_openpilot/revolution.cpp
         return INPUT_TYPE_PWM;
+    case HwRevoMini::RCVRPORT_PPM:
+    case HwRevoMini::RCVRPORT_PPMPWM:
+    case HwRevoMini::RCVRPORT_PPMUART:
+    case HwRevoMini::RCVRPORT_PPMFRSKY:
+        return INPUT_TYPE_PPM;
     default:
         break;
     }

--- a/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revomini.cpp
@@ -24,6 +24,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "revomini.h"
@@ -159,10 +163,17 @@ bool RevoMini::setInputOnPort(enum InputType type, int port_num)
 
     switch(type) {
     case INPUT_TYPE_PWM:
+<<<<<<< HEAD:ground/gcs/src/plugins/boards_openpilot/revomini.cpp
         settings.RcvrPort = HwRevoMini::RCVRPORT_PWM;
         break;
     case INPUT_TYPE_PPM:
         settings.RcvrPort = HwRevoMini::RCVRPORT_PPM;
+=======
+        settings.RxPort = HwRevolution::RXPORT_PWM;
+        break;
+    case INPUT_TYPE_PPM:
+        settings.RxPort = HwRevolution::RXPORT_PPM;
+>>>>>>> 85d329d... Revo: Flexi-Io Support:ground/gcs/src/plugins/boards_openpilot/revolution.cpp
         break;
     case INPUT_TYPE_SBUS:
         settings.FlexiPort = HwRevoMini::FLEXIPORT_TELEMETRY;
@@ -173,6 +184,9 @@ bool RevoMini::setInputOnPort(enum InputType type, int port_num)
         break;
     case INPUT_TYPE_HOTTSUMD:
         settings.FlexiPort = HwRevoMini::FLEXIPORT_HOTTSUMD;
+        break;
+    case INPUT_TYPE_HOTTSUMH:
+        settings.MainPort = HwRevolution::MAINPORT_HOTTSUMH;
         break;
     default:
         return false;
@@ -208,6 +222,8 @@ enum Core::IBoardType::InputType RevoMini::getInputOnPort(int port_num)
         return INPUT_TYPE_DSM;
     case HwRevoMini::FLEXIPORT_HOTTSUMD:
         return INPUT_TYPE_HOTTSUMD;
+    case HwRevolution::FLEXIPORT_HOTTSUMH:
+        return INPUT_TYPE_HOTTSUMH;
     default:
         break;
     }
@@ -215,14 +231,32 @@ enum Core::IBoardType::InputType RevoMini::getInputOnPort(int port_num)
     switch(settings.MainPort) {
     case HwRevoMini::MAINPORT_SBUS:
         return INPUT_TYPE_SBUS;
+    case HwRevolution::MAINPORT_DSM:
+        return INPUT_TYPE_DSM;
+    case HwRevolution::MAINPORT_HOTTSUMD:
+        return INPUT_TYPE_HOTTSUMD;
+    case HwRevolution::MAINPORT_HOTTSUMH:
+        return INPUT_TYPE_HOTTSUMH;
     default:
         break;
     }
 
+<<<<<<< HEAD:ground/gcs/src/plugins/boards_openpilot/revomini.cpp
     switch(settings.RcvrPort) {
     case HwRevoMini::RCVRPORT_PPM:
         return INPUT_TYPE_PPM;
     case HwRevoMini::RCVRPORT_PWM:
+=======
+    switch(settings.RxPort) {
+    case HwRevolution::RXPORT_PPM:
+    case HwRevolution::RXPORT_PPMPWM:
+    case HwRevolution::RXPORT_PPMOUTPUTS:
+    case HwRevolution::RXPORT_PPMUART:
+    case HwRevolution::RXPORT_PPMUARTOUTPUTS:
+    case HwRevolution::RXPORT_PPMFRSKY:
+        return INPUT_TYPE_PPM;
+    case HwRevolution::RXPORT_PWM:
+>>>>>>> 85d329d... Revo: Flexi-Io Support:ground/gcs/src/plugins/boards_openpilot/revolution.cpp
         return INPUT_TYPE_PWM;
     default:
         break;
@@ -252,7 +286,7 @@ int RevoMini::queryMaxGyroRate()
     case HwRevoMini::GYRORANGE_2000:
         return 2000;
     default:
-        return 500;
+        return 2000;
     }
 }
 

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -73,8 +73,6 @@
 				<option>MSP</option>
 				<option>OpenLog</option>
 				<option>PicoC</option>
-				<option>S.Bus</option>
-				<option>S.Bus Non Inverted</option>
 				<option>Telemetry</option>
 			</options>
 		</field>

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -3,13 +3,16 @@
 		<description>Selection of optional hardware configurations.</description>
 
 		<field name="RcvrPort" units="function" type="enum" elements="1" defaultvalue="PWM">
-		<options>
-			 <option>Disabled</option>
-			 <option>PWM</option>
-			 <option>PPM</option>
-			 <option>PPM+PWM</option>
-			 <option>PPM+Outputs</option>
-			 <option>Outputs</option>
+			<options>
+				<option>Disabled</option>
+				<option>Outputs</option>
+				<option>PPM</option>
+				<option>PPM+FrSky</option>
+				<option>PPM+Outputs</option>
+				<option>PPM+PWM</option>
+				<option>PPM+UART</option>
+				<option>PWM</option>
+				<option>UART</option>
 		</options>
 		</field>		
 		<field name="MainPort" units="function" type="enum" elements="1"  parent="HwShared.PortTypes" defaultvalue="Telemetry">
@@ -50,6 +53,29 @@
 				<option>LighttelemetryTx</option>
 				<option>PicoC</option>
 				<option>FrSKY SPort Telemetry</option>
+			</options>
+		</field>
+		<field name="RcvrPortUsart" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">
+			<options>
+				<option>Disabled</option>
+				<option>ComBridge</option>
+				<option>DebugConsole</option>
+				<option>DSM</option>
+				<option>FrSKY Sensor Hub</option>
+				<option>FrSKY SPort Telemetry</option>
+				<option>GPS</option>
+				<option>HoTT SUMD</option>
+				<option>HoTT SUMH</option>
+				<option>HoTT Telemetry</option>
+				<option>LighttelemetryTx</option>
+				<option>MavLinkTX</option>
+				<option>MavLinkTX_GPS_RX</option>
+				<option>MSP</option>
+				<option>OpenLog</option>
+				<option>PicoC</option>
+				<option>S.Bus</option>
+				<option>S.Bus Non Inverted</option>
+				<option>Telemetry</option>
 			</options>
 		</field>
 


### PR DESCRIPTION
This adds various UART functionality to the Flex-IO header including
- UART
- FrSky telemetry
- Serial protocols

This is a back port from https://github.com/d-ronin/dRonin/pull/617 and
credit goes to @henn1001 
