### PR TITLE
OSD: do not show GForce if Accels not registered

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1067,7 +1067,7 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 	}
 
 	// G Force
-	if (page->GForce) {
+	if (page->GForce && AccelsHandle() != NULL) {
 		AccelsData accelsData;
 		AccelsGet(&accelsData);
 		tmp = sqrtf(powf(accelsData.x, 2.f) + powf(accelsData.y, 2.f) + powf(accelsData.z, 2.f)) / 9.81f;


### PR DESCRIPTION
This prevents TauOSD going into a boot loop because
it doesn't have raw accels.
