### PR TITLE
Flight: Add external magnetometer capability to RevoMini

### DIFF
--- a/flight/targets/revomini/fw/pios_config.h
+++ b/flight/targets/revomini/fw/pios_config.h
@@ -133,6 +133,8 @@
  */
 #define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (6984538)
 
+#define SUPPORTS_EXTERNAL_MAG
+
 #endif /* PIOS_CONFIG_H */
 /**
  * @}

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -79,6 +79,9 @@
 		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,333,500,666,1000,2000,4000,8000" defaultvalue="666"/>
 		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="256"/>
 
+		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,ExternalI2CFlexiPort" defaultvalue="Internal"/>
+		<field name="ExtMagOrientation" units="function" type="enum" elements="1" options="Top0degCW,Top90degCW,Top180degCW,Top270degCW,Bottom0degCW,Bottom90degCW,Bottom180degCW,Bottom270degCW" defaultvalue="Top0degCW" />
+
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Allows connecting an external magnetometer to the RevoMini target

Back port from https://github.com/d-ronin/dRonin/pull/806
credit goes to @jihlein 

Signed-off-by: James Cotton peabody124@gmail.com
